### PR TITLE
Add ESI response header best practices and reorganize docs

### DIFF
--- a/guides/DOCUMENTATION.md
+++ b/guides/DOCUMENTATION.md
@@ -1,43 +1,42 @@
-# 📚 ESI.ts Documentation Guide
+# ESI.ts Documentation Guide
 
 > **Version 3.4.0** - Latest documentation for the EVE Online ESI API TypeScript client
 
-## 🌐 Online Documentation
+## Local Documentation
 
-The complete API documentation is automatically generated from the TypeScript source code and is available:
+The complete API documentation is automatically generated from the TypeScript source code using TypeDoc.
 
-- **Online**: [GitHub Pages](https://lgriffin.github.io/ESI.ts/) (if enabled)
 - **Locally**: Run `npm run docs:serve` to serve docs at `http://localhost:8080`
 
-## 📖 Documentation Structure
+## Documentation Structure
 
 ### Main Sections
 
-1. **[Classes](docs/classes/index.html)** - All API clients and core classes
+1. **[Classes](../docs/classes/index.html)** - All API clients and core classes
    - `EsiClient` - Main client with all APIs
    - `CustomEsiClient` - Lightweight client with selected APIs
    - Individual clients (`CharacterClient`, `MarketClient`, etc.)
 
-2. **[Interfaces](docs/interfaces/index.html)** - TypeScript interfaces and contracts
+2. **[Interfaces](../docs/interfaces/index.html)** - TypeScript interfaces and contracts
    - Configuration interfaces
    - API response types
    - Client contracts
 
-3. **[Functions](docs/functions/index.html)** - Utility functions and helpers
+3. **[Functions](../docs/functions/index.html)** - Utility functions and helpers
    - Request handlers
    - Validation utilities
    - Test helpers
 
-4. **[Types](docs/types/index.html)** - Type aliases and custom types
+4. **[Types](../docs/types/index.html)** - Type aliases and custom types
 
 ### Key Documentation Pages
 
-- **[EsiClient](docs/classes/src_EsiClient.EsiClient.html)** - Main client class
-- **[EsiClientBuilder](docs/classes/src_EsiClientBuilder.EsiClientBuilder.html)** - Builder pattern for custom clients
-- **[API Request Handler](docs/functions/src_core_ApiRequestHandler.handleRequest.html)** - Core request processing
-- **[ETag Caching](docs/functions/src_core_ApiRequestHandler.initializeETagCache.html)** - Performance caching system
+- **[EsiClient](../docs/classes/src_EsiClient.EsiClient.html)** - Main client class
+- **[EsiClientBuilder](../docs/classes/src_EsiClientBuilder.EsiClientBuilder.html)** - Builder pattern for custom clients
+- **[API Request Handler](../docs/functions/src_core_ApiRequestHandler.handleRequest.html)** - Core request processing
+- **[ETag Caching](../docs/functions/src_core_ApiRequestHandler.initializeETagCache.html)** - Performance caching system
 
-## 🔧 Documentation Commands
+## Documentation Commands
 
 ```bash
 # Generate documentation
@@ -56,9 +55,9 @@ npm run clean:docs
 npm run clean
 ```
 
-## 📝 Documentation Features
+## Documentation Features
 
-### ✅ What's Included
+### What's Included
 
 - **Complete API Coverage** - All classes, methods, and properties
 - **Type Information** - Full TypeScript type definitions
@@ -68,14 +67,14 @@ npm run clean
 - **Cross-References** - Links between related classes and methods
 - **Examples** - Code examples from README and comments
 
-### 🎯 Navigation Tips
+### Navigation Tips
 
 1. **Search Box** - Use the search box in the top-right to find specific classes or methods
 2. **Module Tree** - Navigate through the organized module structure
 3. **Class Hierarchy** - View inheritance relationships
 4. **Source Links** - Click "Defined in" links to view source code on GitHub
 
-## 🚀 Quick Start Examples
+## Quick Start Examples
 
 The documentation includes comprehensive examples for:
 
@@ -88,7 +87,7 @@ The documentation includes comprehensive examples for:
 - **Cursor Pagination** - Freelance Jobs and future cursor-based routes
 - **ESI Scopes** - Required SSO scopes documented per endpoint
 
-## 📊 Documentation Quality
+## Documentation Quality
 
 - **Coverage**: 100% of public APIs documented
 - **Type Safety**: Full TypeScript type information
@@ -96,7 +95,7 @@ The documentation includes comprehensive examples for:
 - **Search**: Full-text search capability
 - **Mobile Friendly**: Responsive design for all devices
 
-## 🔄 Keeping Documentation Updated
+## Keeping Documentation Updated
 
 The documentation is automatically regenerated from source code, ensuring it's always current with the latest API changes. Key benefits:
 
@@ -104,7 +103,3 @@ The documentation is automatically regenerated from source code, ensuring it's a
 - **Type Accurate** - TypeScript ensures type information is correct
 - **Comprehensive** - Covers all public APIs automatically
 - **Searchable** - Full-text search across all content
-
----
-
-**💡 Tip**: Bookmark the documentation site and use it as your primary reference when working with ESI.ts!

--- a/guides/TESTING.md
+++ b/guides/TESTING.md
@@ -13,8 +13,25 @@ tests/
 │   ├── contacts/ContactsClient.test.ts
 │   ├── core/
 │   │   ├── ETagCacheManager.test.ts
-│   │   └── ETagIntegration.test.ts
+│   │   ├── ETagIntegration.test.ts
+│   │   ├── EsiError.test.ts
+│   │   ├── headersUtil.test.ts
+│   │   ├── PaginationHandler.test.ts
+│   │   ├── PaginationIntegration.test.ts
+│   │   ├── RateLimiter.test.ts
+│   │   ├── RateLimitIntegration.test.ts
+│   │   ├── WithMetadata.test.ts
+│   │   ├── circuitBreaker.test.ts
+│   │   ├── constants.test.ts
+│   │   ├── createClient.test.ts
+│   │   ├── CursorPaginationHandler.test.ts
+│   │   ├── CursorPaginationIntegration.test.ts
+│   │   ├── dependencyInjection.test.ts
+│   │   ├── middleware.test.ts
+│   │   ├── tokenRefresh.test.ts
+│   │   └── validation.test.ts
 │   ├── corporations/CorporationsClient.test.ts
+│   ├── dogma/DogmaClient.test.ts
 │   ├── factions/FactionClient.test.ts
 │   ├── fittings/FittingsClient.test.ts
 │   ├── fleets/FleetClient.test.ts
@@ -46,6 +63,7 @@ tests/
 │   │   ├── bdd-contacts.test.ts
 │   │   ├── bdd-contracts.test.ts
 │   │   ├── bdd-corporation.test.ts
+│   │   ├── bdd-dogma.test.ts
 │   │   ├── bdd-etag-caching.test.ts
 │   │   ├── bdd-factions.test.ts
 │   │   ├── bdd-fittings.test.ts
@@ -61,6 +79,7 @@ tests/
 │   │   ├── bdd-market.test.ts
 │   │   ├── bdd-meta.test.ts
 │   │   ├── bdd-pi.test.ts
+│   │   ├── bdd-response-headers.test.ts
 │   │   ├── bdd-route.test.ts
 │   │   ├── bdd-search.test.ts
 │   │   ├── bdd-skills.test.ts
@@ -74,14 +93,17 @@ tests/
 │   │   └── bdd-integration-workflows.test.ts
 │   └── performance/
 │       └── bdd-performance.test.ts
-└── bdd/
-    └── simple-bdd-demo.test.ts
+├── bdd/
+│   └── simple-bdd-demo.test.ts
+└── integration/                  # Integration tests (real ESI API)
+    ├── gated-auth.test.ts        # Tier 1: authenticated endpoint stubs
+    └── live-esi.test.ts          # Tier 2: live ESI API smoke tests
 ```
 
 ## Running Tests
 
 ```bash
-# All tests (TDD + BDD) — 73 suites, 577 tests
+# All unit + BDD tests — 84 suites, 690 tests
 npm test
 
 # Watch mode for development
@@ -107,13 +129,60 @@ npm run bdd:integration
 npm run bdd:performance
 
 # All other BDD domains are also runnable individually:
-# npm run bdd:assets, bdd:calendar, bdd:contacts, bdd:contracts,
-# bdd:factions, bdd:fittings, bdd:fleets, bdd:freelance,
-# bdd:incursions, bdd:industry, bdd:insurance, bdd:killmails,
-# bdd:location, bdd:loyalty, bdd:mail, bdd:pi, bdd:route,
+# npm run bdd:assets, bdd:calendar, bdd:clones, bdd:contacts,
+# bdd:contracts, bdd:dogma, bdd:etag-caching, bdd:factions,
+# bdd:fittings, bdd:fleets, bdd:freelance, bdd:incursions,
+# bdd:industry, bdd:insurance, bdd:killmails, bdd:location,
+# bdd:loyalty, bdd:mail, bdd:meta, bdd:pi, bdd:route,
 # bdd:search, bdd:skills, bdd:sovereignty, bdd:status,
 # bdd:ui, bdd:wallet, bdd:wars
 ```
+
+## Integration Tests
+
+Integration tests live in `tests/integration/` and hit the real ESI API. They are **not** part of the default `npm test` run and require a separate config.
+
+```bash
+# Run integration tests
+npx jest --config jest.integration.config.cjs
+```
+
+### Tier 1: Gated Auth Tests (`gated-auth.test.ts`)
+
+Full-stack integration tests that exercise the real request pipeline (rate limiter, circuit breaker, middleware, ETag caching) against live ESI endpoints. These use public endpoints that don't require authentication.
+
+**What they cover:**
+
+- Rate limiter throttling with real ESI rate limit headers
+- ETag cache hit/miss behavior with real `304 Not Modified` responses
+- Circuit breaker state transitions with real server errors
+- Middleware request/response interception in the live pipeline
+- Error handling with real `404`, `400` responses
+
+```bash
+# Run Tier 1 only
+npx jest --config jest.integration.config.cjs --testPathPattern=gated-auth
+```
+
+### Tier 2: Live ESI Smoke Tests (`live-esi.test.ts`)
+
+Lightweight smoke tests that verify the library can talk to real ESI and get correct response shapes. Designed to catch regressions that mocks wouldn't surface (e.g. ESI schema changes, header format changes).
+
+**What they cover:**
+
+- Server status endpoint returns valid player count and version
+- Alliance lookup returns expected fields
+- Market prices returns array of type/price pairs
+- Character info returns expected fields
+- Universe system lookup returns valid system data
+- 404 handling for nonexistent resources
+
+```bash
+# Run Tier 2 only
+npx jest --config jest.integration.config.cjs --testPathPattern=live-esi
+```
+
+**Note:** Integration tests are rate-limited and have longer timeouts. They may fail if ESI is experiencing downtime. CI runs them on a schedule rather than on every push.
 
 ### Live API Verification
 
@@ -150,15 +219,19 @@ npm run example:contacts     # Contact list with standings
 
 ### Configuration
 
-A single Jest config drives all tests:
+Two Jest configs drive the test suites:
 
-- **Config file**: `jest.unit.config.cjs`
+- **Unit + BDD**: `jest.unit.config.cjs` — runs TDD and BDD tests with `jest-fetch-mock`
+- **Integration**: `jest.integration.config.cjs` — runs integration tests against live ESI
+
+Common setup:
+
 - **Setup**: `src/config/jest/jest.setup.ts` — enables `jest-fetch-mock`, creates a shared `ApiClient`, resets rate limiter before each test
 - **Global setup/teardown**: `src/config/jest/globalSetup.ts` and `globalTeardown.ts`
 
 ### Mocking
 
-All tests use [jest-fetch-mock](https://github.com/jefflau/jest-fetch-mock) to intercept `fetch` calls. No real HTTP requests are made during tests.
+All unit and BDD tests use [jest-fetch-mock](https://github.com/jefflau/jest-fetch-mock) to intercept `fetch` calls. No real HTTP requests are made during tests.
 
 ```typescript
 import fetchMock from 'jest-fetch-mock';
@@ -334,7 +407,7 @@ describe('Feature: Retrieve Alliance Information', () => {
 
 ### BDD Test Categories
 
-- **Core** (`bdd-scenarios/core/`): Domain-specific scenarios — alliance, character, clones, corporation, market, meta, universe, ETag caching
+- **Core** (`bdd-scenarios/core/`): Domain-specific scenarios — alliance, character, clones, corporation, market, meta, universe, ETag caching, response headers
 - **Integration** (`bdd-scenarios/integration/`): Cross-domain workflows — character profile assembly, market analysis, fleet operations
 - **Performance** (`bdd-scenarios/performance/`): Concurrent requests, large dataset handling, memory efficiency, error handling performance
 
@@ -360,9 +433,10 @@ jest.spyOn(client.alliance, 'getAllianceById').mockRejectedValue(error);
 
 1. **TDD test**: Create `tests/tdd/<domain>/<ClientName>.test.ts`. Mock fetch responses, call client methods, assert results.
 2. **BDD test**: Add scenarios to existing files in `tests/bdd-scenarios/core/` or create new ones. Use `jest.spyOn` on `EsiClient` properties.
-3. **Test data**: Add factory methods to `src/testing/TestDataFactory.ts` if new response types are needed.
+3. **Integration test**: Add to `tests/integration/`. Use real fetch (no mocks). Keep tests idempotent and read-only against ESI.
+4. **Test data**: Add factory methods to `src/testing/TestDataFactory.ts` if new response types are needed.
 
-All tests run through the single `jest.unit.config.cjs` config — no separate config files needed.
+Unit and BDD tests run through `jest.unit.config.cjs`. Integration tests use `jest.integration.config.cjs`.
 
 ## Debugging
 

--- a/src/core/ApiRequestHandler.ts
+++ b/src/core/ApiRequestHandler.ts
@@ -182,7 +182,12 @@ function handleEarlyStatus(
         };
       }
     }
-    throw new EsiError(304, 'Not Modified — no cached data available', url);
+    throw new EsiError(
+      304,
+      'Not Modified — no cached data available',
+      url,
+      parsed.requestId ?? undefined,
+    );
   }
 
   return null;
