### PR TITLE
Remove GitHub Pages deploy step from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,13 +226,6 @@ jobs:
           path: docs/
           retention-days: 30
 
-      - name: Deploy to GitHub Pages
-        if: github.event_name == 'push'
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs
-
   quality-gate:
     name: Quality Gate
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Remove the `peaceiris/actions-gh-pages@v3` deploy step that fails with `Permission denied` since GitHub Pages was never configured for this repo
- Doc generation and artifact upload are preserved — deploy can be re-added when Pages is set up

## Test plan
- [ ] CI documentation job passes without the deploy step

🤖 Generated with [Claude Code](https://claude.com/claude-code)