### PR TITLE
v4.0.0: Remove singletons, security hardening, comprehensive test coverage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,11 @@ jobs:
       - name: 🔒 Security audit
         run: npm audit --audit-level=high
 
+      - name: 📋 Verify changelog
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          grep -q "## \[${VERSION}\]" CHANGELOG.md || (echo "CHANGELOG.md missing entry for v${VERSION}" && exit 1)
+
       - name: 🏗️ Build project
         run: npm run build
 
@@ -103,7 +108,6 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs
-          cname: esi-ts-docs.yourdomain.com # Optional: Add your custom domain
 
   # Job 4: Create Release Assets
   create-assets:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,59 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [4.0.0] - Unreleased
+
+### Breaking Changes
+
+- **Removed `RateLimiter.getInstance()` singleton** - Create instances with `new RateLimiter()` instead
+- **Removed global cache/circuit breaker functions** - `initializeETagCache()`, `getETagCache()`, `resetETagCache()`, `initializeCircuitBreaker()`, `getCircuitBreaker()`, `resetCircuitBreaker()` are no longer exported from `ApiRequestHandler`
+- Each `EsiClient` and `ApiClientBuilder` now creates its own `RateLimiter`, `ETagCacheManager`, and `CircuitBreaker` instances
+
+### Added
+
+- TypeScript declaration files (`.d.ts`) now emitted with builds
+- `exports` field in `package.json` for modern Node.js module resolution
+- `engines` field specifying Node.js >= 18.0.0
+- `publishConfig` with public access for scoped package
+- `RateLimiter`, `ETagCacheManager`, and `CircuitBreaker` classes exported from main index
+- `ApiClientBuilder.setRateLimiter()`, `.setCache()`, `.setCircuitBreaker()` builder methods
+- `validateBaseUrl()` for SSRF protection — validates ESI host allowlist and HTTPS
+- `unsafeAllowCustomHost` config option to bypass base URL validation
+- URL sanitization in `EsiError` — sensitive query params (`token`, `access_token`, `api_key`) are redacted
+- Path parameters encoded with `encodeURIComponent()` for defense-in-depth
+- URL assertions in all client unit tests — every test now verifies the correct endpoint URL
+- Endpoint definition contract tests — 1800+ tests validating path templates, params, methods
+- `CHANGELOG.md` following Keep a Changelog format
+- Changelog validation step in release workflow
+
+### Fixed
+
+- `.d.ts` files not generated during build (`declaration: true` added to `tsconfig.json`)
+- Release pipeline CNAME placeholder removed from GitHub Pages deployment
+- `ContractsClient.ts` test file renamed to `.test.ts` so Jest actually runs it
+
+### Changed
+
+- `RateLimiter` constructor is now public
+- Cache, rate limiter, and circuit breaker are instance-based per client (no global shared state)
+- `ApiClientBuilder.build()` auto-creates a `RateLimiter` if none was explicitly set
+
+## [3.4.0] - 2026-04-29
+
+### Added
+
+- ESI response header best practices documentation
+- Dogma test coverage (10 TDD + 9 BDD tests)
+- Gated authenticated integration tests (32 tests across 14 endpoint groups)
+- EVE SSO token creator for local integration testing
+- Search endpoint `categories` query parameter
+
+### Fixed
+
+- 3 industry endpoint paths (`corporation` -> `corporations`) for mining routes
+- Pagination middleware bypass: pages 2+ now route through request pipeline
+- Consolidated duplicate alliance contact endpoints

--- a/package.json
+++ b/package.json
@@ -1,10 +1,23 @@
 {
   "name": "@lgriffin/esi.ts",
-  "version": "3.4.0",
+  "version": "4.0.0",
   "description": "This is a TypeScript Implementation for the EVE Online API offered through ESI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "type": "commonjs",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist"
   ],

--- a/src/EsiClient.ts
+++ b/src/EsiClient.ts
@@ -36,14 +36,16 @@ import { WalletClient } from './clients/WalletClient';
 import { WarsClient } from './clients/WarsClient';
 import { MetaClient } from './clients/MetaClient';
 import { FreelanceJobsClient } from './clients/FreelanceJobsClient';
+import { validateBaseUrl } from './core/util/validation';
 import {
-  initializeETagCache,
-  getETagCache,
-  initializeCircuitBreaker,
-  getCircuitBreaker,
-} from './core/ApiRequestHandler';
-import { ETagCacheConfig } from './core/cache/ETagCacheManager';
-import { CircuitBreakerConfig } from './core/circuitBreaker/CircuitBreaker';
+  ETagCacheManager,
+  ETagCacheConfig,
+} from './core/cache/ETagCacheManager';
+import {
+  CircuitBreaker,
+  CircuitBreakerConfig,
+} from './core/circuitBreaker/CircuitBreaker';
+import { RateLimiter } from './core/rateLimiter/RateLimiter';
 import logger from './core/logger/logger';
 
 export type EsiDatasource = 'tranquility' | 'singularity';
@@ -60,6 +62,7 @@ export interface EsiClientConfig {
   etagCacheConfig?: ETagCacheConfig;
   enableCircuitBreaker?: boolean;
   circuitBreakerConfig?: CircuitBreakerConfig;
+  unsafeAllowCustomHost?: boolean;
   requestInterceptors?: RequestInterceptor[];
   responseInterceptors?: ResponseInterceptor[];
 }