@@ -389,7 +394,12 @@ function handleErrorResponse(
     logWarn(`Rate limited (${response.status}) on ${url}`);
   }
 
-  throw new EsiError(response.status, errorMessage, url);
+  throw new EsiError(
+    response.status,
+    errorMessage,
+    url,
+    parsed.requestId ?? undefined,
+  );
 }
 
 function wrapError(error: unknown): never {
@@ -462,11 +472,18 @@ async function fetchOnePage(
     else cb.recordSuccess(endpoint);
   }
 
+  if (parsed.warning) {
+    logWarn(
+      `ESI Warning ${parsed.warning.code} for ${url}: ${parsed.warning.message}`,
+    );
+  }
+
   if (!response.ok) {
     throw new EsiError(
       response.status,
       STATUS_MESSAGES[response.status] || response.statusText,
       url,
+      parsed.requestId ?? undefined,
     );
   }
 
@@ -538,6 +555,12 @@ const executeRequest = async (
     if (cb) {
       if (response.status >= 500) cb.recordFailure(endpoint, response.status);
       else cb.recordSuccess(endpoint);
+    }
+
+    if (parsed.warning) {
+      logWarn(
+        `ESI Warning ${parsed.warning.code} for ${url}: ${parsed.warning.message}`,
+      );
     }
 
     if (response.status === 201) {

--- a/src/core/endpoints/createClient.ts
+++ b/src/core/endpoints/createClient.ts
@@ -4,6 +4,7 @@ import { EndpointMap, EndpointArgs } from './EndpointDefinition';
 import { CursorTokens } from '../pagination/CursorPaginationHandler';
 import { EsiResponse, EsiResponseMeta } from '../../types/api-responses';
 import { validatePathParam, validateQueryParam } from '../util/validation';
+import { parseWarning } from '../util/headersUtil';
 import { logWarn } from '../logger/loggerUtil';
 
 export interface CursorOptions {
@@ -31,11 +32,19 @@ export type WithMetadata<T> = {
 };
 
 function buildMeta(response: EsiHandlerResponse): EsiResponseMeta {
-  return {
+  const meta: EsiResponseMeta = {
     headers: response.headers,
     fromCache: response.fromCache ?? false,
     stale: response.stale ?? false,
   };
+  const w = parseWarning(response.headers['warning']);
+  if (w) meta.warning = w;
+  if (response.headers['x-esi-request-id'])
+    meta.requestId = response.headers['x-esi-request-id'];
+  if (response.headers['date']) meta.date = response.headers['date'];
+  if (response.headers['content-language'])
+    meta.contentLanguage = response.headers['content-language'];
+  return meta;
 }
 
 /* eslint-disable sonarjs/cognitive-complexity */

--- a/src/core/util/error.ts
+++ b/src/core/util/error.ts
@@ -3,6 +3,7 @@ export class EsiError extends Error {
     public readonly statusCode: number,
     message: string,
     public readonly url?: string,
+    public readonly requestId?: string,
   ) {
     super(message);
     this.name = 'EsiError';

--- a/src/core/util/headersUtil.ts
+++ b/src/core/util/headersUtil.ts
@@ -1,3 +1,8 @@
+export interface EsiWarning {
+  code: number;
+  message: string;
+}
+
 export interface ParsedHeaders {
   raw: Record<string, string>;
   xPages: number;
@@ -8,6 +13,21 @@ export interface ParsedHeaders {
   cursorBefore: string | null;
   cursorAfter: string | null;
   hasCursorPagination: boolean;
+  warning: EsiWarning | null;
+  requestId: string | null;
+  date: string | null;
+  contentLanguage: string | null;
+}
+
+export function parseWarning(
+  value: string | null | undefined,
+): EsiWarning | null {
+  if (!value) return null;
+  const match =
+    /^(\d{3}) - "([^"]+)"$/.exec(value) ??
+    /^(\d{3}) - ([^ ].+[^ ])$/.exec(value);
+  if (!match) return null;
+  return { code: parseInt(match[1], 10), message: match[2] };
 }
 
 export function parseHeaders(fetchHeaders: Headers): ParsedHeaders {
@@ -29,5 +49,9 @@ export function parseHeaders(fetchHeaders: Headers): ParsedHeaders {
     cursorBefore,
     cursorAfter,
     hasCursorPagination: 'x-cursor-before' in raw || 'x-cursor-after' in raw,
+    warning: parseWarning(raw['warning']),
+    requestId: raw['x-esi-request-id'] ?? null,
+    date: raw['date'] ?? null,
+    contentLanguage: raw['content-language'] ?? null,
   };
 }

--- a/src/types/api-responses.ts
+++ b/src/types/api-responses.ts
@@ -3,6 +3,10 @@ export interface EsiResponseMeta {
   headers: Record<string, string>;
   fromCache: boolean;
   stale: boolean;
+  warning?: { code: number; message: string };
+  requestId?: string;
+  date?: string;
+  contentLanguage?: string;
 }
 
 export interface EsiResponse<T> {

--- a/tests/bdd-scenarios/core/bdd-response-headers.test.ts
+++ b/tests/bdd-scenarios/core/bdd-response-headers.test.ts
@@ -1,0 +1,149 @@
+import { StatusClient } from '../../../src/clients/StatusClient';
+import { ApiClient } from '../../../src/core/ApiClient';
+import { EsiError } from '../../../src/core/util/error';
+import { RateLimiter } from '../../../src/core/rateLimiter/RateLimiter';
+import { resetETagCache } from '../../../src/core/ApiRequestHandler';
+import fetchMock from 'jest-fetch-mock';
+
+fetchMock.enableMocks();
+
+const STATUS_BODY = JSON.stringify({
+  players: 30000,
+  server_version: '2148422',
+  start_time: '2026-04-29T11:00:00Z',
+});
+
+describe('BDD: ESI Response Header Best Practices', () => {
+  let apiClient: ApiClient;
+  let statusClient: StatusClient;
+
+  beforeEach(() => {
+    fetchMock.resetMocks();
+    resetETagCache();
+    RateLimiter.getInstance().reset();
+    apiClient = new ApiClient('https://esi.evetech.net', 'test-client');
+    statusClient = new StatusClient(apiClient);
+  });
+
+  describe('Feature: Warning Header Detection', () => {
+    describe('Scenario: Deprecated endpoint returns 299 warning', () => {
+      it('Given a deprecated endpoint, When I call it with metadata, Then the meta should contain the deprecation warning', async () => {
+        fetchMock.mockResponseOnce(STATUS_BODY, {
+          headers: {
+            'content-type': 'application/json',
+            warning: '299 - "This route is deprecated"',
+          },
+        });
+
+        const metaClient = statusClient.withMetadata();
+        const result = await metaClient.getStatus();
+
+        expect(result.meta.warning).toBeDefined();
+        expect(result.meta.warning!.code).toBe(299);
+        expect(result.meta.warning!.message).toBe('This route is deprecated');
+      });
+    });
+
+    describe('Scenario: Endpoint returns 199 upgrade notice', () => {
+      it('Given an endpoint with an available upgrade, When I call it with metadata, Then the meta should contain the upgrade warning', async () => {
+        fetchMock.mockResponseOnce(STATUS_BODY, {
+          headers: {
+            'content-type': 'application/json',
+            warning: '199 - "This route has an upgrade available"',
+          },
+        });
+
+        const metaClient = statusClient.withMetadata();
+        const result = await metaClient.getStatus();
+
+        expect(result.meta.warning).toBeDefined();
+        expect(result.meta.warning!.code).toBe(199);
+        expect(result.meta.warning!.message).toBe(
+          'This route has an upgrade available',
+        );
+      });
+    });
+
+    describe('Scenario: Endpoint returns no warning', () => {
+      it('Given a normal endpoint, When I call it with metadata, Then the meta should not contain a warning', async () => {
+        fetchMock.mockResponseOnce(STATUS_BODY, {
+          headers: { 'content-type': 'application/json' },
+        });
+
+        const metaClient = statusClient.withMetadata();
+        const result = await metaClient.getStatus();
+
+        expect(result.meta.warning).toBeUndefined();
+      });
+    });
+  });
+
+  describe('Feature: Request ID Tracking', () => {
+    describe('Scenario: Request ID exposed in metadata', () => {
+      it('Given an API response with x-esi-request-id, When I call with metadata, Then the meta should contain the request ID', async () => {
+        fetchMock.mockResponseOnce(STATUS_BODY, {
+          headers: {
+            'content-type': 'application/json',
+            'x-esi-request-id': 'abc-123-def-456',
+          },
+        });
+
+        const metaClient = statusClient.withMetadata();
+        const result = await metaClient.getStatus();
+
+        expect(result.meta.requestId).toBe('abc-123-def-456');
+      });
+    });
+
+    describe('Scenario: Request ID included in EsiError on failure', () => {
+      it('Given an API error response with x-esi-request-id, When the request fails, Then the EsiError should contain the request ID', () => {
+        const error = new EsiError(
+          404,
+          'Resource not found',
+          'https://esi.evetech.net/latest/characters/12345/',
+          'abc-123-def-456',
+        );
+
+        expect(error.requestId).toBe('abc-123-def-456');
+        expect(error.statusCode).toBe(404);
+        expect(error.url).toBe(
+          'https://esi.evetech.net/latest/characters/12345/',
+        );
+      });
+    });
+  });
+
+  describe('Feature: Date and Content-Language Exposure', () => {
+    describe('Scenario: Date header exposed in metadata', () => {
+      it('Given an API response with a Date header, When I call with metadata, Then the meta should contain the date', async () => {
+        fetchMock.mockResponseOnce(STATUS_BODY, {
+          headers: {
+            'content-type': 'application/json',
+            date: 'Tue, 29 Apr 2026 12:00:00 GMT',
+          },
+        });
+
+        const metaClient = statusClient.withMetadata();
+        const result = await metaClient.getStatus();
+
+        expect(result.meta.date).toBe('Tue, 29 Apr 2026 12:00:00 GMT');
+      });
+    });
+
+    describe('Scenario: Content-Language exposed in metadata', () => {
+      it('Given an API response with Content-Language, When I call with metadata, Then the meta should contain the language', async () => {
+        fetchMock.mockResponseOnce(STATUS_BODY, {
+          headers: {
+            'content-type': 'application/json',
+            'content-language': 'en-us',
+          },
+        });
+
+        const metaClient = statusClient.withMetadata();
+        const result = await metaClient.getStatus();
+
+        expect(result.meta.contentLanguage).toBe('en-us');
+      });
+    });
+  });
+});

--- a/tests/tdd/core/headersUtil.test.ts
+++ b/tests/tdd/core/headersUtil.test.ts
@@ -1,0 +1,130 @@
+import { parseHeaders, parseWarning } from '../../../src/core/util/headersUtil';
+
+function makeHeaders(entries: Record<string, string>): Headers {
+  const h = new Headers();
+  for (const [k, v] of Object.entries(entries)) {
+    h.set(k, v);
+  }
+  return h;
+}
+
+describe('parseWarning', () => {
+  it('parses a 199 upgrade notice', () => {
+    const w = parseWarning('199 - "This route has an upgrade available"');
+    expect(w).toEqual({
+      code: 199,
+      message: 'This route has an upgrade available',
+    });
+  });
+
+  it('parses a 299 deprecation warning', () => {
+    const w = parseWarning('299 - "This route is deprecated"');
+    expect(w).toEqual({ code: 299, message: 'This route is deprecated' });
+  });
+
+  it('handles unquoted warning messages', () => {
+    const w = parseWarning('199 - This route has an upgrade available');
+    expect(w).toEqual({
+      code: 199,
+      message: 'This route has an upgrade available',
+    });
+  });
+
+  it('returns null for null/undefined/empty input', () => {
+    expect(parseWarning(null)).toBeNull();
+    expect(parseWarning(undefined)).toBeNull();
+    expect(parseWarning('')).toBeNull();
+  });
+
+  it('returns null for malformed warnings', () => {
+    expect(parseWarning('not a warning')).toBeNull();
+    expect(parseWarning('abc - "message"')).toBeNull();
+    expect(parseWarning('199')).toBeNull();
+  });
+});
+
+describe('parseHeaders', () => {
+  it('extracts warning header', () => {
+    const h = makeHeaders({
+      warning: '299 - "This route is deprecated"',
+    });
+    const parsed = parseHeaders(h);
+    expect(parsed.warning).toEqual({
+      code: 299,
+      message: 'This route is deprecated',
+    });
+  });
+
+  it('sets warning to null when absent', () => {
+    const parsed = parseHeaders(makeHeaders({}));
+    expect(parsed.warning).toBeNull();
+  });
+
+  it('extracts x-esi-request-id', () => {
+    const parsed = parseHeaders(
+      makeHeaders({ 'x-esi-request-id': 'abc-123-def' }),
+    );
+    expect(parsed.requestId).toBe('abc-123-def');
+  });
+
+  it('sets requestId to null when absent', () => {
+    const parsed = parseHeaders(makeHeaders({}));
+    expect(parsed.requestId).toBeNull();
+  });
+
+  it('extracts date header', () => {
+    const parsed = parseHeaders(
+      makeHeaders({ date: 'Tue, 29 Apr 2026 12:00:00 GMT' }),
+    );
+    expect(parsed.date).toBe('Tue, 29 Apr 2026 12:00:00 GMT');
+  });
+
+  it('sets date to null when absent', () => {
+    const parsed = parseHeaders(makeHeaders({}));
+    expect(parsed.date).toBeNull();
+  });
+
+  it('extracts content-language header', () => {
+    const parsed = parseHeaders(makeHeaders({ 'content-language': 'en-us' }));
+    expect(parsed.contentLanguage).toBe('en-us');
+  });
+
+  it('sets contentLanguage to null when absent', () => {
+    const parsed = parseHeaders(makeHeaders({}));
+    expect(parsed.contentLanguage).toBeNull();
+  });
+
+  it('preserves existing pagination and etag fields', () => {
+    const h = makeHeaders({
+      'x-pages': '5',
+      etag: '"abc123"',
+      'cache-control': 'public, max-age=300',
+      expires: 'Tue, 29 Apr 2026 13:00:00 GMT',
+      'last-modified': 'Tue, 29 Apr 2026 11:00:00 GMT',
+    });
+    const parsed = parseHeaders(h);
+    expect(parsed.xPages).toBe(5);
+    expect(parsed.etag).toBe('"abc123"');
+    expect(parsed.cacheControl).toBe('public, max-age=300');
+    expect(parsed.expires).toBe('Tue, 29 Apr 2026 13:00:00 GMT');
+    expect(parsed.lastModified).toBe('Tue, 29 Apr 2026 11:00:00 GMT');
+  });
+
+  it('detects cursor pagination headers', () => {
+    const h = makeHeaders({
+      'x-cursor-before': 'token-before',
+      'x-cursor-after': 'token-after',
+    });
+    const parsed = parseHeaders(h);
+    expect(parsed.hasCursorPagination).toBe(true);
+    expect(parsed.cursorBefore).toBe('token-before');
+    expect(parsed.cursorAfter).toBe('token-after');
+  });
+
+  it('lowercases all header keys in raw map', () => {
+    const h = makeHeaders({ 'X-ESI-Request-ID': 'req-456' });
+    const parsed = parseHeaders(h);
+    expect(parsed.raw['x-esi-request-id']).toBe('req-456');
+    expect(parsed.requestId).toBe('req-456');
+  });
+});


### PR DESCRIPTION
## Summary

- **Parse and surface 4 ESI response headers** per best practices: `Warning` (deprecation/upgrade notices), `X-ESI-Request-Id` (CCP debugging), `Date`, and `Content-Language`
- **Auto-log Warning headers** on every response so deprecation notices are visible without consumers opting in
- **Thread `requestId` into `EsiError`** so error reports include the request ID for CCP support tickets
- **Expose all 4 fields via `EsiResponseMeta`** for `withMetadata()` consumers
- **Reorganize docs**: move `DOCUMENTATION.md` and `TESTING.md` into `guides/` to keep root clean; remove GitHub Pages reference; update TESTING.md with integration test documentation and current counts (84 suites, 690 tests)

### Files changed

| File | Change |
|------|--------|
| `src/core/util/headersUtil.ts` | Added `parseWarning()`, extended `ParsedHeaders` with 4 new fields |
| `src/core/util/error.ts` | Added optional `requestId` param to `EsiError` |
| `src/types/api-responses.ts` | Extended `EsiResponseMeta` with `warning`, `requestId`, `date`, `contentLanguage` |
| `src/core/endpoints/createClient.ts` | Updated `buildMeta()` to populate new fields |
| `src/core/ApiRequestHandler.ts` | Warning auto-logging, requestId threaded to all EsiError throws |
| `tests/tdd/core/headersUtil.test.ts` | 16 TDD tests for header parsing |
| `tests/bdd-scenarios/core/bdd-response-headers.test.ts` | 7 BDD scenarios for consumer-facing behavior |
| `guides/DOCUMENTATION.md` | Moved from root, removed GitHub Pages reference |
| `guides/TESTING.md` | Moved from root, added integration test docs, updated counts |

## Test plan

- [x] 16 TDD tests for `parseWarning()` and new `ParsedHeaders` fields
- [x] 7 BDD scenarios covering warning detection, request ID tracking, date/content-language exposure
- [x] Full test suite green (84 suites, 690 tests)
- [x] Clean `tsc --noEmit` compilation
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)