### PR TITLE
Add quick wins: User-Agent, cache stats, datasource, validation, deprecation

### DIFF
--- a/src/EsiClient.ts
+++ b/src/EsiClient.ts
@@ -36,10 +36,13 @@ import { initializeETagCache, getETagCache } from './core/ApiRequestHandler';
 import { ETagCacheConfig } from './core/cache/ETagCacheManager';
 import logger from './core/logger/logger';
 
+export type EsiDatasource = 'tranquility' | 'singularity';
+
 export interface EsiClientConfig {
   clientId?: string;
   baseUrl?: string;
   accessToken?: string;
+  datasource?: EsiDatasource;
   timeout?: number;
   retryAttempts?: number;
   enableETagCache?: boolean;
@@ -58,6 +61,13 @@ export class EsiClient {
       config?.baseUrl || process.env.ESI_BASE_URL || 'https://esi.evetech.net',
       token,
     );
+
+    const datasource =
+      config?.datasource ||
+      (process.env.ESI_DATASOURCE as EsiDatasource | undefined);
+    if (datasource) {
+      this.apiClient.setDatasource(datasource);
+    }
 
     this.etagCacheEnabled = config?.enableETagCache !== false;
     if (this.etagCacheEnabled) {
@@ -180,6 +190,8 @@ export class EsiClient {
   getCacheStats(): {
     totalEntries: number;
     maxEntries: number;
+    hits: number;
+    misses: number;
     hitRate: number;
     oldestEntry: number | null;
     newestEntry: number | null;

--- a/src/TODO
+++ b/src/TODO
@@ -1,46 +1,76 @@
-Development Roadmap
+Development Roadmap — ESI.ts v3.4.0
+=====================================
 
-Looking at the ESI Spec, taking the Alliance as an example, there are 4 APIs. My approach wrapped the other /alliances endpoints such as in Contacts under Alliance to make it more logical.
-This means I need to check manually 1:1 to make sure all endpoints are there and that they are either logically mapping to the ESI or logically placed in a structure that I recognise. This is
-important because of the Client / Builder relationship so my thinking is to match the ESI spec identically and not mix up locations. This might lead to a custom builder that could pull all the /character
-or / alliance or /corp and make a holistic Builder/Client for that combination. This might lead to a structural refactor and have Builders and Clients matching the ESI and a Logical grouping of Builders/Clients then as a custom option
+Completed
+---------
 
+[x] ESI Spec 1:1 Endpoint Coverage
+    170 GET + 35 non-GET endpoints across 32 domain clients.
+    Automated validation via `npm run validate:esi` against live ESI swagger spec.
 
+[x] API Verb Handling
+    All HTTP verbs explicitly passed; POST/PUT/DELETE bodies JSON-serialized.
+    Status-specific handling for 201, 204, 304, 420, 429, 5xx.
 
+[x] Models
+    Type-safe request/response models. EsiError class with typed status checks.
+    TestDataFactory provides comprehensive mock models for all domains.
 
-API Verb
-Not all passing in GET using the defaults in apirequesthandler which isn't clean. Handled this now but need to recheck the , undefined paramater and make sure its the right way instead of using JSON.stringify(object)
+[x] Caching
+    ETag-based caching with If-None-Match, Cache-Control max-age TTL,
+    stale-on-error for 5xx, write invalidation, LRU eviction, auto-cleanup.
 
-Models:
-Need to review the request models particularly for issues and handle that gracefully
+[x] Rate Limiting
+    Floating-window (X-Ratelimit-*) + legacy error-limit (x-esi-error-limit-*).
+    Token costs per spec, proactive deceleration, hard block on 420/429.
 
+[x] Pagination
+    Offset-based (page=N) with retry logic and empty-page detection.
+    Cursor-based (before/after tokens) for Freelance Jobs with polling support.
 
-Caching:
-See can I / should I consider caching here
-
-Rate Limiting:
-For some pages we will get rate limited, we might want to check the number of pages and decide to only request X every minute
-
-Pagination II
-General pagination is in place, I wonder can we request a specific page
-
-URL Tidy up:
-Construction of the URL to bring in different data sources, right now we don't add that to the URL but we should if it is present in the conf file
-
-Integration with Mock ESI data:
-Currently using a mix of my own mocks and real data. ESI Mock is a project, need to look to see can I bind against that
-
-Thourough Testing:
-Gaining ESI scopes is slowing me down, I need to revisit this with real requests to look at how it handles. Concerned about any API verb that's not a GET, this might require some refactoring as no
-doubt the return logic handling on things like PUT, POST and DELETE require something beyond what I have in place.
+[x] Testing
+    74 suites, 577+ tests. All verbs covered. BDD scenarios included.
+    Coverage thresholds enforced in CI.
 
 
+Recently Completed
+------------------
+
+[x] User-Agent Version Fix
+    Centralized in src/core/constants.ts as 'esi.ts/3.4.0'. Updated across
+    ApiRequestHandler, PaginationHandler, CursorPaginationHandler, MetaClient.
+
+[x] Datasource Parameter
+    EsiClientConfig accepts datasource: 'tranquility' | 'singularity'.
+    Also reads from ESI_DATASOURCE env var. Appended to all endpoint URLs.
+
+[x] Cache Hit Rate Tracking
+    ETagCacheManager now tracks hits/misses. getStats() returns actual
+    hitRate, hits, and misses. Counters reset on clear().
+
+[x] Input Validation
+    Path params validated for empty values, unsafe characters (path traversal,
+    query injection), and non-finite numbers. Query params validated for
+    null/undefined, non-finite numbers, and excessive length.
+
+[x] Deprecation Handling
+    EndpointDefinition supports deprecated?: { message, replacedBy, sunsetDate }.
+    Logs a warning via logger on each call to a deprecated endpoint.
 
 
+Remaining Gaps
+--------------
 
-Testing Summary:
-- All client tests now follow consistent patterns and best practices
-- Fixed missing imports (fetchMock, getBody) across all test files
-- Improved error handling and edge case testing
-- Added comprehensive data structure validation
-- Tests now use proper client architecture instead of direct API testing
+[ ] Token Refresh / OAuth2 SSO
+    Only supports static access tokens via setAccessToken() or env var.
+    No automatic token refresh, expiry tracking, or SSO callback hooks.
+
+[ ] Request Middleware / Interceptors
+    No hooks for intercepting or transforming requests/responses.
+    All logic is monolithic in ApiRequestHandler. Extensibility point
+    for consumers who need custom headers, logging, or metrics.
+
+[ ] Circuit Breaker
+    Rate limiter handles throttling, but there is no circuit breaker for
+    repeated failures to a specific endpoint (e.g., back off after N
+    consecutive 5xx errors rather than continuing to retry).

--- a/src/clients/MetaClient.ts
+++ b/src/clients/MetaClient.ts
@@ -2,6 +2,7 @@ import { ApiClient } from '../core/ApiClient';
 import { createClient, WithMetadata } from '../core/endpoints/createClient';
 import { metaEndpoints } from '../core/endpoints/metaEndpoints';
 import { logInfo, logError } from '../core/logger/loggerUtil';
+import { USER_AGENT, COMPATIBILITY_DATE } from '../core/constants';
 
 export class MetaClient {
   private api: ReturnType<typeof createClient<typeof metaEndpoints>>;
@@ -39,8 +40,8 @@ export class MetaClient {
         method: 'GET',
         headers: {
           accept: 'text/yaml, application/x-yaml, text/plain',
-          'User-Agent': 'esiJS/2.0.0',
-          'X-Compatibility-Date': '2025-12-16',
+          'User-Agent': USER_AGENT,
+          'X-Compatibility-Date': COMPATIBILITY_DATE,
         },
       });
 

--- a/src/core/ApiClient.ts
+++ b/src/core/ApiClient.ts
@@ -1,10 +1,13 @@
+export type EsiDatasource = 'tranquility' | 'singularity';
+
 export class ApiClient {
+  private datasource?: EsiDatasource;
+
   constructor(
     private clientId: string,
     private link: string,
     private accessToken?: string,
   ) {
-    // Remove trailing slash from the link if present
     this.link = this.link.replace(/\/$/, '');
   }
 
@@ -14,6 +17,14 @@ export class ApiClient {
 
   getLink(): string {
     return this.link;
+  }
+
+  getDatasource(): EsiDatasource | undefined {
+    return this.datasource;
+  }
+
+  setDatasource(datasource: EsiDatasource | undefined): void {
+    this.datasource = datasource;
   }
 
   setAccessToken(token: string): void {

--- a/src/core/ApiRequestHandler.ts
+++ b/src/core/ApiRequestHandler.ts
@@ -11,6 +11,7 @@ import { ETagCacheManager } from './cache/ETagCacheManager';
 import { RateLimiter } from './rateLimiter/RateLimiter';
 import { PaginationHandler } from './pagination/PaginationHandler';
 import { CursorTokens } from './pagination/CursorPaginationHandler';
+import { USER_AGENT, COMPATIBILITY_DATE } from './constants';
 
 export interface EsiHandlerResponse {
   headers: Record<string, string>;
@@ -84,8 +85,8 @@ export const handleRequest = async (
   const url = `${client.getLink()}/${endpoint}`;
   const headers: HeadersInit = {
     accept: 'gzip, deflate, br',
-    'User-Agent': `esiJS/2.0.0`, // Use the version from package.json ideally
-    'X-Compatibility-Date': '2025-12-16',
+    'User-Agent': USER_AGENT,
+    'X-Compatibility-Date': COMPATIBILITY_DATE,
   };
 
   if (requiresAuth) {

--- a/src/core/cache/ETagCacheManager.ts
+++ b/src/core/cache/ETagCacheManager.ts
@@ -18,6 +18,8 @@ export class ETagCacheManager {
   private cache: Map<string, CacheEntry> = new Map();
   private config: Required<ETagCacheConfig>;
   private cleanupTimer?: NodeJS.Timeout;
+  private hits: number = 0;
+  private misses: number = 0;
 
   constructor(config: ETagCacheConfig = {}) {
     this.config = {
@@ -39,16 +41,18 @@ export class ETagCacheManager {
     const entry = this.cache.get(url);
 
     if (!entry) {
+      this.misses++;
       return null;
     }
 
-    // Check if entry has expired
     if (this.isExpired(entry)) {
       this.cache.delete(url);
+      this.misses++;
       logDebug(`Cache entry expired for ${url}`);
       return null;
     }
 
+    this.hits++;
     logDebug(`Cache hit for ${url} with ETag ${entry.etag}`);
     return entry;
   }
@@ -125,6 +129,8 @@ export class ETagCacheManager {
    */
   clear(): void {
     this.cache.clear();
+    this.hits = 0;
+    this.misses = 0;
     logInfo('ETag cache cleared');
   }
 
@@ -134,17 +140,22 @@ export class ETagCacheManager {
   getStats(): {
     totalEntries: number;
     maxEntries: number;
+    hits: number;
+    misses: number;
     hitRate: number;
     oldestEntry: number | null;
     newestEntry: number | null;
   } {
     const entries = Array.from(this.cache.values());
     const timestamps = entries.map((e) => e.timestamp);
+    const total = this.hits + this.misses;
 
     return {
       totalEntries: this.cache.size,
       maxEntries: this.config.maxEntries,
-      hitRate: 0, // Would need to track hits/misses for this
+      hits: this.hits,
+      misses: this.misses,
+      hitRate: total > 0 ? this.hits / total : 0,
       oldestEntry: timestamps.length > 0 ? Math.min(...timestamps) : null,
       newestEntry: timestamps.length > 0 ? Math.max(...timestamps) : null,
     };

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -1,0 +1,4 @@
+export const PACKAGE_NAME = 'esi.ts';
+export const PACKAGE_VERSION = '3.4.0';
+export const USER_AGENT = `${PACKAGE_NAME}/${PACKAGE_VERSION}`;
+export const COMPATIBILITY_DATE = '2025-12-16';

--- a/src/core/endpoints/EndpointDefinition.ts
+++ b/src/core/endpoints/EndpointDefinition.ts
@@ -1,5 +1,11 @@
 export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
 
+export interface DeprecationInfo {
+  message?: string;
+  replacedBy?: string;
+  sunsetDate?: string;
+}
+
 export interface EndpointDefinition {
   /** URL template with placeholders, e.g. 'alliances/{allianceId}/' */
   path: string;
@@ -18,6 +24,8 @@ export interface EndpointDefinition {
   bodyBuilder?: (...args: any[]) => unknown;
   /** Whether this endpoint uses cursor-based pagination (before/after tokens) */
   cursorPagination?: boolean;
+  /** Mark an endpoint as deprecated with optional migration guidance */
+  deprecated?: DeprecationInfo;
 }
 
 export type EndpointMap = Record<string, EndpointDefinition>;

--- a/src/core/endpoints/createClient.ts
+++ b/src/core/endpoints/createClient.ts
@@ -3,6 +3,8 @@ import { handleRequest, EsiHandlerResponse } from '../ApiRequestHandler';
 import { EndpointMap, EndpointArgs } from './EndpointDefinition';
 import { CursorTokens } from '../pagination/CursorPaginationHandler';
 import { EsiResponse, EsiResponseMeta } from '../../types/api-responses';
+import { validatePathParam, validateQueryParam } from '../util/validation';
+import { logWarn } from '../logger/loggerUtil';
 
 export interface CursorOptions {
   before?: string;
@@ -50,21 +52,34 @@ export function createClient<T extends EndpointMap>(
     (client as Record<string, (...args: unknown[]) => Promise<unknown>>)[
       methodName
     ] = async (...args: unknown[]) => {
+      if (def.deprecated) {
+        const parts = [`Endpoint '${methodName}' is deprecated.`];
+        if (def.deprecated.message) parts.push(def.deprecated.message);
+        if (def.deprecated.replacedBy)
+          parts.push(`Use '${def.deprecated.replacedBy}' instead.`);
+        if (def.deprecated.sunsetDate)
+          parts.push(`Sunset date: ${def.deprecated.sunsetDate}.`);
+        logWarn(parts.join(' '));
+      }
+
       let argIndex = 0;
 
       let path = def.path;
       if (def.pathParams) {
         for (const param of def.pathParams) {
-          path = path.replace(`{${param}}`, String(args[argIndex++]));
+          const raw = args[argIndex++];
+          const validated = validatePathParam(param, raw);
+          path = path.replace(`{${param}}`, validated);
         }
       }
 
       if (def.queryParams) {
         const queryParts: string[] = [];
-        for (const [, queryKey] of Object.entries(def.queryParams)) {
+        for (const [paramName, queryKey] of Object.entries(def.queryParams)) {
           const value = args[argIndex++];
           if (value !== undefined) {
-            queryParts.push(`${queryKey}=${encodeURIComponent(String(value))}`);
+            const validated = validateQueryParam(paramName, value);
+            queryParts.push(`${queryKey}=${encodeURIComponent(validated)}`);
           }
         }
         if (queryParts.length > 0) {
@@ -82,6 +97,13 @@ export function createClient<T extends EndpointMap>(
       } else if (def.hasBody) {
         // eslint-disable-next-line security/detect-object-injection
         body = args[argIndex];
+      }
+
+      const datasource = apiClient.getDatasource();
+      if (datasource) {
+        path +=
+          (path.includes('?') ? '&' : '?') +
+          `datasource=${encodeURIComponent(datasource)}`;
       }
 
       if (def.cursorPagination) {

--- a/src/core/pagination/CursorPaginationHandler.ts
+++ b/src/core/pagination/CursorPaginationHandler.ts
@@ -18,6 +18,7 @@
 import { ApiClient } from '../ApiClient';
 import { logInfo, logWarn, logError } from '../logger/loggerUtil';
 import { RateLimiter } from '../rateLimiter/RateLimiter';
+import { USER_AGENT, COMPATIBILITY_DATE } from '../constants';
 
 export interface CursorTokens {
   before: string | null;
@@ -61,8 +62,8 @@ export class CursorPaginationHandler {
       method,
       headers: {
         accept: 'gzip, deflate, br',
-        'User-Agent': 'esiJS/2.0.0',
-        'X-Compatibility-Date': '2025-12-16',
+        'User-Agent': USER_AGENT,
+        'X-Compatibility-Date': COMPATIBILITY_DATE,
         ...(requiresAuth
           ? { Authorization: client.getAuthorizationHeader() }
           : {}),

--- a/src/core/pagination/PaginationHandler.ts
+++ b/src/core/pagination/PaginationHandler.ts
@@ -6,6 +6,7 @@
 import { ApiClient } from '../ApiClient';
 import { logInfo, logWarn, logError } from '../logger/loggerUtil';
 import { RateLimiter } from '../rateLimiter/RateLimiter';
+import { USER_AGENT, COMPATIBILITY_DATE } from '../constants';
 
 export interface PaginationOptions {
   maxPages?: number;
@@ -162,8 +163,8 @@ export class PaginationHandler {
       method,
       headers: {
         accept: 'gzip, deflate, br',
-        'User-Agent': 'esiJS/2.0.0',
-        'X-Compatibility-Date': '2025-12-16',
+        'User-Agent': USER_AGENT,
+        'X-Compatibility-Date': COMPATIBILITY_DATE,
         ...(requiresAuth
           ? { Authorization: client.getAuthorizationHeader() }
           : {}),

--- a/src/core/util/validation.ts
+++ b/src/core/util/validation.ts
@@ -1,0 +1,57 @@
+import { buildError } from './error';
+
+const UNSAFE_PATH_CHARS = /[/\\?#@!$&'()*+,;=<>{}|^`]/;
+
+export function validatePathParam(paramName: string, value: unknown): string {
+  if (value === null || value === undefined || value === '') {
+    throw buildError(
+      `Path parameter '${paramName}' must not be empty`,
+      'VALIDATION_ERROR',
+    );
+  }
+
+  const str = String(value);
+
+  if (UNSAFE_PATH_CHARS.test(str)) {
+    throw buildError(
+      `Path parameter '${paramName}' contains invalid characters`,
+      'VALIDATION_ERROR',
+    );
+  }
+
+  if (typeof value === 'number' && !Number.isFinite(value)) {
+    throw buildError(
+      `Path parameter '${paramName}' must be a finite number`,
+      'VALIDATION_ERROR',
+    );
+  }
+
+  return str;
+}
+
+export function validateQueryParam(paramName: string, value: unknown): string {
+  if (value === null || value === undefined) {
+    throw buildError(
+      `Query parameter '${paramName}' must not be null or undefined`,
+      'VALIDATION_ERROR',
+    );
+  }
+
+  const str = String(value);
+
+  if (typeof value === 'number' && !Number.isFinite(value)) {
+    throw buildError(
+      `Query parameter '${paramName}' must be a finite number`,
+      'VALIDATION_ERROR',
+    );
+  }
+
+  if (str.length > 2000) {
+    throw buildError(
+      `Query parameter '${paramName}' exceeds maximum length`,
+      'VALIDATION_ERROR',
+    );
+  }
+
+  return str;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 // Main client
-export { EsiClient, EsiClientConfig } from './EsiClient';
+export { EsiClient, EsiClientConfig, EsiDatasource } from './EsiClient';
 export { getDefaultClient } from './EsiClient';
 
 // Builder & factory
@@ -68,6 +68,9 @@ export {
   isForbidden,
   isServerError,
 } from './core/util/error';
+
+// Endpoint definition types
+export { DeprecationInfo } from './core/endpoints/EndpointDefinition';
 
 // Types
 export * from './types/api-responses';

--- a/tests/tdd/core/ETagCacheManager.test.ts
+++ b/tests/tdd/core/ETagCacheManager.test.ts
@@ -161,6 +161,51 @@ describe('ETagCacheManager', () => {
         newStats.oldestEntry!,
       );
     });
+
+    it('should track hits and misses', () => {
+      cacheManager.set('url1', '"etag1"', [], {});
+
+      cacheManager.get('url1'); // hit
+      cacheManager.get('url1'); // hit
+      cacheManager.get('url-miss'); // miss
+
+      const stats = cacheManager.getStats();
+      expect(stats.hits).toBe(2);
+      expect(stats.misses).toBe(1);
+      expect(stats.hitRate).toBeCloseTo(2 / 3);
+    });
+
+    it('should return hitRate of 0 when no lookups have occurred', () => {
+      const stats = cacheManager.getStats();
+      expect(stats.hitRate).toBe(0);
+      expect(stats.hits).toBe(0);
+      expect(stats.misses).toBe(0);
+    });
+
+    it('should count expired entries as misses', async () => {
+      cacheManager.set('url1', '"etag1"', [], {}, 50); // 50ms TTL
+
+      cacheManager.get('url1'); // hit (still valid)
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      cacheManager.get('url1'); // miss (expired)
+
+      const stats = cacheManager.getStats();
+      expect(stats.hits).toBe(1);
+      expect(stats.misses).toBe(1);
+      expect(stats.hitRate).toBeCloseTo(0.5);
+    });
+
+    it('should reset hit/miss counters on clear', () => {
+      cacheManager.set('url1', '"etag1"', [], {});
+      cacheManager.get('url1'); // hit
+      cacheManager.get('url-miss'); // miss
+
+      cacheManager.clear();
+      const stats = cacheManager.getStats();
+      expect(stats.hits).toBe(0);
+      expect(stats.misses).toBe(0);
+      expect(stats.hitRate).toBe(0);
+    });
   });
 
   describe('Configuration Updates', () => {

--- a/tests/tdd/core/constants.test.ts
+++ b/tests/tdd/core/constants.test.ts
@@ -1,0 +1,24 @@
+import {
+  USER_AGENT,
+  PACKAGE_NAME,
+  PACKAGE_VERSION,
+  COMPATIBILITY_DATE,
+} from '../../../src/core/constants';
+
+describe('constants', () => {
+  it('should have the correct package name', () => {
+    expect(PACKAGE_NAME).toBe('esi.ts');
+  });
+
+  it('should have a valid semver version', () => {
+    expect(PACKAGE_VERSION).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it('should construct USER_AGENT from name and version', () => {
+    expect(USER_AGENT).toBe(`${PACKAGE_NAME}/${PACKAGE_VERSION}`);
+  });
+
+  it('should have a valid compatibility date', () => {
+    expect(COMPATIBILITY_DATE).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+});

--- a/tests/tdd/core/createClient.test.ts
+++ b/tests/tdd/core/createClient.test.ts
@@ -1,0 +1,208 @@
+import { ApiClient } from '../../../src/core/ApiClient';
+import { createClient } from '../../../src/core/endpoints/createClient';
+import { EndpointMap } from '../../../src/core/endpoints/EndpointDefinition';
+import * as loggerUtil from '../../../src/core/logger/loggerUtil';
+import { RateLimiter } from '../../../src/core/rateLimiter/RateLimiter';
+import fetchMock from 'jest-fetch-mock';
+
+fetchMock.enableMocks();
+
+const BASE_URL = 'https://esi.evetech.net';
+
+describe('createClient', () => {
+  let apiClient: ApiClient;
+
+  beforeEach(() => {
+    fetchMock.resetMocks();
+    apiClient = new ApiClient('test', BASE_URL);
+    RateLimiter.getInstance().setTestMode(true);
+  });
+
+  afterEach(() => {
+    RateLimiter.getInstance().setTestMode(false);
+  });
+
+  describe('datasource parameter', () => {
+    const endpoints = {
+      getStatus: {
+        path: 'latest/status/',
+        method: 'GET' as const,
+        requiresAuth: false,
+      },
+    } satisfies EndpointMap;
+
+    it('should not append datasource when not configured', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ players: 100 }));
+      const client = createClient(apiClient, endpoints);
+      await client.getStatus();
+
+      const calledUrl = fetchMock.mock.calls[0]?.[0] as string;
+      expect(calledUrl).not.toContain('datasource');
+    });
+
+    it('should append datasource=singularity when configured', async () => {
+      apiClient.setDatasource('singularity');
+      fetchMock.mockResponseOnce(JSON.stringify({ players: 100 }));
+      const client = createClient(apiClient, endpoints);
+      await client.getStatus();
+
+      const calledUrl = fetchMock.mock.calls[0]?.[0] as string;
+      expect(calledUrl).toContain('datasource=singularity');
+    });
+
+    it('should append datasource with correct separator when query params exist', async () => {
+      const endpointsWithQuery = {
+        getMarketOrders: {
+          path: 'latest/markets/{regionId}/orders/',
+          method: 'GET' as const,
+          requiresAuth: false,
+          pathParams: ['regionId'] as const,
+          queryParams: { typeId: 'type_id' },
+        },
+      } satisfies EndpointMap;
+
+      apiClient.setDatasource('tranquility');
+      fetchMock.mockResponseOnce(JSON.stringify([]));
+      const client = createClient(apiClient, endpointsWithQuery);
+      await client.getMarketOrders(10000002, 34);
+
+      const calledUrl = fetchMock.mock.calls[0]?.[0] as string;
+      expect(calledUrl).toContain('type_id=34');
+      expect(calledUrl).toContain('&datasource=tranquility');
+    });
+  });
+
+  describe('input validation', () => {
+    const endpoints = {
+      getAlliance: {
+        path: 'latest/alliances/{allianceId}/',
+        method: 'GET' as const,
+        requiresAuth: false,
+        pathParams: ['allianceId'] as const,
+      },
+      getMarketOrders: {
+        path: 'latest/markets/{regionId}/orders/',
+        method: 'GET' as const,
+        requiresAuth: false,
+        pathParams: ['regionId'] as const,
+        queryParams: { typeId: 'type_id' },
+      },
+    } satisfies EndpointMap;
+
+    it('should reject empty path parameters', async () => {
+      const client = createClient(apiClient, endpoints);
+      await expect(client.getAlliance('')).rejects.toThrow('must not be empty');
+    });
+
+    it('should reject path parameters with slashes', async () => {
+      const client = createClient(apiClient, endpoints);
+      await expect(client.getAlliance('../foo')).rejects.toThrow(
+        'invalid characters',
+      );
+    });
+
+    it('should reject NaN path parameters', async () => {
+      const client = createClient(apiClient, endpoints);
+      await expect(client.getAlliance(NaN)).rejects.toThrow('finite number');
+    });
+
+    it('should accept valid numeric path parameters', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ alliance_id: 99003214 }));
+      const client = createClient(apiClient, endpoints);
+      await client.getAlliance(99003214);
+
+      const calledUrl = fetchMock.mock.calls[0]?.[0] as string;
+      expect(calledUrl).toContain('/alliances/99003214/');
+    });
+  });
+
+  describe('deprecation warnings', () => {
+    const warnSpy = jest.spyOn(loggerUtil, 'logWarn');
+
+    beforeEach(() => {
+      warnSpy.mockClear();
+    });
+
+    afterAll(() => {
+      warnSpy.mockRestore();
+    });
+
+    it('should log a warning when a deprecated endpoint is called', async () => {
+      const endpoints = {
+        getOldThing: {
+          path: 'latest/old/',
+          method: 'GET' as const,
+          requiresAuth: false,
+          deprecated: { message: 'This endpoint is going away.' },
+        },
+      } satisfies EndpointMap;
+
+      fetchMock.mockResponseOnce(JSON.stringify({}));
+      const client = createClient(apiClient, endpoints);
+      await client.getOldThing();
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("'getOldThing' is deprecated"),
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('This endpoint is going away.'),
+      );
+    });
+
+    it('should include replacedBy in the warning', async () => {
+      const endpoints = {
+        getLegacy: {
+          path: 'latest/legacy/',
+          method: 'GET' as const,
+          requiresAuth: false,
+          deprecated: { replacedBy: 'getModern' },
+        },
+      } satisfies EndpointMap;
+
+      fetchMock.mockResponseOnce(JSON.stringify({}));
+      const client = createClient(apiClient, endpoints);
+      await client.getLegacy();
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Use 'getModern' instead"),
+      );
+    });
+
+    it('should include sunsetDate in the warning', async () => {
+      const endpoints = {
+        getSunset: {
+          path: 'latest/sunset/',
+          method: 'GET' as const,
+          requiresAuth: false,
+          deprecated: { sunsetDate: '2026-06-01' },
+        },
+      } satisfies EndpointMap;
+
+      fetchMock.mockResponseOnce(JSON.stringify({}));
+      const client = createClient(apiClient, endpoints);
+      await client.getSunset();
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Sunset date: 2026-06-01'),
+      );
+    });
+
+    it('should not log a warning for non-deprecated endpoints', async () => {
+      const endpoints = {
+        getCurrent: {
+          path: 'latest/current/',
+          method: 'GET' as const,
+          requiresAuth: false,
+        },
+      } satisfies EndpointMap;
+
+      fetchMock.mockResponseOnce(JSON.stringify({}));
+      const client = createClient(apiClient, endpoints);
+      await client.getCurrent();
+
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('deprecated'),
+      );
+    });
+  });
+});

--- a/tests/tdd/core/validation.test.ts
+++ b/tests/tdd/core/validation.test.ts
@@ -1,0 +1,87 @@
+import {
+  validatePathParam,
+  validateQueryParam,
+} from '../../../src/core/util/validation';
+
+describe('validatePathParam', () => {
+  it('should accept valid numeric IDs', () => {
+    expect(validatePathParam('allianceId', 99003214)).toBe('99003214');
+    expect(validatePathParam('characterId', 12345)).toBe('12345');
+  });
+
+  it('should accept valid string values', () => {
+    expect(validatePathParam('hash', 'abc123def')).toBe('abc123def');
+  });
+
+  it('should reject empty values', () => {
+    expect(() => validatePathParam('id', '')).toThrow('must not be empty');
+    expect(() => validatePathParam('id', null)).toThrow('must not be empty');
+    expect(() => validatePathParam('id', undefined)).toThrow(
+      'must not be empty',
+    );
+  });
+
+  it('should reject values with path traversal characters', () => {
+    expect(() => validatePathParam('id', '../etc/passwd')).toThrow(
+      'invalid characters',
+    );
+    expect(() => validatePathParam('id', 'foo/bar')).toThrow(
+      'invalid characters',
+    );
+    expect(() => validatePathParam('id', 'foo\\bar')).toThrow(
+      'invalid characters',
+    );
+  });
+
+  it('should reject values with query string characters', () => {
+    expect(() => validatePathParam('id', 'foo?bar=1')).toThrow(
+      'invalid characters',
+    );
+    expect(() => validatePathParam('id', 'foo#anchor')).toThrow(
+      'invalid characters',
+    );
+  });
+
+  it('should reject NaN and Infinity', () => {
+    expect(() => validatePathParam('id', NaN)).toThrow('finite number');
+    expect(() => validatePathParam('id', Infinity)).toThrow('finite number');
+    expect(() => validatePathParam('id', -Infinity)).toThrow('finite number');
+  });
+});
+
+describe('validateQueryParam', () => {
+  it('should accept valid string values', () => {
+    expect(validateQueryParam('type_id', '34')).toBe('34');
+    expect(validateQueryParam('name', 'Tritanium')).toBe('Tritanium');
+  });
+
+  it('should accept valid numeric values', () => {
+    expect(validateQueryParam('type_id', 34)).toBe('34');
+  });
+
+  it('should reject null and undefined', () => {
+    expect(() => validateQueryParam('type_id', null)).toThrow(
+      'must not be null',
+    );
+    expect(() => validateQueryParam('type_id', undefined)).toThrow(
+      'must not be null',
+    );
+  });
+
+  it('should reject NaN and Infinity', () => {
+    expect(() => validateQueryParam('page', NaN)).toThrow('finite number');
+    expect(() => validateQueryParam('page', Infinity)).toThrow('finite number');
+  });
+
+  it('should reject overly long values', () => {
+    const longString = 'a'.repeat(2001);
+    expect(() => validateQueryParam('search', longString)).toThrow(
+      'exceeds maximum length',
+    );
+  });
+
+  it('should accept values at the length limit', () => {
+    const maxString = 'a'.repeat(2000);
+    expect(validateQueryParam('search', maxString)).toBe(maxString);
+  });
+});


### PR DESCRIPTION
## Summary
- **User-Agent version fix**: Centralized in `src/core/constants.ts` as `esi.ts/3.4.0`, replacing hardcoded `esiJS/2.0.0` across 4 files
- **Cache hit/miss tracking**: `ETagCacheManager.getStats()` now returns real `hitRate`, `hits`, and `misses` counters
- **Datasource parameter**: `EsiClientConfig` accepts `datasource: 'tranquility' | 'singularity'` (also via `ESI_DATASOURCE` env var), appended to all endpoint URLs
- **Input validation**: Path params reject empty values, unsafe characters (path traversal, query injection), and non-finite numbers. Query params validated for null, non-finite numbers, and excessive length
- **Deprecation handling**: `EndpointDefinition` supports `deprecated?: { message, replacedBy, sunsetDate }` with runtime log warnings

## Changed files
- `src/core/constants.ts` — new: centralized User-Agent and compatibility date
- `src/core/util/validation.ts` — new: `validatePathParam()` and `validateQueryParam()`
- `src/core/ApiClient.ts` — added `datasource` getter/setter
- `src/core/endpoints/EndpointDefinition.ts` — added `DeprecationInfo` type
- `src/core/endpoints/createClient.ts` — wired validation, deprecation warnings, datasource append
- `src/core/cache/ETagCacheManager.ts` — added hit/miss counters
- `src/EsiClient.ts` — added `EsiDatasource` config, updated cache stats return type
- `src/index.ts` — exported `EsiDatasource` and `DeprecationInfo`
- Updated User-Agent in: `ApiRequestHandler`, `PaginationHandler`, `CursorPaginationHandler`, `MetaClient`

## Test plan
- [x] 31 new tests added across 3 new test files
- [x] All 608 tests pass (76 suites)
- [x] ESLint clean
- [x] TypeScript compiles without errors
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)