@@ -71,9 +74,13 @@ export class EsiClient {
 
   constructor(config?: EsiClientConfig) {
     const token = config?.accessToken || process.env.ESI_ACCESS_TOKEN;
+    const baseUrl = validateBaseUrl(
+      config?.baseUrl || process.env.ESI_BASE_URL || 'https://esi.evetech.net',
+      config?.unsafeAllowCustomHost,
+    );
     this.apiClient = new ApiClient(
       config?.clientId || process.env.ESI_CLIENT_ID || 'esi-client',
-      config?.baseUrl || process.env.ESI_BASE_URL || 'https://esi.evetech.net',
+      baseUrl,
       token,
     );
 
@@ -88,15 +95,17 @@ export class EsiClient {
       this.apiClient.setTokenProvider(config.onTokenRefresh);
     }
 
+    this.apiClient.setRateLimiter(new RateLimiter());
+
     this.etagCacheEnabled = config?.enableETagCache !== false;
     if (this.etagCacheEnabled) {
-      const cache = initializeETagCache(config?.etagCacheConfig);
-      this.apiClient.setCache(cache);
+      this.apiClient.setCache(new ETagCacheManager(config?.etagCacheConfig));
     }
 
     if (config?.enableCircuitBreaker) {
-      const cb = initializeCircuitBreaker(config.circuitBreakerConfig);
-      this.apiClient.setCircuitBreaker(cb);
+      this.apiClient.setCircuitBreaker(
+        new CircuitBreaker(config.circuitBreakerConfig),
+      );
     }
 
     if (config?.requestInterceptors) {
@@ -248,21 +257,21 @@ export class EsiClient {
     newestEntry: number | null;
   } | null {
     if (!this.etagCacheEnabled) return null;
-    const cache = getETagCache();
-    return cache ? cache.getStats() : null;
+    const cache = this.apiClient.getCache();
+    return cache ? (cache as ETagCacheManager).getStats() : null;
   }
 
   clearCache(): void {
-    const cache = getETagCache();
+    const cache = this.apiClient.getCache();
     if (cache) {
-      cache.clear();
+      (cache as ETagCacheManager).clear();
     }
   }
 
   updateCacheConfig(newConfig: Partial<ETagCacheConfig>): void {
-    const cache = getETagCache();
+    const cache = this.apiClient.getCache();
     if (cache) {
-      cache.updateConfig(newConfig);
+      (cache as ETagCacheManager).updateConfig(newConfig);
     }
   }
 
@@ -274,21 +283,21 @@ export class EsiClient {
       { state: 'closed' | 'open' | 'half-open'; failures: number }
     >;
   } | null {
-    const cb = getCircuitBreaker();
+    const cb = this.apiClient.getCircuitBreaker();
     return cb ? cb.getStats() : null;
   }
 
   resetCircuitBreaker(endpoint?: string): void {
-    const cb = getCircuitBreaker();
+    const cb = this.apiClient.getCircuitBreaker();
     if (cb) {
       cb.reset(endpoint);
     }
   }
 
   shutdown(): void {
-    const cache = getETagCache();
+    const cache = this.apiClient.getCache();
     if (cache) {
-      cache.shutdown();
+      (cache as ETagCacheManager).shutdown();
     }
     this.clients.clear();
     logger.info('EsiClient shutdown completed');

--- a/src/EsiClientBuilder.ts
+++ b/src/EsiClientBuilder.ts
@@ -1,4 +1,6 @@
 import { ApiClient } from './core/ApiClient';
+import { RateLimiter } from './core/rateLimiter/RateLimiter';
+import { validateBaseUrl } from './core/util/validation';
 import {
   ApiClientType,
   ClientInstance,
@@ -48,11 +50,16 @@ export class CustomEsiClient {
 
   constructor(config: EsiClientConfig & { clients: ApiClientType[] }) {
     this.enabledClients = new Set(config.clients);
+    const baseUrl = validateBaseUrl(
+      config.baseUrl || process.env.ESI_BASE_URL || 'https://esi.evetech.net',
+      config.unsafeAllowCustomHost,
+    );
     this.apiClient = new ApiClient(
       config.clientId || process.env.ESI_CLIENT_ID || 'esi-custom-client',
-      config.baseUrl || process.env.ESI_BASE_URL || 'https://esi.evetech.net',
+      baseUrl,
       config.accessToken || process.env.ESI_ACCESS_TOKEN,
     );
+    this.apiClient.setRateLimiter(new RateLimiter());
 
     for (const name of this.enabledClients) {
       this.clients.set(name, createClientInstance(name, this.apiClient));
@@ -250,11 +257,17 @@ export class EsiApiFactory {
   }
 
   private static buildApiClient(config?: EsiClientConfig): ApiClient {
-    return new ApiClient(
-      config?.clientId || process.env.ESI_CLIENT_ID || 'esi-standalone-client',
+    const baseUrl = validateBaseUrl(
       config?.baseUrl || process.env.ESI_BASE_URL || 'https://esi.evetech.net',
+      config?.unsafeAllowCustomHost,
+    );
+    const client = new ApiClient(
+      config?.clientId || process.env.ESI_CLIENT_ID || 'esi-standalone-client',
+      baseUrl,
       config?.accessToken || process.env.ESI_ACCESS_TOKEN,
     );
+    client.setRateLimiter(new RateLimiter());
+    return client;
   }
 }
 

--- a/src/config/jest/globalSetup.ts
+++ b/src/config/jest/globalSetup.ts
@@ -1,14 +1,4 @@
-/**
- * Global Jest setup to configure test environment
- */
-
 export default async function globalSetup() {
-  // Enable test mode for rate limiter to disable delays during tests
-  const { RateLimiter } = await import('../../core/rateLimiter/RateLimiter');
-  const rateLimiter = RateLimiter.getInstance();
-  rateLimiter.setTestMode(true);
-  rateLimiter.reset(); // Reset any existing state
-
   // eslint-disable-next-line no-console
-  console.log('Test mode enabled for rate limiter');
+  console.log('Jest Unit Config Loaded');
 }

--- a/src/config/jest/globalTeardown.ts
+++ b/src/config/jest/globalTeardown.ts
@@ -1,13 +1,4 @@
-/**
- * Global Jest teardown to clean up test environment
- */
-
 export default async function globalTeardown() {
-  // Reset rate limiter after all tests complete
-  const { RateLimiter } = await import('../../core/rateLimiter/RateLimiter');
-  const rateLimiter = RateLimiter.getInstance();
-  rateLimiter.reset();
-
   // eslint-disable-next-line no-console
   console.log('Rate limiter reset after test completion');
 }

--- a/src/config/jest/jest.setup.ts
+++ b/src/config/jest/jest.setup.ts
@@ -1,4 +1,5 @@
 import { ApiClientBuilder } from '../../core/ApiClientBuilder';
+import { RateLimiter } from '../../core/rateLimiter/RateLimiter';
 import { getConfig } from '../../config/configManager';
 import fetchMock from 'jest-fetch-mock';
 import { getBody, getHeaders } from '../../../src/core/util/testHelpers';
@@ -8,23 +9,22 @@ fetchMock.enableMocks();
 
 const config = getConfig();
 
+const rateLimiter = new RateLimiter();
+rateLimiter.setTestMode(true);
+
 const client = new ApiClientBuilder()
   .setClientId(config.projectName)
   .setLink(config.link)
   .setAccessToken(process.env.ESI_ACCESS_TOKEN || 'test-token')
+  .setRateLimiter(rateLimiter)
   .build();
 
 export const getClient = () => client;
 
-beforeEach(async () => {
+beforeEach(() => {
   fetchMock.resetMocks();
-
-  const { RateLimiter } = await import('../../core/rateLimiter/RateLimiter');
-  const rateLimiter = RateLimiter.getInstance();
   rateLimiter.reset();
-  rateLimiter.setTestMode(true);
 });
 
-// Assigning functions to the global object
 global.getBody = getBody;
 global.getHeaders = getHeaders;

--- a/src/core/ApiClientBuilder.ts
+++ b/src/core/ApiClientBuilder.ts
@@ -1,9 +1,16 @@
 import { ApiClient } from './ApiClient';
+import { IRateLimiter } from './rateLimiter/IRateLimiter';
+import { RateLimiter } from './rateLimiter/RateLimiter';
+import { ICache } from './cache/ICache';
+import { CircuitBreaker } from './circuitBreaker/CircuitBreaker';
 
 export class ApiClientBuilder {
   private clientId!: string;
   private link!: string;
-  private accessToken?: string; // Make accessToken optional
+  private accessToken?: string;
+  private rateLimiter?: IRateLimiter;
+  private cache?: ICache;
+  private circuitBreaker?: CircuitBreaker;
 
   setClientId(clientId: string): ApiClientBuilder {
     this.clientId = clientId;
@@ -16,12 +23,30 @@ export class ApiClientBuilder {
   }
 
   setAccessToken(accessToken?: string): ApiClientBuilder {
-    // Update method to accept optional token
     this.accessToken = accessToken;
     return this;
   }
 
+  setRateLimiter(limiter: IRateLimiter): ApiClientBuilder {
+    this.rateLimiter = limiter;
+    return this;
+  }
+
+  setCache(cache: ICache): ApiClientBuilder {
+    this.cache = cache;
+    return this;
+  }
+
+  setCircuitBreaker(cb: CircuitBreaker): ApiClientBuilder {
+    this.circuitBreaker = cb;
+    return this;
+  }
+
   build(): ApiClient {
-    return new ApiClient(this.clientId, this.link, this.accessToken);
+    const client = new ApiClient(this.clientId, this.link, this.accessToken);
+    client.setRateLimiter(this.rateLimiter ?? new RateLimiter());
+    if (this.cache) client.setCache(this.cache);
+    if (this.circuitBreaker) client.setCircuitBreaker(this.circuitBreaker);
+    return client;
   }
 }

--- a/src/core/ApiRequestHandler.ts
+++ b/src/core/ApiRequestHandler.ts
@@ -7,10 +7,9 @@ import {
   logDebug,
 } from '../core/logger/loggerUtil';
 import { parseHeaders, ParsedHeaders } from '../core/util/headersUtil';
-import { ETagCacheManager } from './cache/ETagCacheManager';
+import { ETagCacheManager, ETagCacheConfig } from './cache/ETagCacheManager';
 import { ICache } from './cache/ICache';
 import { IRateLimiter } from './rateLimiter/IRateLimiter';
-import { RateLimiter } from './rateLimiter/RateLimiter';
 import { PaginationHandler, PageFetcher } from './pagination/PaginationHandler';
 import { CursorTokens } from './pagination/CursorPaginationHandler';
 import { USER_AGENT, COMPATIBILITY_DATE } from './constants';
@@ -45,60 +44,26 @@ const STATUS_MESSAGES: Record<number, string> = {
   520: 'Internal server error, did the request terminate too soon?',
 };
 
-// --- Global instance management (backward compat) ---
-
-let globalCache: ETagCacheManager | null = null;
-let globalCircuitBreaker: CircuitBreaker | null = null;
-
-export const initializeETagCache = (
-  config?: ConstructorParameters<typeof ETagCacheManager>[0],
-): ETagCacheManager => {
-  if (!globalCache) {
-    globalCache = new ETagCacheManager(config);
-  }
-  return globalCache;
-};
-
-export const getETagCache = (): ETagCacheManager | null => {
-  return globalCache;
-};
-
-export const resetETagCache = (): void => {
-  if (globalCache) {
-    globalCache.shutdown();
-  }
-  globalCache = null;
-};
-
-export const initializeCircuitBreaker = (
-  config?: CircuitBreakerConfig,
-): CircuitBreaker => {
-  if (!globalCircuitBreaker) {
-    globalCircuitBreaker = new CircuitBreaker(config);
-  }
-  return globalCircuitBreaker;
-};
-
-export const getCircuitBreaker = (): CircuitBreaker | null => {
-  return globalCircuitBreaker;
-};
-
-export const resetCircuitBreaker = (): void => {
-  globalCircuitBreaker = null;
-};
-
 // --- Dependency resolution ---
 
 function resolveCache(client: ApiClient): ICache | null {
-  return client.getCache() ?? globalCache;
+  return client.getCache();
 }
 
 function resolveRateLimiter(client: ApiClient): IRateLimiter {
-  return client.getRateLimiter() ?? RateLimiter.getInstance();
+  const limiter = client.getRateLimiter();
+  if (!limiter) {
+    throw buildError(
+      'No rate limiter configured on ApiClient. ' +
+        'Set one via apiClient.setRateLimiter(new RateLimiter()).',
+      'CONFIGURATION_ERROR',
+    );
+  }
+  return limiter;
 }
 
 function resolveCircuitBreaker(client: ApiClient): CircuitBreaker | null {
-  return client.getCircuitBreaker() ?? globalCircuitBreaker;
+  return client.getCircuitBreaker();
 }
 
 // --- Pure helpers ---

--- a/src/core/endpoints/createClient.ts
+++ b/src/core/endpoints/createClient.ts
@@ -78,7 +78,7 @@ export function createClient<T extends EndpointMap>(
         for (const param of def.pathParams) {
           const raw = args[argIndex++];
           const validated = validatePathParam(param, raw);
-          path = path.replace(`{${param}}`, validated);
+          path = path.replace(`{${param}}`, encodeURIComponent(validated));
         }
       }
 

--- a/src/core/pagination/CursorPaginationHandler.ts
+++ b/src/core/pagination/CursorPaginationHandler.ts
@@ -17,7 +17,6 @@
 
 import { ApiClient } from '../ApiClient';
 import { logInfo, logWarn, logError } from '../logger/loggerUtil';
-import { RateLimiter } from '../rateLimiter/RateLimiter';
 import { USER_AGENT, COMPATIBILITY_DATE } from '../constants';
 
 export interface CursorTokens {
@@ -106,7 +105,7 @@ export class CursorPaginationHandler {
     options: CursorPaginationOptions = {},
   ): Promise<unknown[]> {
     const opts = { ...this.DEFAULT_OPTIONS, ...options };
-    const rateLimiter = RateLimiter.getInstance();
+    const rateLimiter = client.getRateLimiter();
     const allData: unknown[] = [...firstPageData];
 
     let afterToken = firstCursors.after;
@@ -115,7 +114,7 @@ export class CursorPaginationHandler {
 
     while (afterToken && pageCount < opts.maxPages) {
       try {
-        await rateLimiter.checkRateLimit();
+        if (rateLimiter) await rateLimiter.checkRateLimit();
 
         const page = await this.fetchPageWithRetry(
           client,

--- a/src/core/pagination/PaginationHandler.ts
+++ b/src/core/pagination/PaginationHandler.ts
@@ -5,7 +5,6 @@
 
 import { ApiClient } from '../ApiClient';
 import { logInfo, logWarn, logError } from '../logger/loggerUtil';
-import { RateLimiter } from '../rateLimiter/RateLimiter';
 import { USER_AGENT, COMPATIBILITY_DATE } from '../constants';
 
 export interface PaginationOptions {
@@ -41,7 +40,7 @@ export class PaginationHandler {
     pageFetch?: PageFetcher,
   ): Promise<unknown[]> {
     const opts = { ...this.DEFAULT_OPTIONS, ...options };
-    const rateLimiter = RateLimiter.getInstance();
+    const rateLimiter = client.getRateLimiter();
     const allData: unknown[] = [...firstPageData];
 
     const effectiveMaxPage = Math.min(totalPages, opts.maxPages);
@@ -56,7 +55,7 @@ export class PaginationHandler {
 
     for (let page = 2; page <= effectiveMaxPage; page++) {
       try {
-        await rateLimiter.checkRateLimit();
+        if (rateLimiter) await rateLimiter.checkRateLimit();
 
         const pageData = await this.fetchPageWithRetry(
           client,

--- a/src/core/rateLimiter/RateLimiter.ts
+++ b/src/core/rateLimiter/RateLimiter.ts
@@ -52,16 +52,14 @@ function getTokenCost(statusCode: number): number {
 }
 
 export class RateLimiter implements IRateLimiter {
-  private static instance: RateLimiter;
   private rateLimitInfo: RateLimitInfo;
   private lastRequestTime: number = 0;
   private readonly minDelayMs: number = 50;
   private isTestMode: boolean = false;
 
-  /** Threshold below which we start adding delays to decelerate */
-  private readonly decelerationThreshold: number = 0.2; // 20% remaining
+  private readonly decelerationThreshold: number = 0.2;
 
-  private constructor() {
+  constructor() {
     this.rateLimitInfo = this.defaultInfo();
   }
 
@@ -76,13 +74,6 @@ export class RateLimiter implements IRateLimiter {
       retryAfter: null,
       blockedUntil: 0,
     };
-  }
-
-  static getInstance(): RateLimiter {
-    if (!RateLimiter.instance) {
-      RateLimiter.instance = new RateLimiter();
-    }
-    return RateLimiter.instance;
   }
 
   /**

--- a/src/core/util/error.ts
+++ b/src/core/util/error.ts
@@ -1,12 +1,32 @@
+function sanitizeUrl(url?: string): string | undefined {
+  if (!url) return url;
+  try {
+    const parsed = new URL(url);
+    const sensitiveParams = ['token', 'access_token', 'api_key'];
+    for (const param of sensitiveParams) {
+      if (parsed.searchParams.has(param)) {
+        parsed.searchParams.set(param, '[REDACTED]');
+      }
+    }
+    return parsed.toString();
+  } catch {
+    const qIndex = url.indexOf('?');
+    return qIndex >= 0 ? url.substring(0, qIndex) + '?[params-redacted]' : url;
+  }
+}
+
 export class EsiError extends Error {
+  public readonly url?: string;
+
   constructor(
     public readonly statusCode: number,
     message: string,
-    public readonly url?: string,
+    url?: string,
     public readonly requestId?: string,
   ) {
     super(message);
     this.name = 'EsiError';
+    this.url = sanitizeUrl(url);
   }
 
   isRateLimited(): boolean {

--- a/src/core/util/validation.ts
+++ b/src/core/util/validation.ts
@@ -29,6 +29,35 @@ export function validatePathParam(paramName: string, value: unknown): string {
   return str;
 }
 
+const ALLOWED_ESI_HOSTS = ['esi.evetech.net'];
+
+export function validateBaseUrl(
+  url: string,
+  allowCustomHost?: boolean,
+): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw buildError(`Invalid base URL: ${url}`, 'VALIDATION_ERROR');
+  }
+
+  if (parsed.protocol !== 'https:') {
+    throw buildError('Base URL must use HTTPS protocol', 'VALIDATION_ERROR');
+  }
+
+  if (!allowCustomHost && !ALLOWED_ESI_HOSTS.includes(parsed.hostname)) {
+    throw buildError(
+      `Base URL host '${parsed.hostname}' is not in the allowlist. ` +
+        `Allowed hosts: ${ALLOWED_ESI_HOSTS.join(', ')}. ` +
+        `Set unsafeAllowCustomHost to bypass this check.`,
+      'VALIDATION_ERROR',
+    );
+  }
+
+  return url.replace(/\/$/, '');
+}
+
 export function validateQueryParam(paramName: string, value: unknown): string {
   if (value === null || value === undefined) {
     throw buildError(

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,10 +82,18 @@ export {
 
 // Circuit breaker
 export {
+  CircuitBreaker,
   CircuitBreakerConfig,
   CircuitState,
   CircuitOpenError,
 } from './core/circuitBreaker/CircuitBreaker';
+
+// Rate limiter & cache (for direct instantiation)
+export { RateLimiter, RateLimitInfo } from './core/rateLimiter/RateLimiter';
+export {
+  ETagCacheManager,
+  ETagCacheConfig,
+} from './core/cache/ETagCacheManager';
 
 // Interfaces (for custom implementations / testing)
 export { ICache } from './core/cache/ICache';

--- a/tests/bdd-scenarios/core/bdd-etag-caching.test.ts
+++ b/tests/bdd-scenarios/core/bdd-etag-caching.test.ts
@@ -6,10 +6,6 @@
  */
 
 import { EsiClient } from '../../../src/EsiClient';
-import {
-  getETagCache,
-  resetETagCache,
-} from '../../../src/core/ApiRequestHandler';
 import fetchMock from 'jest-fetch-mock';
 
 fetchMock.enableMocks();
@@ -19,9 +15,6 @@ describe('BDD: ETag Caching System', () => {
 
   beforeEach(() => {
     fetchMock.resetMocks();
-
-    // Reset the global cache to ensure clean state
-    resetETagCache();
 
     client = new EsiClient({
       clientId: 'test-client',
@@ -67,14 +60,21 @@ describe('BDD: ETag Caching System', () => {
         // Then: The response should be cached for future use
         expect(result).toEqual(allianceData);
 
-        const cache = getETagCache();
-        expect(cache).toBeDefined();
-
         const cacheStats = client.getCacheStats();
+        expect(cacheStats).toBeDefined();
         expect(cacheStats!.totalEntries).toBe(1);
 
-        const cachedETag = cache?.getETag('https://esi.evetech.net/alliances');
-        expect(cachedETag).toBe(etag);
+        // Verify the ETag is cached by making a second request and checking If-None-Match
+        fetchMock.mockResponseOnce('', {
+          status: 304,
+          headers: { ETag: etag },
+        });
+        await client.alliance.getAlliances();
+        const secondCallHeaders = fetchMock.mock.calls[1][1]?.headers as Record<
+          string,
+          string
+        >;
+        expect(secondCallHeaders['If-None-Match']).toBe(etag);
       });
     });
 
@@ -141,9 +141,17 @@ describe('BDD: ETag Caching System', () => {
         // Then: The cache should be updated with the new data
         expect(updatedResult).toEqual(newData);
 
-        const cache = getETagCache();
-        const cachedETag = cache?.getETag('https://esi.evetech.net/alliances');
-        expect(cachedETag).toBe(newETag);
+        // Verify cache was updated with new ETag by making a third request
+        fetchMock.mockResponseOnce('', {
+          status: 304,
+          headers: { ETag: newETag },
+        });
+        await client.alliance.getAlliances();
+        const thirdCallHeaders = fetchMock.mock.calls[2][1]?.headers as Record<
+          string,
+          string
+        >;
+        expect(thirdCallHeaders['If-None-Match']).toBe(newETag);
       });
     });
   });

--- a/tests/bdd-scenarios/core/bdd-response-headers.test.ts
+++ b/tests/bdd-scenarios/core/bdd-response-headers.test.ts
@@ -2,7 +2,6 @@ import { StatusClient } from '../../../src/clients/StatusClient';
 import { ApiClient } from '../../../src/core/ApiClient';
 import { EsiError } from '../../../src/core/util/error';
 import { RateLimiter } from '../../../src/core/rateLimiter/RateLimiter';
-import { resetETagCache } from '../../../src/core/ApiRequestHandler';
 import fetchMock from 'jest-fetch-mock';
 
 fetchMock.enableMocks();
@@ -19,9 +18,11 @@ describe('BDD: ESI Response Header Best Practices', () => {
 
   beforeEach(() => {
     fetchMock.resetMocks();
-    resetETagCache();
-    RateLimiter.getInstance().reset();
+    const rateLimiter = new RateLimiter();
+    rateLimiter.reset();
+    rateLimiter.setTestMode(true);
     apiClient = new ApiClient('https://esi.evetech.net', 'test-client');
+    apiClient.setRateLimiter(rateLimiter);
     statusClient = new StatusClient(apiClient);
   });
 

--- a/tests/integration/full-stack.test.ts
+++ b/tests/integration/full-stack.test.ts
@@ -1,9 +1,5 @@
 import { EsiClient } from '../../src/EsiClient';
 import { EsiClientBuilder, EsiApiFactory } from '../../src/EsiClientBuilder';
-import {
-  resetETagCache,
-  resetCircuitBreaker,
-} from '../../src/core/ApiRequestHandler';
 import { RateLimiter } from '../../src/core/rateLimiter/RateLimiter';
 import { EsiError } from '../../src/core/util/error';
 import { ICache, CacheEntry } from '../../src/core/cache/ICache';
@@ -24,11 +20,6 @@ const standardHeaders = (overrides: Record<string, string> = {}) => ({
 
 function resetGlobals() {
   fetchMock.resetMocks();
-  resetETagCache();
-  resetCircuitBreaker();
-  const rl = RateLimiter.getInstance();
-  rl.reset();
-  rl.setTestMode(true);
 }
 
 describe('Integration: Full Request Lifecycle', () => {
@@ -39,6 +30,7 @@ describe('Integration: Full Request Lifecycle', () => {
     client = new EsiClient({
       clientId: 'integration-test',
       baseUrl: BASE_URL,
+      unsafeAllowCustomHost: true,
       enableETagCache: true,
       etagCacheConfig: { maxEntries: 100, defaultTtl: 60000 },
     });
@@ -103,6 +95,7 @@ describe('Integration: ETag Cache Round-Trip', () => {
     client = new EsiClient({
       clientId: 'etag-integration',
       baseUrl: BASE_URL,
+      unsafeAllowCustomHost: true,
       enableETagCache: true,
       etagCacheConfig: { maxEntries: 100, defaultTtl: 60000 },
     });
@@ -160,6 +153,7 @@ describe('Integration: Circuit Breaker Trip and Recovery', () => {
     client = new EsiClient({
       clientId: 'cb-integration',
       baseUrl: BASE_URL,
+      unsafeAllowCustomHost: true,
       enableETagCache: false,
       enableCircuitBreaker: true,
       circuitBreakerConfig: {
@@ -230,6 +224,7 @@ describe('Integration: Middleware Pipeline', () => {
     client = new EsiClient({
       clientId: 'mw-integration',
       baseUrl: BASE_URL,
+      unsafeAllowCustomHost: true,
       enableETagCache: false,
     });
   });
@@ -327,6 +322,7 @@ describe('Integration: Token Refresh Flow', () => {
     const client = new EsiClient({
       clientId: 'token-integration',
       baseUrl: BASE_URL,
+      unsafeAllowCustomHost: true,
       accessToken: 'expired-token',
       enableETagCache: false,
       onTokenRefresh: async () => {
@@ -364,6 +360,7 @@ describe('Integration: Pagination Assembly', () => {
     client = new EsiClient({
       clientId: 'pagination-integration',
       baseUrl: BASE_URL,
+      unsafeAllowCustomHost: true,
       enableETagCache: false,
     });
   });
@@ -397,6 +394,7 @@ describe('Integration: Error Propagation', () => {
     client = new EsiClient({
       clientId: 'error-integration',
       baseUrl: BASE_URL,
+      unsafeAllowCustomHost: true,
       enableETagCache: false,
     });
   });
@@ -439,6 +437,7 @@ describe('Integration: Error Propagation', () => {
     const cachedClient = new EsiClient({
       clientId: 'stale-cache-test',
       baseUrl: BASE_URL,
+      unsafeAllowCustomHost: true,
       enableETagCache: true,
       etagCacheConfig: { maxEntries: 100, defaultTtl: 60000 },
     });
@@ -473,6 +472,7 @@ describe('Integration: Client Creation Patterns', () => {
     const client = new EsiClient({
       clientId: 'pattern-full',
       baseUrl: BASE_URL,
+      unsafeAllowCustomHost: true,
       enableETagCache: false,
     });
     fetchMock.mockResponseOnce(JSON.stringify({ players: 1 }), {
@@ -486,7 +486,11 @@ describe('Integration: Client Creation Patterns', () => {
   it('should produce a working client via EsiClientBuilder', async () => {
     const custom = new EsiClientBuilder()
       .addClients(['status', 'market'])
-      .withConfig({ clientId: 'pattern-builder', baseUrl: BASE_URL })
+      .withConfig({
+        clientId: 'pattern-builder',
+        baseUrl: BASE_URL,
+        unsafeAllowCustomHost: true,
+      })
       .build();
 
     expect(custom.hasClient('status')).toBe(true);
@@ -505,6 +509,7 @@ describe('Integration: Client Creation Patterns', () => {
     const marketClient = EsiApiFactory.createMarketClient({
       clientId: 'pattern-factory',
       baseUrl: BASE_URL,
+      unsafeAllowCustomHost: true,
     });
     fetchMock.mockResponseOnce(
       JSON.stringify([{ type_id: 34, average_price: 5.0 }]),
@@ -590,10 +595,15 @@ describe('Integration: DI Isolation', () => {
     const { ApiClient } = await import('../../src/core/ApiClient');
     const { handleRequest } = await import('../../src/core/ApiRequestHandler');
 
+    const rl = new RateLimiter();
+    rl.setTestMode(true);
+
     const clientA = new ApiClient('a', BASE_URL, undefined);
+    clientA.setRateLimiter(rl);
     clientA.setCache(cacheA);
 
     const clientB = new ApiClient('b', BASE_URL, undefined);
+    clientB.setRateLimiter(rl);
     clientB.setCache(cacheB);
 
     fetchMock.mockResponseOnce(JSON.stringify({ a: 1 }), {

--- a/tests/tdd/alliances/AllianceClient.test.ts
+++ b/tests/tdd/alliances/AllianceClient.test.ts
@@ -46,6 +46,9 @@ describe('AllianceClient', () => {
       expect(result.creator_id).toBe(12345);
       expect(result.creator_corporation_id).toBe(67890);
       expect(result.date_founded).toBe('2010-05-23T05:20:00Z');
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        'https://esi.evetech.net/latest/alliances/99005338/',
+      );
     });
 
     it('should throw EsiError on API errors', async () => {
@@ -94,6 +97,9 @@ describe('AllianceClient', () => {
       expect(result[1].contact_type).toBe('corporation');
       expect(result[1].standing).toBe(-5.0);
       expect(result[1].label_ids).toEqual([3]);
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        'https://esi.evetech.net/latest/alliances/99005338/contacts',
+      );
     });
   });
 
@@ -130,6 +136,9 @@ describe('AllianceClient', () => {
       expect(result[1].name).toBe('Neutrals');
       expect(result[2].label_id).toBe(3);
       expect(result[2].name).toBe('Enemies');
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        'https://esi.evetech.net/latest/alliances/99005338/contacts/labels',
+      );
     });
   });
 
@@ -152,6 +161,9 @@ describe('AllianceClient', () => {
       result.forEach((corpId: number) => {
         expect(typeof corpId).toBe('number');
       });
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        'https://esi.evetech.net/latest/alliances/99005338/corporations/',
+      );
     });
   });
 
@@ -174,6 +186,9 @@ describe('AllianceClient', () => {
       expect(result.px128x128).toBe(
         'https://images.evetech.net/alliances/99005338/logo?size=128',
       );
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        'https://esi.evetech.net/latest/alliances/99005338/icons/',
+      );
     });
   });
 
@@ -193,6 +208,9 @@ describe('AllianceClient', () => {
         expect(typeof allianceId).toBe('number');
         expect(allianceId).toBeGreaterThan(0);
       });
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        'https://esi.evetech.net/latest/alliances',
+      );
     });
 
     it('should handle empty alliance list', async () => {
@@ -204,6 +222,9 @@ describe('AllianceClient', () => {
 
       expect(Array.isArray(result)).toBe(true);
       expect(result).toHaveLength(0);
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        'https://esi.evetech.net/latest/alliances',
+      );
     });
   });
 });

--- a/tests/tdd/assets/AssetsClient.test.ts
+++ b/tests/tdd/assets/AssetsClient.test.ts
@@ -62,6 +62,9 @@ describe('AssetsClient', () => {
         expect(typeof asset.type_id).toBe('number');
       },
     );
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/characters/123456789/assets/',
+    );
   });
 
   it('should return valid structure for character asset locations', async () => {
@@ -100,6 +103,9 @@ describe('AssetsClient', () => {
         expect(typeof location.position.z).toBe('number');
       },
     );
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/characters/123456789/assets/locations/',
+    );
   });
 
   it('should return valid structure for character asset names', async () => {
@@ -123,6 +129,9 @@ describe('AssetsClient', () => {
       expect(assetName).toHaveProperty('name');
       expect(typeof assetName.name).toBe('string');
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/characters/123456789/assets/names/',
+    );
   });
 
   it('should return valid structure for corporation assets', async () => {
@@ -167,6 +176,9 @@ describe('AssetsClient', () => {
         expect(typeof asset.type_id).toBe('number');
       },
     );
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/corporations/987654321/assets/',
+    );
   });
 
   it('should return valid structure for corporation asset locations', async () => {
@@ -205,6 +217,9 @@ describe('AssetsClient', () => {
         expect(typeof location.position.z).toBe('number');
       },
     );
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/corporations/987654321/assets/locations/',
+    );
   });
 
   it('should return valid structure for corporation asset names', async () => {
@@ -228,5 +243,8 @@ describe('AssetsClient', () => {
       expect(assetName).toHaveProperty('name');
       expect(typeof assetName.name).toBe('string');
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/corporations/987654321/assets/names/',
+    );
   });
 });

--- a/tests/tdd/calendar/CalendarClient.test.ts
+++ b/tests/tdd/calendar/CalendarClient.test.ts
@@ -59,6 +59,9 @@ describe('CalendarClient', () => {
       expect(event).toHaveProperty('importance');
       expect(typeof event.importance).toBe('number');
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/characters/123456789/calendar/',
+    );
   });
 
   it('should return valid structure for getCalendarEventById', async () => {
@@ -93,6 +96,9 @@ describe('CalendarClient', () => {
     expect(typeof result.title).toBe('string');
     expect(result).toHaveProperty('description');
     expect(typeof result.description).toBe('string');
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/characters/123456789/calendar/1/',
+    );
   });
 
   it('should handle respondToCalendarEvent correctly', async () => {
@@ -103,6 +109,9 @@ describe('CalendarClient', () => {
     );
 
     expect(response).toBeUndefined();
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/characters/123456789/calendar/1/',
+    );
   });
 
   it('should return valid structure for getEventAttendees', async () => {
@@ -127,6 +136,9 @@ describe('CalendarClient', () => {
         expect(attendee).toHaveProperty('response');
         expect(typeof attendee.response).toBe('string');
       },
+    );
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/characters/123456789/calendar/1/attendees/',
     );
   });
 });

--- a/tests/tdd/characters/CharacterClient.test.ts
+++ b/tests/tdd/characters/CharacterClient.test.ts
@@ -38,6 +38,9 @@ describe('CharacterClient', () => {
     expect(typeof result.name).toBe('string');
     expect(result).toHaveProperty('corporation_id');
     expect(typeof result.corporation_id).toBe('number');
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/characters/123456789/',
+    );
   });
 
   it('should return valid structure for getCharacterAgentsResearch', async () => {
@@ -76,6 +79,9 @@ describe('CharacterClient', () => {
       expect(agent).toHaveProperty('started_at');
       expect(typeof agent.started_at).toBe('string');
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/characters/123456789/agents_research/',
+    );
   });
 
   it('should return valid structure for getCharacterBlueprints', async () => {
@@ -124,6 +130,9 @@ describe('CharacterClient', () => {
       expect(blueprint).toHaveProperty('runs');
       expect(typeof blueprint.runs).toBe('number');
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/characters/123456789/blueprints/',
+    );
   });
 
   it('should return valid structure for getCharacterCorporationHistory', async () => {
@@ -158,6 +167,9 @@ describe('CharacterClient', () => {
       expect(history).toHaveProperty('start_date');
       expect(typeof history.start_date).toBe('string');
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/characters/123456789/corporationhistory/',
+    );
   });
 
   it('should return valid structure for postCspaChargeCost', async () => {
@@ -177,5 +189,8 @@ describe('CharacterClient', () => {
 
     expect(result).toHaveProperty('cost');
     expect(typeof result.cost).toBe('number');
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/characters/123456/cspa/',
+    );
   });
 });

--- a/tests/tdd/clients/FreelanceJobsClient.test.ts
+++ b/tests/tdd/clients/FreelanceJobsClient.test.ts
@@ -1,7 +1,6 @@
 import { FreelanceJobsClient } from '../../../src/clients/FreelanceJobsClient';
 import { ApiClient } from '../../../src/core/ApiClient';
 import { RateLimiter } from '../../../src/core/rateLimiter/RateLimiter';
-import { resetETagCache } from '../../../src/core/ApiRequestHandler';
 import fetchMock from 'jest-fetch-mock';
 
 fetchMock.enableMocks();
@@ -66,8 +65,7 @@ describe('FreelanceJobsClient', () => {
 
   beforeEach(() => {
     fetchMock.resetMocks();
-    resetETagCache();
-    const rateLimiter = RateLimiter.getInstance();
+    const rateLimiter = new RateLimiter();
     rateLimiter.reset();
     rateLimiter.setTestMode(true);
     const apiClient = new ApiClient(
@@ -75,6 +73,7 @@ describe('FreelanceJobsClient', () => {
       'https://esi.evetech.net',
       undefined,
     );
+    apiClient.setRateLimiter(rateLimiter);
     client = new FreelanceJobsClient(apiClient);
   });
 
@@ -144,11 +143,14 @@ describe('FreelanceJobsClient', () => {
 
   describe('getCharacterFreelanceJobs', () => {
     it('should fetch character freelance jobs with auth', async () => {
+      const rateLimiter = new RateLimiter();
+      rateLimiter.setTestMode(true);
       const authedApiClient = new ApiClient(
         'test',
         'https://esi.evetech.net',
         'my-token',
       );
+      authedApiClient.setRateLimiter(rateLimiter);
       const authedClient = new FreelanceJobsClient(authedApiClient);
 
       fetchMock.mockResponseOnce(JSON.stringify(MOCK_LISTING));
@@ -166,11 +168,14 @@ describe('FreelanceJobsClient', () => {
     });
 
     it('should pass cursor params for character listing', async () => {
+      const rateLimiter = new RateLimiter();
+      rateLimiter.setTestMode(true);
       const authedApiClient = new ApiClient(
         'test',
         'https://esi.evetech.net',
         'my-token',
       );
+      authedApiClient.setRateLimiter(rateLimiter);
       const authedClient = new FreelanceJobsClient(authedApiClient);
 
       fetchMock.mockResponseOnce(JSON.stringify(MOCK_LISTING));
@@ -189,11 +194,14 @@ describe('FreelanceJobsClient', () => {
 
   describe('getCharacterFreelanceJobParticipation', () => {
     it('should fetch participation for a specific job', async () => {
+      const rateLimiter = new RateLimiter();
+      rateLimiter.setTestMode(true);
       const authedApiClient = new ApiClient(
         'test',
         'https://esi.evetech.net',
         'my-token',
       );
+      authedApiClient.setRateLimiter(rateLimiter);
       const authedClient = new FreelanceJobsClient(authedApiClient);
       const mockParticipation = { status: 'committed', contributions: 5 };
 
@@ -213,11 +221,14 @@ describe('FreelanceJobsClient', () => {
 
   describe('getCorporationFreelanceJobs', () => {
     it('should fetch corporation freelance jobs with auth', async () => {
+      const rateLimiter = new RateLimiter();
+      rateLimiter.setTestMode(true);
       const authedApiClient = new ApiClient(
         'test',
         'https://esi.evetech.net',
         'my-token',
       );
+      authedApiClient.setRateLimiter(rateLimiter);
       const authedClient = new FreelanceJobsClient(authedApiClient);
 
       fetchMock.mockResponseOnce(JSON.stringify(MOCK_LISTING));
@@ -237,11 +248,14 @@ describe('FreelanceJobsClient', () => {
 
   describe('getCorporationFreelanceJobParticipants', () => {
     it('should fetch participants for a corporation job', async () => {
+      const rateLimiter = new RateLimiter();
+      rateLimiter.setTestMode(true);
       const authedApiClient = new ApiClient(
         'test',
         'https://esi.evetech.net',
         'my-token',
       );
+      authedApiClient.setRateLimiter(rateLimiter);
       const authedClient = new FreelanceJobsClient(authedApiClient);
       const mockParticipants = [{ character_id: 111 }, { character_id: 222 }];
 

--- a/tests/tdd/clones/ClonesClient.test.ts
+++ b/tests/tdd/clones/ClonesClient.test.ts
@@ -44,6 +44,9 @@ describe('ClonesClient', () => {
     expect(result.home_location).toHaveProperty('location_type');
     expect(result).toHaveProperty('jump_clones');
     expect(Array.isArray(result.jump_clones)).toBe(true);
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/characters/123456789/clones',
+    );
   });
 
   it('should return valid structure for implants', async () => {
@@ -57,5 +60,8 @@ describe('ClonesClient', () => {
     result.forEach((implant: number) => {
       expect(typeof implant).toBe('number');
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/characters/123456789/implants',
+    );
   });
 });

--- a/tests/tdd/contacts/ContactsClient.test.ts
+++ b/tests/tdd/contacts/ContactsClient.test.ts
@@ -46,6 +46,9 @@ describe('ContactsClient', () => {
         expect(contact).toHaveProperty('standing');
         expect(contact).toHaveProperty('label_ids');
       });
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        'https://esi.evetech.net/latest/alliances/123456/contacts',
+      );
     });
 
     it('should return valid structure for getAllianceContactLabels', async () => {
@@ -67,6 +70,9 @@ describe('ContactsClient', () => {
         expect(label).toHaveProperty('label_id');
         expect(label).toHaveProperty('name');
       });
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        'https://esi.evetech.net/latest/alliances/123456/contacts/labels',
+      );
     });
   });
 
@@ -113,6 +119,9 @@ describe('ContactsClient', () => {
       expect(result[1].label_ids).toEqual([2, 3]);
       expect(result[1].is_watched).toBe(true);
       expect(result[1].is_blocked).toBe(true);
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        'https://esi.evetech.net/latest/characters/123456/contacts',
+      );
     });
 
     it('should return valid structure for getCharacterContactLabels', async () => {
@@ -146,6 +155,9 @@ describe('ContactsClient', () => {
         expect(typeof label.label_id).toBe('number');
         expect(typeof label.name).toBe('string');
       });
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        'https://esi.evetech.net/latest/characters/123456/contacts/labels',
+      );
     });
 
     it('should handle postCharacterContacts (add contacts)', async () => {
@@ -173,6 +185,9 @@ describe('ContactsClient', () => {
 
       expect(Array.isArray(result)).toBe(true);
       expect(result).toEqual([123456789, 987654321]);
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        'https://esi.evetech.net/latest/characters/123456/contacts',
+      );
     });
 
     it('should handle putCharacterContacts (edit contacts)', async () => {
@@ -192,6 +207,9 @@ describe('ContactsClient', () => {
       );
 
       expect(result).toEqual({});
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        'https://esi.evetech.net/latest/characters/123456/contacts',
+      );
     });
 
     it('should handle deleteCharacterContacts', async () => {
@@ -205,6 +223,9 @@ describe('ContactsClient', () => {
       );
 
       expect(result).toEqual({});
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        'https://esi.evetech.net/latest/characters/123456/contacts',
+      );
     });
   });
 
@@ -247,6 +268,9 @@ describe('ContactsClient', () => {
         expect(Array.isArray(contact.label_ids)).toBe(true);
         expect(typeof contact.is_watched).toBe('boolean');
       });
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        'https://esi.evetech.net/latest/corporations/123456789/contacts',
+      );
     });
 
     it('should return valid structure for getCorporationContactLabels', async () => {
@@ -276,6 +300,9 @@ describe('ContactsClient', () => {
         expect(typeof label.label_id).toBe('number');
         expect(typeof label.name).toBe('string');
       });
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        'https://esi.evetech.net/latest/corporations/123456789/contacts/labels',
+      );
     });
   });
 

--- a/tests/tdd/contracts/ContractsClient.test.ts
+++ b/tests/tdd/contracts/ContractsClient.test.ts
@@ -47,6 +47,9 @@ describe('ContractClient', () => {
       expect(contract).toHaveProperty('type');
       expect(typeof contract.type).toBe('string');
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/characters/123456789/contracts',
+    );
   });
 
   it('should return valid structure for getContractBids', async () => {
@@ -73,6 +76,9 @@ describe('ContractClient', () => {
       expect(bid).toHaveProperty('date_bid');
       expect(typeof bid.date_bid).toBe('string');
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/characters/123456789/contracts/1/bids',
+    );
   });
 
   it('should return valid structure for getContractItems', async () => {
@@ -99,6 +105,9 @@ describe('ContractClient', () => {
       expect(item).toHaveProperty('quantity');
       expect(typeof item.quantity).toBe('number');
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/characters/123456789/contracts/1/items',
+    );
   });
 
   it('should return valid structure for getPublicContracts', async () => {
@@ -126,6 +135,9 @@ describe('ContractClient', () => {
       expect(contract).toHaveProperty('type');
       expect(typeof contract.type).toBe('string');
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/contracts/public/123',
+    );
   });
 
   it('should return valid structure for getPublicContractBids', async () => {
@@ -150,6 +162,9 @@ describe('ContractClient', () => {
       expect(bid).toHaveProperty('date_bid');
       expect(typeof bid.date_bid).toBe('string');
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/contracts/public/bids/1',
+    );
   });
 
   it('should return valid structure for getPublicContractItems', async () => {
@@ -176,6 +191,9 @@ describe('ContractClient', () => {
       expect(item).toHaveProperty('quantity');
       expect(typeof item.quantity).toBe('number');
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/contracts/public/items/1',
+    );
   });
 
   it('should return valid structure for getCorporationContracts', async () => {
@@ -205,6 +223,9 @@ describe('ContractClient', () => {
       expect(contract).toHaveProperty('type');
       expect(typeof contract.type).toBe('string');
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/corporations/123456789/contracts',
+    );
   });
 
   it('should return valid structure for getCorporationContractBids', async () => {
@@ -231,6 +252,9 @@ describe('ContractClient', () => {
       expect(bid).toHaveProperty('date_bid');
       expect(typeof bid.date_bid).toBe('string');
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/corporations/123456789/contracts/1/bids',
+    );
   });
 
   it('should return valid structure for getCorporationContractItems', async () => {
@@ -257,5 +281,8 @@ describe('ContractClient', () => {
       expect(item).toHaveProperty('quantity');
       expect(typeof item.quantity).toBe('number');
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/corporations/123456789/contracts/1/items',
+    );
   });
 });

--- a/tests/tdd/core/CursorPaginationHandler.test.ts
+++ b/tests/tdd/core/CursorPaginationHandler.test.ts
@@ -23,10 +23,11 @@ describe('CursorPaginationHandler', () => {
 
   beforeEach(() => {
     fetchMock.resetMocks();
-    const rateLimiter = RateLimiter.getInstance();
+    const rateLimiter = new RateLimiter();
     rateLimiter.reset();
     rateLimiter.setTestMode(true);
     client = new ApiClient('test', 'https://esi.evetech.net', undefined);
+    client.setRateLimiter(rateLimiter);
   });
 
   describe('fetchPage', () => {

--- a/tests/tdd/core/CursorPaginationIntegration.test.ts
+++ b/tests/tdd/core/CursorPaginationIntegration.test.ts
@@ -1,7 +1,4 @@
-import {
-  handleRequest,
-  resetETagCache,
-} from '../../../src/core/ApiRequestHandler';
+import { handleRequest } from '../../../src/core/ApiRequestHandler';
 import { ApiClient } from '../../../src/core/ApiClient';
 import { RateLimiter } from '../../../src/core/rateLimiter/RateLimiter';
 import fetchMock from 'jest-fetch-mock';
@@ -18,11 +15,11 @@ describe('Cursor Pagination Integration (handleRequest)', () => {
 
   beforeEach(() => {
     fetchMock.resetMocks();
-    resetETagCache();
-    const rateLimiter = RateLimiter.getInstance();
+    const rateLimiter = new RateLimiter();
     rateLimiter.reset();
     rateLimiter.setTestMode(true);
     client = new ApiClient('test', 'https://esi.evetech.net', undefined);
+    client.setRateLimiter(rateLimiter);
   });
 
   it('should detect cursor pagination and return cursors in response', async () => {

--- a/tests/tdd/core/ETagIntegration.test.ts
+++ b/tests/tdd/core/ETagIntegration.test.ts
@@ -1,9 +1,4 @@
 import { EsiClient } from '../../../src/EsiClient';
-import {
-  initializeETagCache,
-  getETagCache,
-  resetETagCache,
-} from '../../../src/core/ApiRequestHandler';
 import fetchMock from 'jest-fetch-mock';
 
 fetchMock.enableMocks();
@@ -14,20 +9,10 @@ describe('ETag Integration Tests', () => {
   beforeEach(() => {
     fetchMock.resetMocks();
 
-    // Reset the global cache to ensure clean state
-    resetETagCache();
-
-    // Reset rate limiter to ensure clean state
-    const {
-      RateLimiter,
-    } = require('../../../src/core/rateLimiter/RateLimiter');
-    const rateLimiter = RateLimiter.getInstance();
-    rateLimiter.reset();
-    rateLimiter.setTestMode(true);
-
     client = new EsiClient({
       clientId: 'test-client',
       baseUrl: 'https://test-api.example.com',
+      unsafeAllowCustomHost: true,
       enableETagCache: true,
       etagCacheConfig: {
         maxEntries: 100,
@@ -57,10 +42,8 @@ describe('ETag Integration Tests', () => {
 
       expect(response).toEqual(mockData);
 
-      const cache = getETagCache();
-      expect(cache).toBeDefined();
-
       const cacheStats = client.getCacheStats();
+      expect(cacheStats).toBeDefined();
       expect(cacheStats!.totalEntries).toBe(1);
     });
 
@@ -126,9 +109,19 @@ describe('ETag Integration Tests', () => {
       const secondResponse = await client.alliance.getAlliances();
       expect(secondResponse).toEqual(newData);
 
-      const cache = getETagCache();
-      const url = 'https://test-api.example.com/alliances';
-      expect(cache?.getETag(url)).toBe(newETag);
+      // Verify cache was updated with the new ETag by making a third request
+      // and checking the If-None-Match header
+      fetchMock.mockResponseOnce('', {
+        status: 304,
+        headers: { ETag: newETag },
+      });
+
+      await client.alliance.getAlliances();
+      const thirdCallHeaders = fetchMock.mock.calls[2][1]?.headers as Record<
+        string,
+        string
+      >;
+      expect(thirdCallHeaders['If-None-Match']).toBe(newETag);
     });
   });
 

--- a/tests/tdd/core/EsiError.test.ts
+++ b/tests/tdd/core/EsiError.test.ts
@@ -90,4 +90,47 @@ describe('EsiError', () => {
       expect(isServerError(new Error('not esi'))).toBe(false);
     });
   });
+
+  describe('URL sanitization', () => {
+    it('should redact sensitive query parameters', () => {
+      const err = new EsiError(
+        400,
+        'Bad request',
+        'https://esi.evetech.net/latest/foo?token=secret123&page=1',
+      );
+      expect(err.url).toContain('token=%5BREDACTED%5D');
+      expect(err.url).not.toContain('secret123');
+      expect(err.url).toContain('page=1');
+    });
+
+    it('should redact access_token parameter', () => {
+      const err = new EsiError(
+        401,
+        'Unauthorized',
+        'https://esi.evetech.net/latest/foo?access_token=mytoken',
+      );
+      expect(err.url).not.toContain('mytoken');
+    });
+
+    it('should preserve URLs without sensitive params', () => {
+      const err = new EsiError(
+        404,
+        'Not found',
+        'https://esi.evetech.net/latest/alliances/99005338/',
+      );
+      expect(err.url).toBe(
+        'https://esi.evetech.net/latest/alliances/99005338/',
+      );
+    });
+
+    it('should handle malformed URLs by stripping query string', () => {
+      const err = new EsiError(500, 'Error', 'not-a-url?secret=value');
+      expect(err.url).toBe('not-a-url?[params-redacted]');
+    });
+
+    it('should handle undefined URL', () => {
+      const err = new EsiError(500, 'Error');
+      expect(err.url).toBeUndefined();
+    });
+  });
 });

--- a/tests/tdd/core/PaginationHandler.test.ts
+++ b/tests/tdd/core/PaginationHandler.test.ts
@@ -10,10 +10,11 @@ describe('PaginationHandler', () => {
 
   beforeEach(() => {
     fetchMock.resetMocks();
-    const rateLimiter = RateLimiter.getInstance();
+    const rateLimiter = new RateLimiter();
     rateLimiter.reset();
     rateLimiter.setTestMode(true);
     client = new ApiClient('test', 'https://esi.evetech.net', undefined);
+    client.setRateLimiter(rateLimiter);
   });
 
   describe('fetchRemainingPages', () => {

--- a/tests/tdd/core/PaginationIntegration.test.ts
+++ b/tests/tdd/core/PaginationIntegration.test.ts
@@ -1,7 +1,4 @@
-import {
-  handleRequest,
-  resetETagCache,
-} from '../../../src/core/ApiRequestHandler';
+import { handleRequest } from '../../../src/core/ApiRequestHandler';
 import { ApiClient } from '../../../src/core/ApiClient';
 import { RateLimiter } from '../../../src/core/rateLimiter/RateLimiter';
 import fetchMock from 'jest-fetch-mock';
@@ -17,11 +14,11 @@ describe('Pagination Integration (handleRequest)', () => {
 
   beforeEach(() => {
     fetchMock.resetMocks();
-    resetETagCache();
-    const rateLimiter = RateLimiter.getInstance();
+    const rateLimiter = new RateLimiter();
     rateLimiter.reset();
     rateLimiter.setTestMode(true);
     client = new ApiClient('test', 'https://esi.evetech.net', undefined);
+    client.setRateLimiter(rateLimiter);
   });
 
   it('should return single-page data without extra fetches', async () => {

--- a/tests/tdd/core/RateLimitIntegration.test.ts
+++ b/tests/tdd/core/RateLimitIntegration.test.ts
@@ -1,7 +1,4 @@
-import {
-  handleRequest,
-  resetETagCache,
-} from '../../../src/core/ApiRequestHandler';
+import { handleRequest } from '../../../src/core/ApiRequestHandler';
 import { ApiClient } from '../../../src/core/ApiClient';
 import { RateLimiter } from '../../../src/core/rateLimiter/RateLimiter';
 import fetchMock from 'jest-fetch-mock';
@@ -18,11 +15,11 @@ describe('Rate Limit Integration (handleRequest)', () => {
 
   beforeEach(() => {
     fetchMock.resetMocks();
-    resetETagCache();
-    rateLimiter = RateLimiter.getInstance();
+    rateLimiter = new RateLimiter();
     rateLimiter.reset();
     rateLimiter.setTestMode(true);
     client = new ApiClient('test', 'https://esi.evetech.net', 'test-token');
+    client.setRateLimiter(rateLimiter);
   });
 
   it('should update rate limiter on successful 200 response', async () => {

--- a/tests/tdd/core/RateLimiter.test.ts
+++ b/tests/tdd/core/RateLimiter.test.ts
@@ -4,7 +4,7 @@ describe('RateLimiter', () => {
   let limiter: RateLimiter;
 
   beforeEach(() => {
-    limiter = RateLimiter.getInstance();
+    limiter = new RateLimiter();
     limiter.reset();
     limiter.setTestMode(false);
   });
@@ -13,11 +13,11 @@ describe('RateLimiter', () => {
     limiter.setTestMode(true);
   });
 
-  describe('singleton', () => {
-    it('should return the same instance', () => {
-      const a = RateLimiter.getInstance();
-      const b = RateLimiter.getInstance();
-      expect(a).toBe(b);
+  describe('constructor', () => {
+    it('should return independent instances', () => {
+      const a = new RateLimiter();
+      const b = new RateLimiter();
+      expect(a).not.toBe(b);
     });
   });
 

--- a/tests/tdd/core/WithMetadata.test.ts
+++ b/tests/tdd/core/WithMetadata.test.ts
@@ -1,7 +1,6 @@
 import { AllianceClient } from '../../../src/clients/AllianceClient';
 import { ApiClient } from '../../../src/core/ApiClient';
 import { RateLimiter } from '../../../src/core/rateLimiter/RateLimiter';
-import { resetETagCache } from '../../../src/core/ApiRequestHandler';
 import fetchMock from 'jest-fetch-mock';
 
 fetchMock.enableMocks();
@@ -12,9 +11,11 @@ describe('withMetadata()', () => {
 
   beforeEach(() => {
     fetchMock.resetMocks();
-    resetETagCache();
-    RateLimiter.getInstance().reset();
+    const rateLimiter = new RateLimiter();
+    rateLimiter.reset();
+    rateLimiter.setTestMode(true);
     apiClient = new ApiClient('https://esi.evetech.net', 'test-client');
+    apiClient.setRateLimiter(rateLimiter);
     allianceClient = new AllianceClient(apiClient);
   });
 

--- a/tests/tdd/core/createClient.test.ts
+++ b/tests/tdd/core/createClient.test.ts
@@ -11,15 +11,18 @@ const BASE_URL = 'https://esi.evetech.net';
 
 describe('createClient', () => {
   let apiClient: ApiClient;
+  let rateLimiter: RateLimiter;
 
   beforeEach(() => {
     fetchMock.resetMocks();
+    rateLimiter = new RateLimiter();
+    rateLimiter.setTestMode(true);
     apiClient = new ApiClient('test', BASE_URL);
-    RateLimiter.getInstance().setTestMode(true);
+    apiClient.setRateLimiter(rateLimiter);
   });
 
   afterEach(() => {
-    RateLimiter.getInstance().setTestMode(false);
+    rateLimiter.setTestMode(false);
   });
 
   describe('datasource parameter', () => {

--- a/tests/tdd/core/dependencyInjection.test.ts
+++ b/tests/tdd/core/dependencyInjection.test.ts
@@ -79,18 +79,22 @@ class MockCache implements ICache {
 }
 
 describe('Dependency Injection', () => {
+  let rateLimiter: RateLimiter;
+
   beforeEach(() => {
     fetchMock.resetMocks();
-    RateLimiter.getInstance().setTestMode(true);
+    rateLimiter = new RateLimiter();
+    rateLimiter.setTestMode(true);
   });
 
   afterEach(() => {
-    RateLimiter.getInstance().setTestMode(false);
+    rateLimiter.setTestMode(false);
   });
 
   describe('ICache injection', () => {
     it('should use injected cache for ETag lookup', async () => {
       const client = new ApiClient('test', 'https://esi.evetech.net');
+      client.setRateLimiter(rateLimiter);
       const mockCache = new MockCache();
       client.setCache(mockCache);
 
@@ -106,6 +110,7 @@ describe('Dependency Injection', () => {
 
     it('should send If-None-Match when cache has ETag', async () => {
       const client = new ApiClient('test', 'https://esi.evetech.net');
+      client.setRateLimiter(rateLimiter);
       const mockCache = new MockCache();
       mockCache.set(
         'https://esi.evetech.net/v1/status/',
@@ -130,6 +135,7 @@ describe('Dependency Injection', () => {
 
     it('should serve cached data on 304', async () => {
       const client = new ApiClient('test', 'https://esi.evetech.net');
+      client.setRateLimiter(rateLimiter);
       const mockCache = new MockCache();
       mockCache.set(
         'https://esi.evetech.net/v1/status/',
@@ -151,6 +157,7 @@ describe('Dependency Injection', () => {
   describe('IRateLimiter injection', () => {
     it('should use injected rate limiter', async () => {
       const client = new ApiClient('test', 'https://esi.evetech.net');
+      client.setRateLimiter(rateLimiter);
       let checkCalled = false;
       let updateCalled = false;
 
@@ -188,6 +195,7 @@ describe('Dependency Injection', () => {
   describe('CircuitBreaker injection', () => {
     it('should use injected circuit breaker', async () => {
       const client = new ApiClient('test', 'https://esi.evetech.net');
+      client.setRateLimiter(rateLimiter);
       const cb = new CircuitBreaker({ failureThreshold: 2 });
       client.setCircuitBreaker(cb);
 
@@ -206,6 +214,7 @@ describe('Dependency Injection', () => {
 
     it('should block requests when circuit is open', async () => {
       const client = new ApiClient('test', 'https://esi.evetech.net');
+      client.setRateLimiter(rateLimiter);
       const cb = new CircuitBreaker({ failureThreshold: 1 });
       client.setCircuitBreaker(cb);
 
@@ -223,6 +232,8 @@ describe('Dependency Injection', () => {
     it('should use different caches for different clients', async () => {
       const client1 = new ApiClient('test1', 'https://esi.evetech.net');
       const client2 = new ApiClient('test2', 'https://esi.evetech.net');
+      client1.setRateLimiter(rateLimiter);
+      client2.setRateLimiter(rateLimiter);
 
       const cache1 = new MockCache();
       const cache2 = new MockCache();

--- a/tests/tdd/core/endpointDefinitions.test.ts
+++ b/tests/tdd/core/endpointDefinitions.test.ts
@@ -1,0 +1,141 @@
+import { allianceEndpoints } from '../../../src/core/endpoints/allianceEndpoints';
+import { assetEndpoints } from '../../../src/core/endpoints/assetEndpoints';
+import { calendarEndpoints } from '../../../src/core/endpoints/calendarEndpoints';
+import { characterEndpoints } from '../../../src/core/endpoints/characterEndpoints';
+import { cloneEndpoints } from '../../../src/core/endpoints/cloneEndpoints';
+import { contactEndpoints } from '../../../src/core/endpoints/contactEndpoints';
+import { contractEndpoints } from '../../../src/core/endpoints/contractEndpoints';
+import { corporationEndpoints } from '../../../src/core/endpoints/corporationEndpoints';
+import { dogmaEndpoints } from '../../../src/core/endpoints/dogmaEndpoints';
+import { factionEndpoints } from '../../../src/core/endpoints/factionEndpoints';
+import { fittingEndpoints } from '../../../src/core/endpoints/fittingEndpoints';
+import { fleetEndpoints } from '../../../src/core/endpoints/fleetEndpoints';
+import { freelanceJobsEndpoints } from '../../../src/core/endpoints/freelanceJobsEndpoints';
+import { incursionEndpoints } from '../../../src/core/endpoints/incursionEndpoints';
+import { industryEndpoints } from '../../../src/core/endpoints/industryEndpoints';
+import { insuranceEndpoints } from '../../../src/core/endpoints/insuranceEndpoints';
+import { killmailEndpoints } from '../../../src/core/endpoints/killmailEndpoints';
+import { locationEndpoints } from '../../../src/core/endpoints/locationEndpoints';
+import { loyaltyEndpoints } from '../../../src/core/endpoints/loyaltyEndpoints';
+import { mailEndpoints } from '../../../src/core/endpoints/mailEndpoints';
+import { marketEndpoints } from '../../../src/core/endpoints/marketEndpoints';
+import { metaEndpoints } from '../../../src/core/endpoints/metaEndpoints';
+import { piEndpoints } from '../../../src/core/endpoints/piEndpoints';
+import { routeEndpoints } from '../../../src/core/endpoints/routeEndpoints';
+import { searchEndpoints } from '../../../src/core/endpoints/searchEndpoints';
+import { skillEndpoints } from '../../../src/core/endpoints/skillEndpoints';
+import { sovereigntyEndpoints } from '../../../src/core/endpoints/sovereigntyEndpoints';
+import { statusEndpoints } from '../../../src/core/endpoints/statusEndpoints';
+import { uiEndpoints } from '../../../src/core/endpoints/uiEndpoints';
+import { universeEndpoints } from '../../../src/core/endpoints/universeEndpoints';
+import { walletEndpoints } from '../../../src/core/endpoints/walletEndpoints';
+import { warEndpoints } from '../../../src/core/endpoints/warEndpoints';
+
+const ALL_ENDPOINTS: Record<string, Record<string, any>> = {
+  alliance: allianceEndpoints,
+  asset: assetEndpoints,
+  calendar: calendarEndpoints,
+  character: characterEndpoints,
+  clone: cloneEndpoints,
+  contact: contactEndpoints,
+  contract: contractEndpoints,
+  corporation: corporationEndpoints,
+  dogma: dogmaEndpoints,
+  faction: factionEndpoints,
+  fitting: fittingEndpoints,
+  fleet: fleetEndpoints,
+  freelanceJobs: freelanceJobsEndpoints,
+  incursion: incursionEndpoints,
+  industry: industryEndpoints,
+  insurance: insuranceEndpoints,
+  killmail: killmailEndpoints,
+  location: locationEndpoints,
+  loyalty: loyaltyEndpoints,
+  mail: mailEndpoints,
+  market: marketEndpoints,
+  meta: metaEndpoints,
+  pi: piEndpoints,
+  route: routeEndpoints,
+  search: searchEndpoints,
+  skill: skillEndpoints,
+  sovereignty: sovereigntyEndpoints,
+  status: statusEndpoints,
+  ui: uiEndpoints,
+  universe: universeEndpoints,
+  wallet: walletEndpoints,
+  war: warEndpoints,
+};
+
+const VALID_METHODS = ['GET', 'POST', 'PUT', 'DELETE'];
+
+describe('Endpoint Definitions', () => {
+  for (const [groupName, endpoints] of Object.entries(ALL_ENDPOINTS)) {
+    describe(`${groupName} endpoints`, () => {
+      for (const [methodName, def] of Object.entries(endpoints)) {
+        describe(methodName, () => {
+          it('has a non-empty path', () => {
+            expect(def.path).toBeTruthy();
+            expect(typeof def.path).toBe('string');
+          });
+
+          it('path does not start with /', () => {
+            expect(def.path[0]).not.toBe('/');
+          });
+
+          it('has a valid HTTP method', () => {
+            expect(VALID_METHODS).toContain(def.method);
+          });
+
+          it('pathParams match placeholders in path', () => {
+            const placeholders = (def.path.match(/\{([^}]+)\}/g) || []).map(
+              (ph: string) => ph.slice(1, -1),
+            );
+
+            if (def.pathParams) {
+              expect([...def.pathParams]).toEqual(placeholders);
+            } else {
+              expect(placeholders).toHaveLength(0);
+            }
+          });
+
+          it('path placeholders use valid identifier names', () => {
+            const placeholders = def.path.match(/\{([^}]+)\}/g) || [];
+            for (const ph of placeholders) {
+              const paramName = ph.slice(1, -1);
+              expect(paramName).toMatch(/^[a-zA-Z][a-zA-Z0-9]*$/);
+            }
+          });
+
+          it('path segments are lowercase', () => {
+            const segments = def.path
+              .replace(/\{[^}]+\}/g, '')
+              .split('/')
+              .filter(Boolean);
+            for (const seg of segments) {
+              expect(seg).toMatch(/^[a-z][a-z0-9_.-]*$/);
+            }
+          });
+
+          it('GET endpoints do not have hasBody or bodyBuilder', () => {
+            if (def.method === 'GET') {
+              expect(def.hasBody).toBeFalsy();
+              expect(def.bodyBuilder).toBeUndefined();
+            }
+          });
+
+          it('queryParams values are valid query keys', () => {
+            if (def.queryParams) {
+              for (const [, queryKey] of Object.entries(def.queryParams)) {
+                expect(queryKey).toMatch(/^[a-z][a-z0-9_]*$/);
+              }
+            }
+          });
+
+          it('requiresAuth is a boolean', () => {
+            expect(typeof def.requiresAuth).toBe('boolean');
+          });
+        });
+      }
+    });
+  }
+});

--- a/tests/tdd/core/middleware.test.ts
+++ b/tests/tdd/core/middleware.test.ts
@@ -11,13 +11,16 @@ import fetchMock from 'jest-fetch-mock';
 fetchMock.enableMocks();
 
 describe('Middleware', () => {
+  let rateLimiter: RateLimiter;
+
   beforeEach(() => {
     fetchMock.resetMocks();
-    RateLimiter.getInstance().setTestMode(true);
+    rateLimiter = new RateLimiter();
+    rateLimiter.setTestMode(true);
   });
 
   afterEach(() => {
-    RateLimiter.getInstance().setTestMode(false);
+    rateLimiter.setTestMode(false);
   });
 
   describe('MiddlewareManager', () => {
@@ -98,6 +101,7 @@ describe('Middleware', () => {
   describe('Integration with handleRequest', () => {
     it('should apply request interceptor headers to outgoing request', async () => {
       const client = new ApiClient('test', 'https://esi.evetech.net');
+      client.setRateLimiter(rateLimiter);
       client.addRequestInterceptor((ctx: RequestContext) => ({
         ...ctx,
         headers: { ...ctx.headers, 'X-Trace-Id': 'abc-123' },
@@ -116,6 +120,7 @@ describe('Middleware', () => {
 
     it('should apply response interceptor to transform body', async () => {
       const client = new ApiClient('test', 'https://esi.evetech.net');
+      client.setRateLimiter(rateLimiter);
       client.addResponseInterceptor((ctx: ResponseContext) => ({
         ...ctx,
         body: { ...(ctx.body as Record<string, unknown>), injected: true },
@@ -131,6 +136,7 @@ describe('Middleware', () => {
 
     it('should provide durationMs in response context', async () => {
       const client = new ApiClient('test', 'https://esi.evetech.net');
+      client.setRateLimiter(rateLimiter);
       let capturedDuration = -1;
 
       client.addResponseInterceptor((ctx: ResponseContext) => {
@@ -147,6 +153,7 @@ describe('Middleware', () => {
 
     it('should allow removing interceptor at runtime', async () => {
       const client = new ApiClient('test', 'https://esi.evetech.net');
+      client.setRateLimiter(rateLimiter);
       const remove = client.addRequestInterceptor((ctx: RequestContext) => ({
         ...ctx,
         headers: { ...ctx.headers, 'X-Custom': 'yes' },

--- a/tests/tdd/core/tokenRefresh.test.ts
+++ b/tests/tdd/core/tokenRefresh.test.ts
@@ -7,13 +7,16 @@ import fetchMock from 'jest-fetch-mock';
 fetchMock.enableMocks();
 
 describe('Token Refresh', () => {
+  let rateLimiter: RateLimiter;
+
   beforeEach(() => {
     fetchMock.resetMocks();
-    RateLimiter.getInstance().setTestMode(true);
+    rateLimiter = new RateLimiter();
+    rateLimiter.setTestMode(true);
   });
 
   afterEach(() => {
-    RateLimiter.getInstance().setTestMode(false);
+    rateLimiter.setTestMode(false);
   });
 
   describe('ApiClient.refreshToken', () => {
@@ -112,6 +115,7 @@ describe('Token Refresh', () => {
         'https://esi.evetech.net',
         'expired-token',
       );
+      client.setRateLimiter(rateLimiter);
       client.setTokenProvider(async () => 'fresh-token');
 
       fetchMock
@@ -142,6 +146,7 @@ describe('Token Refresh', () => {
         'https://esi.evetech.net',
         'expired-token',
       );
+      client.setRateLimiter(rateLimiter);
 
       fetchMock.mockResponseOnce('', { status: 401 });
 
@@ -154,6 +159,7 @@ describe('Token Refresh', () => {
 
     it('should not retry on 401 for non-authenticated requests', async () => {
       const client = new ApiClient('test', 'https://esi.evetech.net');
+      client.setRateLimiter(rateLimiter);
       client.setTokenProvider(async () => 'fresh-token');
 
       fetchMock.mockResponseOnce('', { status: 401 });
@@ -171,6 +177,7 @@ describe('Token Refresh', () => {
         'https://esi.evetech.net',
         'expired-token',
       );
+      client.setRateLimiter(rateLimiter);
       client.setTokenProvider(async () => {
         throw new Error('Refresh token expired');
       });
@@ -190,6 +197,7 @@ describe('Token Refresh', () => {
         'https://esi.evetech.net',
         'bad-token',
       );
+      client.setRateLimiter(rateLimiter);
       client.setTokenProvider(async () => 'still-bad-token');
 
       fetchMock
@@ -209,6 +217,7 @@ describe('Token Refresh', () => {
         'https://esi.evetech.net',
         'valid-token',
       );
+      client.setRateLimiter(rateLimiter);
       client.setTokenProvider(async () => 'fresh-token');
 
       fetchMock.mockResponseOnce('', { status: 403 });
@@ -226,6 +235,7 @@ describe('Token Refresh', () => {
         'https://esi.evetech.net',
         'bad-token',
       );
+      client.setRateLimiter(rateLimiter);
       client.setTokenProvider(async () => 'still-bad');
 
       fetchMock

--- a/tests/tdd/core/validation.test.ts
+++ b/tests/tdd/core/validation.test.ts
@@ -1,6 +1,7 @@
 import {
   validatePathParam,
   validateQueryParam,
+  validateBaseUrl,
 } from '../../../src/core/util/validation';
 
 describe('validatePathParam', () => {
@@ -83,5 +84,56 @@ describe('validateQueryParam', () => {
   it('should accept values at the length limit', () => {
     const maxString = 'a'.repeat(2000);
     expect(validateQueryParam('search', maxString)).toBe(maxString);
+  });
+});
+
+describe('validateBaseUrl', () => {
+  it('should accept valid ESI URLs', () => {
+    expect(validateBaseUrl('https://esi.evetech.net')).toBe(
+      'https://esi.evetech.net',
+    );
+    expect(validateBaseUrl('https://esi.evetech.net/latest')).toBe(
+      'https://esi.evetech.net/latest',
+    );
+  });
+
+  it('should strip trailing slash', () => {
+    expect(validateBaseUrl('https://esi.evetech.net/')).toBe(
+      'https://esi.evetech.net',
+    );
+  });
+
+  it('should reject non-HTTPS URLs', () => {
+    expect(() => validateBaseUrl('http://esi.evetech.net')).toThrow(
+      'HTTPS protocol',
+    );
+  });
+
+  it('should reject non-allowlisted hosts', () => {
+    expect(() => validateBaseUrl('https://evil.com')).toThrow(
+      'not in the allowlist',
+    );
+  });
+
+  it('should reject subdomain spoofing', () => {
+    expect(() => validateBaseUrl('https://esi.evetech.net.evil.com')).toThrow(
+      'not in the allowlist',
+    );
+  });
+
+  it('should reject invalid URLs', () => {
+    expect(() => validateBaseUrl('not-a-url')).toThrow('Invalid base URL');
+  });
+
+  it('should allow custom hosts when unsafeAllowCustomHost is true', () => {
+    expect(validateBaseUrl('https://my-proxy.example.com', true)).toBe(
+      'https://my-proxy.example.com',
+    );
+  });
+
+  it('should still require HTTPS even with unsafeAllowCustomHost', () => {
+    expect(() => validateBaseUrl('http://my-proxy.example.com', true)).toThrow(
+      'HTTPS protocol',
+    );
   });
 });

--- a/tests/tdd/corporations/CorporationsClient.test.ts
+++ b/tests/tdd/corporations/CorporationsClient.test.ts
@@ -41,6 +41,9 @@ describe('CorporationsClient', () => {
     expect(typeof result.name).toBe('string');
     expect(result).toHaveProperty('ticker');
     expect(typeof result.ticker).toBe('string');
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/corporations/123456789',
+    );
   });
 
   it('should return valid structure for getCorporationAllianceHistory', async () => {
@@ -76,6 +79,9 @@ describe('CorporationsClient', () => {
         expect(history).toHaveProperty('start_date');
         expect(typeof history.start_date).toBe('string');
       },
+    );
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/corporations/123456789/alliancehistory',
     );
   });
 
@@ -129,6 +135,9 @@ describe('CorporationsClient', () => {
         expect(typeof blueprint.runs).toBe('number');
       },
     );
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/corporations/123456789/blueprints',
+    );
   });
 
   it('should return valid structure for getCorporationAlscLogs', async () => {
@@ -177,6 +186,9 @@ describe('CorporationsClient', () => {
         expect(typeof log.quantity).toBe('number');
       },
     );
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/corporations/123456789/containers/logs',
+    );
   });
 
   it('should return valid structure for getCorporationDivisions', async () => {
@@ -218,6 +230,9 @@ describe('CorporationsClient', () => {
       expect(division).toHaveProperty('division');
       expect(typeof division.division).toBe('number');
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/corporations/123456789/divisions',
+    );
   });
 
   it('should return valid structure for getCorporationFacilities', async () => {
@@ -258,6 +273,9 @@ describe('CorporationsClient', () => {
         expect(typeof facility.solar_system_id).toBe('number');
       },
     );
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/corporations/123456789/facilities',
+    );
   });
 
   it('should return valid structure for getCorporationIcon', async () => {
@@ -279,6 +297,9 @@ describe('CorporationsClient', () => {
     expect(typeof result.px128x128).toBe('string');
     expect(result).toHaveProperty('px256x256');
     expect(typeof result.px256x256).toBe('string');
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/corporations/123456789/icons',
+    );
   });
 
   // Adding tests for key missing methods
@@ -313,6 +334,9 @@ describe('CorporationsClient', () => {
         expect(typeof member.title).toBe('string');
       },
     );
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/corporations/123456789/members',
+    );
   });
 
   it('should return valid structure for getCorporationMemberLimit', async () => {
@@ -326,6 +350,9 @@ describe('CorporationsClient', () => {
 
     expect(typeof result).toBe('number');
     expect(result).toBe(50);
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/corporations/123456789/members/limit',
+    );
   });
 
   it('should return valid structure for getCorporationRoles', async () => {
@@ -358,6 +385,9 @@ describe('CorporationsClient', () => {
       expect(roleData).toHaveProperty('grantable_roles');
       expect(Array.isArray(roleData.grantable_roles)).toBe(true);
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/corporations/123456789/roles',
+    );
   });
 
   it('should return valid structure for getCorporationStandings', async () => {
@@ -389,6 +419,9 @@ describe('CorporationsClient', () => {
       expect(standing).toHaveProperty('standing');
       expect(typeof standing.standing).toBe('number');
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/corporations/123456789/standings',
+    );
   });
 
   it('should return valid structure for getCorporationTitles', async () => {
@@ -422,6 +455,9 @@ describe('CorporationsClient', () => {
       expect(title).toHaveProperty('roles');
       expect(Array.isArray(title.roles)).toBe(true);
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/corporations/123456789/titles',
+    );
   });
 
   it('should return valid structure for getNpcCorporations', async () => {
@@ -436,5 +472,8 @@ describe('CorporationsClient', () => {
       expect(typeof corpId).toBe('number');
       expect(corpId).toBeGreaterThan(0);
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/corporations/npccorps',
+    );
   });
 });

--- a/tests/tdd/dogma/DogmaClient.test.ts
+++ b/tests/tdd/dogma/DogmaClient.test.ts
@@ -34,6 +34,9 @@ describe('DogmaClient', () => {
       result.forEach((id: number) => {
         expect(typeof id).toBe('number');
       });
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        'https://esi.evetech.net/latest/dogma/attributes',
+      );
     });
 
     it('should handle empty attributes list', async () => {
@@ -43,6 +46,9 @@ describe('DogmaClient', () => {
 
       expect(Array.isArray(result)).toBe(true);
       expect(result).toHaveLength(0);
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        'https://esi.evetech.net/latest/dogma/attributes',
+      );
     });
   });
 
@@ -74,6 +80,9 @@ describe('DogmaClient', () => {
       expect(result.published).toBe(true);
       expect(result.display_name).toBe('Powergrid Output');
       expect(result.high_is_good).toBe(true);
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        'https://esi.evetech.net/latest/dogma/attributes/20',
+      );
     });
 
     it('should throw on non-existent attribute', async () => {
@@ -98,6 +107,9 @@ describe('DogmaClient', () => {
       result.forEach((id: number) => {
         expect(typeof id).toBe('number');
       });
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        'https://esi.evetech.net/latest/dogma/effects',
+      );
     });
   });
 
@@ -125,6 +137,9 @@ describe('DogmaClient', () => {
       expect(result.published).toBe(true);
       expect(result.is_warp_safe).toBe(true);
       expect(result.is_offensive).toBe(false);
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        'https://esi.evetech.net/latest/dogma/effects/11',
+      );
     });
 
     it('should throw on non-existent effect', async () => {
@@ -169,6 +184,9 @@ describe('DogmaClient', () => {
       expect(Array.isArray(result.dogma_effects)).toBe(true);
       expect(result.dogma_effects).toHaveLength(2);
       expect(result.dogma_effects[0].effect_id).toBe(11);
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        'https://esi.evetech.net/latest/dogma/dynamic/items/47740/1234567890',
+      );
     });
 
     it('should throw on non-existent dynamic item', async () => {

--- a/tests/tdd/factions/FactionClient.test.ts
+++ b/tests/tdd/factions/FactionClient.test.ts
@@ -47,6 +47,9 @@ describe('FactionClient', () => {
     expect(result.victory_points).toHaveProperty('yesterday');
     expect(result.victory_points).toHaveProperty('last_week');
     expect(result.victory_points).toHaveProperty('total');
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/fw/leaderboards/characters',
+    );
   });
 
   it('should return valid structure for getLeaderboardsCorporations', async () => {
@@ -77,6 +80,9 @@ describe('FactionClient', () => {
     expect(result.victory_points).toHaveProperty('yesterday');
     expect(result.victory_points).toHaveProperty('last_week');
     expect(result.victory_points).toHaveProperty('total');
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/fw/leaderboards/corporations',
+    );
   });
 
   it('should return valid structure for getLeaderboardsOverall', async () => {
@@ -105,6 +111,9 @@ describe('FactionClient', () => {
     expect(result.victory_points).toHaveProperty('yesterday');
     expect(result.victory_points).toHaveProperty('last_week');
     expect(result.victory_points).toHaveProperty('total');
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/fw/leaderboards',
+    );
   });
 
   it('should return valid structure for getStats', async () => {
@@ -157,6 +166,9 @@ describe('FactionClient', () => {
         expect(typeof stat.victory_points.yesterday).toBe('number');
       },
     );
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/fw/stats',
+    );
   });
 
   it('should return valid structure for getCharacterStats', async () => {
@@ -196,6 +208,9 @@ describe('FactionClient', () => {
     expect(typeof result.victory_points.total).toBe('number');
     expect(result.victory_points).toHaveProperty('yesterday');
     expect(typeof result.victory_points.yesterday).toBe('number');
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/characters/123456789/fw/stats',
+    );
   });
 
   it('should return valid structure for getCorporationStats', async () => {
@@ -235,6 +250,9 @@ describe('FactionClient', () => {
     expect(typeof result.victory_points.total).toBe('number');
     expect(result.victory_points).toHaveProperty('yesterday');
     expect(typeof result.victory_points.yesterday).toBe('number');
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/corporations/987654321/fw/stats',
+    );
   });
 
   it('should return valid structure for getSystems', async () => {
@@ -277,6 +295,9 @@ describe('FactionClient', () => {
         expect(typeof system.victory_points_threshold).toBe('number');
       },
     );
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/fw/systems',
+    );
   });
 
   it('should return valid structure for getWars', async () => {
@@ -298,5 +319,8 @@ describe('FactionClient', () => {
       expect(war).toHaveProperty('faction_id');
       expect(typeof war.faction_id).toBe('number');
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/fw/wars',
+    );
   });
 });

--- a/tests/tdd/fittings/FittingsClient.test.ts
+++ b/tests/tdd/fittings/FittingsClient.test.ts
@@ -63,6 +63,9 @@ describe('FittingsClient', () => {
         expect(item).toHaveProperty('type_id');
       });
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/characters/123456/fittings',
+    );
   });
 
   it('should create a fitting', async () => {
@@ -91,6 +94,9 @@ describe('FittingsClient', () => {
 
     expect(result).toHaveProperty('fitting_id');
     expect(typeof result.fitting_id).toBe('number');
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/characters/123456/fittings',
+    );
   });
 
   it('should delete a fitting', async () => {
@@ -99,5 +105,8 @@ describe('FittingsClient', () => {
     const result = await getBody(() => fittingsClient.deleteFitting(123456, 1));
 
     expect(result).toBeUndefined();
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/characters/123456/fittings/1',
+    );
   });
 });

--- a/tests/tdd/fleets/FleetClient.test.ts
+++ b/tests/tdd/fleets/FleetClient.test.ts
@@ -37,6 +37,9 @@ describe('FleetClient', () => {
     expect(result).toHaveProperty('role');
     expect(result).toHaveProperty('squad_id');
     expect(result).toHaveProperty('wing_id');
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/characters/123456789/fleet',
+    );
   });
 
   it('should return valid structure for getFleetInformation', async () => {
@@ -59,6 +62,9 @@ describe('FleetClient', () => {
     expect(result).toHaveProperty('is_registered');
     expect(result).toHaveProperty('is_voice_enabled');
     expect(result).toHaveProperty('motd');
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/fleets/1234567890',
+    );
   });
 
   it('should update the fleet information', async () => {
@@ -71,6 +77,9 @@ describe('FleetClient', () => {
     );
 
     expect(result).toBeUndefined();
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/fleets/1234567890',
+    );
   });
 
   it('should return valid structure for getFleetMembers', async () => {
@@ -106,6 +115,9 @@ describe('FleetClient', () => {
       expect(member).toHaveProperty('takes_fleet_warp');
       expect(member).toHaveProperty('wing_id');
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/fleets/1234567890/members',
+    );
   });
 
   it('should create a fleet invitation', async () => {
@@ -118,6 +130,9 @@ describe('FleetClient', () => {
     );
 
     expect(result).toBeUndefined();
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/fleets/1234567890/members/',
+    );
   });
 
   it('should kick a fleet member', async () => {
@@ -128,6 +143,9 @@ describe('FleetClient', () => {
     );
 
     expect(result).toBeUndefined();
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/fleets/1234567890/members/123456789/',
+    );
   });
 
   it('should move a fleet member', async () => {
@@ -140,6 +158,9 @@ describe('FleetClient', () => {
     );
 
     expect(result).toBeUndefined();
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/fleets/1234567890/members/123456789/',
+    );
   });
 
   it('should delete a fleet squad', async () => {
@@ -150,6 +171,9 @@ describe('FleetClient', () => {
     );
 
     expect(result).toBeUndefined();
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/fleets/1234567890/squads/1/',
+    );
   });
 
   it('should rename a fleet squad', async () => {
@@ -160,6 +184,9 @@ describe('FleetClient', () => {
     );
 
     expect(result).toBeUndefined();
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/fleets/1234567890/squads/1/',
+    );
   });
 
   it('should return fleet wings', async () => {
@@ -190,6 +217,9 @@ describe('FleetClient', () => {
         expect(squad).toHaveProperty('name');
       });
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/fleets/1234567890/wings/',
+    );
   });
 
   it('should create a fleet wing', async () => {
@@ -202,6 +232,9 @@ describe('FleetClient', () => {
     );
 
     expect(result).toBeUndefined();
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/fleets/1234567890/wings/',
+    );
   });
 
   it('should delete a fleet wing', async () => {
@@ -212,6 +245,9 @@ describe('FleetClient', () => {
     );
 
     expect(result).toBeUndefined();
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/fleets/1234567890/wings/1/',
+    );
   });
 
   it('should rename a fleet wing', async () => {
@@ -222,6 +258,9 @@ describe('FleetClient', () => {
     );
 
     expect(result).toBeUndefined();
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/fleets/1234567890/wings/1/',
+    );
   });
 
   it('should create a fleet squad', async () => {
@@ -232,5 +271,8 @@ describe('FleetClient', () => {
     );
 
     expect(result).toBeUndefined();
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/fleets/1234567890/wings/1/squads/',
+    );
   });
 });

--- a/tests/tdd/incursions/IncursionsClient.test.ts
+++ b/tests/tdd/incursions/IncursionsClient.test.ts
@@ -59,5 +59,8 @@ describe('IncursionsClient', () => {
         expect(typeof incursion.type).toBe('string');
       });
     }
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/incursions',
+    );
   });
 });

--- a/tests/tdd/industry/IndustryClient.test.ts
+++ b/tests/tdd/industry/IndustryClient.test.ts
@@ -98,6 +98,9 @@ describe('IndustryClient', () => {
       expect(job).toHaveProperty('completed_character_id');
       expect(typeof job.completed_character_id).toBe('number');
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/characters/123456789/industry/jobs',
+    );
   });
 
   it('should return valid structure for getCharacterMiningLedger', async () => {
@@ -127,6 +130,9 @@ describe('IndustryClient', () => {
       expect(ledger).toHaveProperty('type_id');
       expect(typeof ledger.type_id).toBe('number');
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/characters/123456789/mining',
+    );
   });
 
   it('should return valid structure for getMoonExtractionTimers', async () => {
@@ -159,6 +165,9 @@ describe('IndustryClient', () => {
       expect(timer).toHaveProperty('natural_decay_time');
       expect(typeof timer.natural_decay_time).toBe('string');
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/corporations/123456789/mining/extractions',
+    );
   });
 
   it('should return valid structure for getCorporationMiningObservers', async () => {
@@ -185,6 +194,9 @@ describe('IndustryClient', () => {
       expect(observer).toHaveProperty('last_updated');
       expect(typeof observer.last_updated).toBe('string');
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/corporations/123456789/mining/observers',
+    );
   });
 
   it('should return valid structure for getCorporationMiningObserver', async () => {
@@ -217,6 +229,9 @@ describe('IndustryClient', () => {
       expect(record).toHaveProperty('last_updated');
       expect(typeof record.last_updated).toBe('string');
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/corporations/123456789/mining/observers/987654321',
+    );
   });
 
   it('should return valid structure for getCorporationIndustryJobs', async () => {
@@ -297,6 +312,9 @@ describe('IndustryClient', () => {
       expect(job).toHaveProperty('completed_character_id');
       expect(typeof job.completed_character_id).toBe('number');
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/corporations/123456789/industry/jobs',
+    );
   });
 
   it('should return valid structure for getIndustryFacilities', async () => {
@@ -330,6 +348,9 @@ describe('IndustryClient', () => {
       expect(facility).toHaveProperty('tax');
       expect(typeof facility.tax).toBe('number');
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/industry/facilities',
+    );
   });
 
   it('should return valid structure for getIndustrySystems', async () => {
@@ -362,5 +383,8 @@ describe('IndustryClient', () => {
         expect(typeof index.cost_index).toBe('number');
       });
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/industry/systems',
+    );
   });
 });

--- a/tests/tdd/insurance/InsuranceClient.test.ts
+++ b/tests/tdd/insurance/InsuranceClient.test.ts
@@ -46,5 +46,8 @@ describe('InsuranceClient', () => {
       expect(insurance).toHaveProperty('payout');
       expect(typeof insurance.payout).toBe('number');
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/insurance/prices',
+    );
   });
 });

--- a/tests/tdd/killmails/KillmailClient.test.ts
+++ b/tests/tdd/killmails/KillmailClient.test.ts
@@ -51,6 +51,9 @@ describe('KillmailsClient', () => {
       expect(killmail).toHaveProperty('attackers');
       expect(Array.isArray(killmail.attackers)).toBe(true);
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/characters/123456/killmails/recent',
+    );
   });
 
   it('should return valid structure for getCorporationRecentKillmails', async () => {
@@ -84,6 +87,9 @@ describe('KillmailsClient', () => {
       expect(killmail).toHaveProperty('attackers');
       expect(Array.isArray(killmail.attackers)).toBe(true);
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/corporations/123456/killmails/recent',
+    );
   });
 
   it('should return valid structure for getKillmail', async () => {
@@ -112,5 +118,8 @@ describe('KillmailsClient', () => {
     expect(typeof result.victim.character_id).toBe('number');
     expect(result).toHaveProperty('attackers');
     expect(Array.isArray(result.attackers)).toBe(true);
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/killmails/12345/abcdef1234567890',
+    );
   });
 });

--- a/tests/tdd/location/LocationClient.test.ts
+++ b/tests/tdd/location/LocationClient.test.ts
@@ -39,6 +39,9 @@ describe('LocationClient', () => {
     expect(typeof result.station_id).toBe('number');
     expect(result).toHaveProperty('structure_id');
     expect(typeof result.structure_id).toBe('number');
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/characters/123456/location',
+    );
   });
 
   it('should return valid structure for getCharacterOnline', async () => {
@@ -63,6 +66,9 @@ describe('LocationClient', () => {
     expect(typeof result.last_logout).toBe('string');
     expect(result).toHaveProperty('logins');
     expect(typeof result.logins).toBe('number');
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/characters/123456/online',
+    );
   });
 
   it('should return valid structure for getCharacterShip', async () => {
@@ -82,5 +88,8 @@ describe('LocationClient', () => {
     expect(typeof result.ship_name).toBe('string');
     expect(result).toHaveProperty('ship_type_id');
     expect(typeof result.ship_type_id).toBe('number');
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/characters/123456/ship',
+    );
   });
 });

--- a/tests/tdd/loyalty/LoyaltyClient.test.ts
+++ b/tests/tdd/loyalty/LoyaltyClient.test.ts
@@ -41,6 +41,9 @@ describe('LoyaltyClient', () => {
         expect(typeof points.loyalty_points).toBe('number');
       },
     );
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/characters/123456/loyalty/points',
+    );
   });
 
   it('should return loyalty store offers', async () => {
@@ -80,6 +83,9 @@ describe('LoyaltyClient', () => {
         expect(offer).toHaveProperty('quantity');
         expect(typeof offer.quantity).toBe('number');
       },
+    );
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/loyalty/stores/123/offers',
     );
   });
 });

--- a/tests/tdd/mail/MailClient.test.ts
+++ b/tests/tdd/mail/MailClient.test.ts
@@ -51,6 +51,9 @@ describe('MailClient', () => {
         expect(typeof mail.timestamp).toBe('string');
       },
     );
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/characters/123456789/mail/',
+    );
   });
 
   it('should send a new mail', async () => {
@@ -70,6 +73,9 @@ describe('MailClient', () => {
 
     expect(result).toHaveProperty('mail_id');
     expect(typeof result.mail_id).toBe('number');
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/characters/123456/mail/',
+    );
   });
 
   it('should delete a mail', async () => {
@@ -78,6 +84,9 @@ describe('MailClient', () => {
     const result = await getBody(() => mailClient.deleteMail(123456, 1));
 
     expect(result).toBeUndefined();
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/characters/123456/mail/1/',
+    );
   });
 
   it('should return a mail', async () => {
@@ -103,6 +112,9 @@ describe('MailClient', () => {
     expect(typeof result.from).toBe('number');
     expect(result).toHaveProperty('timestamp');
     expect(typeof result.timestamp).toBe('string');
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/characters/123456/mail/1/',
+    );
   });
 
   it('should update mail metadata', async () => {
@@ -118,6 +130,9 @@ describe('MailClient', () => {
     );
 
     expect(result).toBeUndefined();
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/characters/123456/mail/1/',
+    );
   });
 
   it('should return mail labels and unread counts', async () => {
@@ -150,6 +165,9 @@ describe('MailClient', () => {
     );
     expect(result).toHaveProperty('total_unread_count');
     expect(typeof result.total_unread_count).toBe('number');
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/characters/123456789/mail/labels/',
+    );
   });
 
   it('should create a mail label', async () => {
@@ -169,6 +187,9 @@ describe('MailClient', () => {
 
     expect(result).toHaveProperty('label_id');
     expect(typeof result.label_id).toBe('number');
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/characters/123456/mail/labels/',
+    );
   });
 
   it('should delete a mail label', async () => {
@@ -177,6 +198,9 @@ describe('MailClient', () => {
     const result = await getBody(() => mailClient.deleteMailLabel(123456, 1));
 
     expect(result).toBeUndefined();
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/characters/123456/mail/labels/1/',
+    );
   });
 
   it('should return mailing list subscriptions', async () => {
@@ -198,5 +222,8 @@ describe('MailClient', () => {
       expect(list).toHaveProperty('name');
       expect(typeof list.name).toBe('string');
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/characters/123456789/mail/lists/',
+    );
   });
 });

--- a/tests/tdd/market/MarketClient.test.ts
+++ b/tests/tdd/market/MarketClient.test.ts
@@ -73,6 +73,9 @@ describe('MarketClient', () => {
         expect(typeof order.is_buy_order).toBe('boolean');
       },
     );
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/characters/123456/orders/',
+    );
   });
 
   it('should return character order history', async () => {
@@ -120,6 +123,9 @@ describe('MarketClient', () => {
         expect(order).toHaveProperty('is_buy_order');
         expect(typeof order.is_buy_order).toBe('boolean');
       },
+    );
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/characters/123456/orders/history/',
     );
   });
 
@@ -178,6 +184,9 @@ describe('MarketClient', () => {
         expect(typeof order.is_buy_order).toBe('boolean');
       },
     );
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/corporations/123456/orders/',
+    );
   });
 
   it('should return corporation order history', async () => {
@@ -226,6 +235,9 @@ describe('MarketClient', () => {
         expect(typeof order.is_buy_order).toBe('boolean');
       },
     );
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/corporations/123456/orders/history/',
+    );
   });
 
   it('should return market history', async () => {
@@ -269,6 +281,9 @@ describe('MarketClient', () => {
         expect(history).toHaveProperty('lowest');
         expect(typeof history.lowest).toBe('number');
       },
+    );
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/markets/123456/history/?type_id=678910',
     );
   });
 
@@ -325,6 +340,9 @@ describe('MarketClient', () => {
         expect(typeof order.is_buy_order).toBe('boolean');
       },
     );
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/markets/123456/orders/?order_type=all',
+    );
   });
 
   it('should return market types', async () => {
@@ -338,6 +356,9 @@ describe('MarketClient', () => {
     result.forEach((typeId: number) => {
       expect(typeof typeId).toBe('number');
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/markets/123456/types/',
+    );
   });
 
   it('should return market groups', async () => {
@@ -372,6 +393,9 @@ describe('MarketClient', () => {
         expect(Array.isArray(group.types)).toBe(true);
       },
     );
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/markets/groups/',
+    );
   });
 
   it('should return market group information', async () => {
@@ -396,6 +420,9 @@ describe('MarketClient', () => {
     expect(typeof result.description).toBe('string');
     expect(result).toHaveProperty('types');
     expect(Array.isArray(result.types)).toBe(true);
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/markets/groups/1/',
+    );
   });
 
   it('should return market prices', async () => {
@@ -430,6 +457,9 @@ describe('MarketClient', () => {
         expect(price).toHaveProperty('adjusted_price');
         expect(typeof price.adjusted_price).toBe('number');
       },
+    );
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/markets/prices/',
     );
   });
 
@@ -487,6 +517,9 @@ describe('MarketClient', () => {
         expect(order).toHaveProperty('is_buy_order');
         expect(typeof order.is_buy_order).toBe('boolean');
       },
+    );
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/markets/structures/123456789/',
     );
   });
 });

--- a/tests/tdd/pi/PiClient.test.ts
+++ b/tests/tdd/pi/PiClient.test.ts
@@ -59,6 +59,9 @@ describe('PiClient', () => {
       expect(colony).toHaveProperty('num_pins');
       expect(typeof colony.num_pins).toBe('number');
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/characters/123456/planets',
+    );
   });
 
   it('should return valid structure for getColonyLayout', async () => {
@@ -96,6 +99,9 @@ describe('PiClient', () => {
     expect(Array.isArray(result.pins)).toBe(true);
     expect(result).toHaveProperty('routes');
     expect(Array.isArray(result.routes)).toBe(true);
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/characters/123456/planets/654321',
+    );
   });
 
   it('should return valid structure for getCorporationCustomsOffices', async () => {
@@ -148,6 +154,9 @@ describe('PiClient', () => {
       expect(office).toHaveProperty('corp_tax_rate');
       expect(typeof office.corp_tax_rate).toBe('number');
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/corporations/123456/customs_offices',
+    );
   });
 
   it('should return valid structure for getSchematicInformation', async () => {
@@ -170,5 +179,8 @@ describe('PiClient', () => {
     expect(typeof result.cycle_time).toBe('number');
     expect(result).toHaveProperty('output_quantity');
     expect(typeof result.output_quantity).toBe('number');
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/universe/schematics/1',
+    );
   });
 });

--- a/tests/tdd/route/RouteClient.test.ts
+++ b/tests/tdd/route/RouteClient.test.ts
@@ -1,7 +1,6 @@
 import { RouteClient } from '../../../src/clients/RouteClient';
 import { ApiClient } from '../../../src/core/ApiClient';
 import { RateLimiter } from '../../../src/core/rateLimiter/RateLimiter';
-import { resetETagCache } from '../../../src/core/ApiRequestHandler';
 import fetchMock from 'jest-fetch-mock';
 
 fetchMock.enableMocks();
@@ -11,8 +10,7 @@ describe('RouteClient', () => {
 
   beforeEach(() => {
     fetchMock.resetMocks();
-    resetETagCache();
-    const rateLimiter = RateLimiter.getInstance();
+    const rateLimiter = new RateLimiter();
     rateLimiter.reset();
     rateLimiter.setTestMode(true);
     const apiClient = new ApiClient(
@@ -20,6 +18,7 @@ describe('RouteClient', () => {
       'https://esi.evetech.net',
       undefined,
     );
+    apiClient.setRateLimiter(rateLimiter);
     client = new RouteClient(apiClient);
   });
 

--- a/tests/tdd/search/searchClient.test.ts
+++ b/tests/tdd/search/searchClient.test.ts
@@ -1,5 +1,6 @@
 import { ApiClient } from '../../../src/core/ApiClient';
 import { SearchClient } from '../../../src/clients/SearchClient';
+import { RateLimiter } from '../../../src/core/rateLimiter/RateLimiter';
 import fetchMock from 'jest-fetch-mock';
 
 fetchMock.enableMocks();
@@ -14,6 +15,9 @@ describe('SearchClient', () => {
       'https://esi.evetech.net/latest',
       'token',
     );
+    const rateLimiter = new RateLimiter();
+    rateLimiter.setTestMode(true);
+    client.setRateLimiter(rateLimiter);
     searchClient = new SearchClient(client);
     fetchMock.resetMocks();
   });
@@ -46,5 +50,8 @@ describe('SearchClient', () => {
     expect(result).toHaveProperty('search_results');
     expect(result.search_results).toHaveProperty('character');
     expect(result.search_results.character).toContain(12345678);
+    expect(fetchMock.mock.calls[0][0]).toContain(
+      'https://esi.evetech.net/latest/characters/1689391488/search/',
+    );
   });
 });

--- a/tests/tdd/skills/SkillsClient.test.ts
+++ b/tests/tdd/skills/SkillsClient.test.ts
@@ -45,6 +45,9 @@ describe('SkillsClient', () => {
     expect(typeof result.willpower).toBe('number');
     expect(result).toHaveProperty('charisma');
     expect(typeof result.charisma).toBe('number');
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/characters/123456/attributes',
+    );
   });
 
   it('should return character skills', async () => {
@@ -84,6 +87,9 @@ describe('SkillsClient', () => {
       expect(skill).toHaveProperty('active_skill_level');
       expect(typeof skill.active_skill_level).toBe('number');
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/characters/123456/skills',
+    );
   });
 
   it('should return character skill queue', async () => {
@@ -128,5 +134,8 @@ describe('SkillsClient', () => {
       expect(skill).toHaveProperty('finish_time');
       expect(typeof skill.finish_time).toBe('string');
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/characters/123456/skillqueue',
+    );
   });
 });

--- a/tests/tdd/sovereignty/SovereigntyClient.test.ts
+++ b/tests/tdd/sovereignty/SovereigntyClient.test.ts
@@ -1,5 +1,6 @@
 import { ApiClient } from '../../../src/core/ApiClient';
 import { SovereigntyClient } from '../../../src/clients/SovereigntyClient';
+import { RateLimiter } from '../../../src/core/rateLimiter/RateLimiter';
 import fetchMock from 'jest-fetch-mock';
 
 fetchMock.enableMocks();
@@ -11,6 +12,9 @@ describe('SovereigntyClient', () => {
   beforeEach(() => {
     fetchMock.resetMocks();
     client = new ApiClient('dummy-client-id', 'https://esi.evetech.net');
+    const rateLimiter = new RateLimiter();
+    rateLimiter.setTestMode(true);
+    client.setRateLimiter(rateLimiter);
     sovereigntyClient = new SovereigntyClient(client);
   });
 
@@ -38,6 +42,9 @@ describe('SovereigntyClient', () => {
       expect(campaign).toHaveProperty('campaign_id');
       expect(typeof campaign.campaign_id).toBe('number');
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/sovereignty/campaigns',
+    );
   });
 
   it('should get sovereignty map', async () => {
@@ -58,6 +65,9 @@ describe('SovereigntyClient', () => {
       expect(map).toHaveProperty('system_id');
       expect(typeof map.system_id).toBe('number');
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/sovereignty/map',
+    );
   });
 
   it('should get sovereignty structures', async () => {
@@ -84,5 +94,8 @@ describe('SovereigntyClient', () => {
       expect(structure).toHaveProperty('structure_id');
       expect(typeof structure.structure_id).toBe('number');
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/sovereignty/structures',
+    );
   });
 });

--- a/tests/tdd/status/StatusClient.test.ts
+++ b/tests/tdd/status/StatusClient.test.ts
@@ -36,5 +36,8 @@ describe('StatusClient', () => {
     expect(result.players).toBe(12345);
     expect(result.start_time).toBe('2024-07-01T18:57:11Z');
     expect(result.server_version).toBe('1.2.3');
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/status',
+    );
   });
 });

--- a/tests/tdd/ui/UiClient.test.ts
+++ b/tests/tdd/ui/UiClient.test.ts
@@ -31,6 +31,9 @@ describe('UiClient', () => {
     const result = await getBody(() => uiClient.setAutopilotWaypoint(body));
 
     expect(result).toBeUndefined();
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/ui/autopilot/waypoint',
+    );
   });
 
   it('should open contract window', async () => {
@@ -42,6 +45,9 @@ describe('UiClient', () => {
     const result = await getBody(() => uiClient.openContractWindow(body));
 
     expect(result).toBeUndefined();
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/ui/openwindow/contract',
+    );
   });
 
   it('should open information window', async () => {
@@ -53,6 +59,9 @@ describe('UiClient', () => {
     const result = await getBody(() => uiClient.openInformationWindow(body));
 
     expect(result).toBeUndefined();
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/ui/openwindow/information',
+    );
   });
 
   it('should open market details window', async () => {
@@ -64,6 +73,9 @@ describe('UiClient', () => {
     const result = await getBody(() => uiClient.openMarketDetailsWindow(body));
 
     expect(result).toBeUndefined();
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/ui/openwindow/marketdetails',
+    );
   });
 
   it('should open new mail window', async () => {
@@ -77,5 +89,8 @@ describe('UiClient', () => {
     const result = await getBody(() => uiClient.openNewMailWindow(body));
 
     expect(result).toBeUndefined();
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/ui/openwindow/newmail',
+    );
   });
 });

--- a/tests/tdd/universe/UniverseClient.test.ts
+++ b/tests/tdd/universe/UniverseClient.test.ts
@@ -44,6 +44,9 @@ describe('UniverseClient', () => {
       expect(ancestry).toHaveProperty('bloodline_id');
       expect(typeof ancestry.bloodline_id).toBe('number');
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/universe/ancestries',
+    );
   });
 
   it('should return valid asteroid belt information', async () => {
@@ -63,6 +66,9 @@ describe('UniverseClient', () => {
     expect(typeof result.name).toBe('string');
     expect(result).toHaveProperty('system_id');
     expect(typeof result.system_id).toBe('number');
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/universe/asteroid_belts/1',
+    );
   });
 
   it('should return valid bloodlines', async () => {
@@ -88,6 +94,9 @@ describe('UniverseClient', () => {
       expect(bloodline).toHaveProperty('description');
       expect(typeof bloodline.description).toBe('string');
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/universe/bloodlines',
+    );
   });
 
   it('should return valid constellation information by ID', async () => {
@@ -113,6 +122,9 @@ describe('UniverseClient', () => {
     result.systems.forEach((system: any) => {
       expect(typeof system).toBe('number');
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/universe/constellations/1',
+    );
   });
 
   it('should return valid constellations', async () => {
@@ -143,6 +155,9 @@ describe('UniverseClient', () => {
         expect(typeof system).toBe('number');
       });
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/universe/constellations',
+    );
   });
 
   // Continue writing tests for other UniverseClient methods in a similar manner
@@ -169,6 +184,9 @@ describe('UniverseClient', () => {
       expect(faction).toHaveProperty('description');
       expect(typeof faction.description).toBe('string');
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/universe/factions',
+    );
   });
 
   it('should return valid graphics', async () => {
@@ -193,6 +211,9 @@ describe('UniverseClient', () => {
       expect(graphic).toHaveProperty('description');
       expect(typeof graphic.description).toBe('string');
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/universe/graphics',
+    );
   });
 
   it('should return valid graphic information by ID', async () => {
@@ -212,6 +233,9 @@ describe('UniverseClient', () => {
     expect(typeof result.url).toBe('string');
     expect(result).toHaveProperty('description');
     expect(typeof result.description).toBe('string');
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/universe/graphics/1',
+    );
   });
 
   it('should return valid schematic information', async () => {
@@ -250,6 +274,9 @@ describe('UniverseClient', () => {
     expect(Array.isArray(result.materials)).toBe(true);
     expect(result).toHaveProperty('products');
     expect(Array.isArray(result.products)).toBe(true);
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/universe/schematics/1',
+    );
   });
 
   it('should return valid regions list', async () => {
@@ -264,5 +291,8 @@ describe('UniverseClient', () => {
       expect(typeof regionId).toBe('number');
       expect(regionId).toBeGreaterThan(0);
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/universe/regions',
+    );
   });
 });

--- a/tests/tdd/wallet/WalletClient.test.ts
+++ b/tests/tdd/wallet/WalletClient.test.ts
@@ -32,6 +32,9 @@ describe('WalletClient', () => {
 
     expect(result).toHaveProperty('balance');
     expect(typeof result.balance).toBe('number');
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/characters/123456789/wallet',
+    );
   });
 
   it('should return character wallet journal', async () => {
@@ -75,6 +78,9 @@ describe('WalletClient', () => {
         expect(entry).toHaveProperty('first_party_id');
         expect(entry).toHaveProperty('second_party_id');
       },
+    );
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/characters/123456789/wallet/journal',
     );
   });
 
@@ -126,6 +132,9 @@ describe('WalletClient', () => {
         expect(transaction).toHaveProperty('journal_ref_id');
       },
     );
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/characters/123456789/wallet/transactions',
+    );
   });
 
   it('should return corporation wallet balance', async () => {
@@ -149,6 +158,9 @@ describe('WalletClient', () => {
       expect(wallet).toHaveProperty('balance');
       expect(typeof wallet.balance).toBe('number');
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/corporations/123456789/wallets',
+    );
   });
 
   it('should return corporation wallet journal', async () => {
@@ -192,6 +204,9 @@ describe('WalletClient', () => {
         expect(entry).toHaveProperty('first_party_id');
         expect(entry).toHaveProperty('second_party_id');
       },
+    );
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/corporations/123456789/wallets/1/journal',
     );
   });
 
@@ -242,6 +257,9 @@ describe('WalletClient', () => {
         expect(transaction).toHaveProperty('is_personal');
         expect(transaction).toHaveProperty('journal_ref_id');
       },
+    );
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/corporations/123456789/wallets/1/transactions',
     );
   });
 });

--- a/tests/tdd/wars/WarsClient.test.ts
+++ b/tests/tdd/wars/WarsClient.test.ts
@@ -45,6 +45,9 @@ describe('WarsClient', () => {
       expect(war).toHaveProperty('started');
       expect(typeof war.started).toBe('string');
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/wars',
+    );
   });
 
   it('should return valid war by ID', async () => {
@@ -68,6 +71,9 @@ describe('WarsClient', () => {
     expect(typeof result.declared).toBe('string');
     expect(result).toHaveProperty('started');
     expect(typeof result.started).toBe('string');
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/wars/1',
+    );
   });
 
   it('should return valid war killmails', async () => {
@@ -89,5 +95,8 @@ describe('WarsClient', () => {
       expect(killmail).toHaveProperty('killmail_id');
       expect(typeof killmail.killmail_id).toBe('number');
     });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://esi.evetech.net/latest/wars/1/killmails',
+    );
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
     "typeRoots": ["./node_modules/@types", "./types"],
     "types": ["jest", "node"],
     "outDir": "./dist"


### PR DESCRIPTION
## Summary

- **BREAKING**: Remove `RateLimiter.getInstance()` singleton and global `initializeETagCache()`/`getETagCache()`/`initializeCircuitBreaker()`/`getCircuitBreaker()` functions — all infrastructure is now instance-based per `EsiClient`
- **Security**: Add SSRF protection (`validateBaseUrl()` host allowlist), `encodeURIComponent()` on path params, URL sanitization in `EsiError` (redacts `token`/`access_token`/`api_key`)
- **Testing**: Add 180 URL assertions across 35 test files, 1800+ endpoint contract tests across all 32 definition files, rename `ContractsClient.ts` → `.test.ts` so Jest discovers it
- **Packaging**: Emit `.d.ts` declaration files, add `exports`/`engines`/`publishConfig` to `package.json`, bump version to 4.0.0
- **Release**: Add `CHANGELOG.md` (Keep a Changelog format), changelog validation step in release pipeline, remove CNAME placeholder

## Breaking Changes

| Before (v3.x) | After (v4.0) |
|---|---|
| `RateLimiter.getInstance()` | `new RateLimiter()` |
| `initializeETagCache()` / `getETagCache()` | `new ETagCacheManager()` via `apiClient.setCache()` |
| `initializeCircuitBreaker()` / `getCircuitBreaker()` | `new CircuitBreaker()` via `apiClient.setCircuitBreaker()` |
| Global shared state across clients | Per-instance isolation |

## Test plan

- [x] All 86 test suites pass (2,539 tests)
- [x] `npm run build` succeeds, `.d.ts` files in `dist/`
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` — 0 errors
- [x] `npm run format:check` — clean
- [ ] Verify changelog validation step runs in CI
- [ ] Verify `npm pack --dry-run` includes `.d.ts` files
- [ ] Smoke test: import `@lgriffin/esi.ts` in a consumer project and verify types resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)