### PR TITLE
Add request deduplication, diagnostics API, async pagination, rate limiter config

### DIFF
--- a/src/EsiClient.ts
+++ b/src/EsiClient.ts
@@ -45,7 +45,9 @@ import {
   CircuitBreaker,
   CircuitBreakerConfig,
 } from './core/circuitBreaker/CircuitBreaker';
-import { RateLimiter } from './core/rateLimiter/RateLimiter';
+import { RateLimiter, RateLimiterConfig } from './core/rateLimiter/RateLimiter';
+import { RequestDeduplicator } from './core/RequestDeduplicator';
+import { EsiDiagnostics } from './core/EsiDiagnostics';
 import logger from './core/logger/logger';
 
 export type EsiDatasource = 'tranquility' | 'singularity';
@@ -63,6 +65,8 @@ export interface EsiClientConfig {
   enableCircuitBreaker?: boolean;
   circuitBreakerConfig?: CircuitBreakerConfig;
   unsafeAllowCustomHost?: boolean;
+  enableRequestDeduplication?: boolean;
+  rateLimiterConfig?: RateLimiterConfig;
   requestInterceptors?: RequestInterceptor[];
   responseInterceptors?: ResponseInterceptor[];
 }
@@ -71,6 +75,8 @@ export class EsiClient {
   private apiClient: ApiClient;
   private clients: Map<string, unknown> = new Map();
   private etagCacheEnabled: boolean;
+  private _diagnostics: EsiDiagnostics | null = null;
+  private deduplicator: RequestDeduplicator | null = null;
 
   constructor(config?: EsiClientConfig) {
     const token = config?.accessToken || process.env.ESI_ACCESS_TOKEN;
@@ -99,7 +105,12 @@ export class EsiClient {
       this.apiClient.setTokenProvider(config.onTokenRefresh);
     }
 
-    this.apiClient.setRateLimiter(new RateLimiter());
+    this.apiClient.setRateLimiter(new RateLimiter(config?.rateLimiterConfig));
+
+    if (config?.enableRequestDeduplication !== false) {
+      this.deduplicator = new RequestDeduplicator();
+      this.apiClient.setDeduplicator(this.deduplicator);
+    }
 
     this.etagCacheEnabled = config?.enableETagCache !== false;
     if (this.etagCacheEnabled) {
@@ -251,57 +262,44 @@ export class EsiClient {
     );
   }
 
-  getCacheStats(): {
-    totalEntries: number;
-    maxEntries: number;
-    hits: number;
-    misses: number;
-    hitRate: number;
-    oldestEntry: number | null;
-    newestEntry: number | null;
-  } | null {
-    if (!this.etagCacheEnabled) return null;
-    const cache = this.apiClient.getCache();
-    return cache ? (cache as ETagCacheManager).getStats() : null;
+  get diagnostics(): EsiDiagnostics {
+    if (!this._diagnostics) {
+      this._diagnostics = new EsiDiagnostics(
+        this.apiClient,
+        this.etagCacheEnabled,
+        this.deduplicator,
+      );
+    }
+    return this._diagnostics;
+  }
+
+  getCacheStats() {
+    return this.diagnostics.getCacheStats();
   }
 
   clearCache(): void {
-    const cache = this.apiClient.getCache();
-    if (cache) {
-      (cache as ETagCacheManager).clear();
-    }
+    this.diagnostics.clearCache();
   }
 
   updateCacheConfig(newConfig: Partial<ETagCacheConfig>): void {
-    const cache = this.apiClient.getCache();
-    if (cache) {
-      (cache as ETagCacheManager).updateConfig(newConfig);
-    }
+    this.diagnostics.updateCacheConfig(newConfig);
   }
 
-  getCircuitBreakerStats(): {
-    totalCircuits: number;
-    openCircuits: number;
-    circuits: Record<
-      string,
-      { state: 'closed' | 'open' | 'half-open'; failures: number }
-    >;
-  } | null {
-    const cb = this.apiClient.getCircuitBreaker();
-    return cb ? cb.getStats() : null;
+  getCircuitBreakerStats() {
+    return this.diagnostics.getCircuitBreakerStats();
   }
 
   resetCircuitBreaker(endpoint?: string): void {
-    const cb = this.apiClient.getCircuitBreaker();
-    if (cb) {
-      cb.reset(endpoint);
-    }
+    this.diagnostics.resetCircuitBreaker(endpoint);
   }
 
   shutdown(): void {
     const cache = this.apiClient.getCache();
     if (cache) {
       (cache as ETagCacheManager).shutdown();
+    }
+    if (this.deduplicator) {
+      this.deduplicator.clear();
     }
     this.clients.clear();
     logger.info('EsiClient shutdown completed');

--- a/src/core/ApiClient.ts
+++ b/src/core/ApiClient.ts
@@ -6,6 +6,7 @@ import {
 import { ICache } from './cache/ICache';
 import { IRateLimiter } from './rateLimiter/IRateLimiter';
 import { CircuitBreaker } from './circuitBreaker/CircuitBreaker';
+import { RequestDeduplicator } from './RequestDeduplicator';
 
 export type EsiDatasource = 'tranquility' | 'singularity';
 
@@ -20,6 +21,7 @@ export class ApiClient {
   private rateLimiter: IRateLimiter | null = null;
   private circuitBreaker: CircuitBreaker | null = null;
   private timeout: number = 30_000;
+  private deduplicator: RequestDeduplicator | null = null;
 
   constructor(
     private clientId: string,
@@ -59,6 +61,14 @@ export class ApiClient {
 
   setCircuitBreaker(cb: CircuitBreaker | null): void {
     this.circuitBreaker = cb;
+  }
+
+  getDeduplicator(): RequestDeduplicator | null {
+    return this.deduplicator;
+  }
+
+  setDeduplicator(dedup: RequestDeduplicator | null): void {
+    this.deduplicator = dedup;
   }
 
   getMiddleware(): MiddlewareManager {

--- a/src/core/ApiRequestHandler.ts
+++ b/src/core/ApiRequestHandler.ts
@@ -632,15 +632,16 @@ export const handleRequest = async (
   requiresAuth: boolean = false,
   useETag: boolean = true,
 ): Promise<EsiHandlerResponse> => {
+  const doExecute = () =>
+    executeRequest(client, endpoint, method, body, requiresAuth, useETag);
+
+  const dedup = client.getDeduplicator();
+  const canDedup = dedup && method === 'GET' && !body;
+
   try {
-    return await executeRequest(
-      client,
-      endpoint,
-      method,
-      body,
-      requiresAuth,
-      useETag,
-    );
+    return canDedup
+      ? await dedup.dedupe<EsiHandlerResponse>(endpoint, doExecute)
+      : await doExecute();
   } catch (error: unknown) {
     if (
       error instanceof EsiError &&

--- a/src/core/EsiDiagnostics.ts
+++ b/src/core/EsiDiagnostics.ts
@@ -1,0 +1,68 @@
+import { ApiClient } from './ApiClient';
+import { ETagCacheManager, ETagCacheConfig } from './cache/ETagCacheManager';
+import { RequestDeduplicator } from './RequestDeduplicator';
+
+export interface CacheStats {
+  totalEntries: number;
+  maxEntries: number;
+  hits: number;
+  misses: number;
+  hitRate: number;
+  oldestEntry: number | null;
+  newestEntry: number | null;
+}
+
+export interface CircuitBreakerStats {
+  totalCircuits: number;
+  openCircuits: number;
+  circuits: Record<
+    string,
+    { state: 'closed' | 'open' | 'half-open'; failures: number }
+  >;
+}
+
+export class EsiDiagnostics {
+  constructor(
+    private apiClient: ApiClient,
+    private etagCacheEnabled: boolean,
+    private deduplicator: RequestDeduplicator | null,
+  ) {}
+
+  getCacheStats(): CacheStats | null {
+    if (!this.etagCacheEnabled) return null;
+    const cache = this.apiClient.getCache();
+    return cache ? (cache as ETagCacheManager).getStats() : null;
+  }
+
+  clearCache(): void {
+    const cache = this.apiClient.getCache();
+    if (cache) {
+      (cache as ETagCacheManager).clear();
+    }
+  }
+
+  updateCacheConfig(newConfig: Partial<ETagCacheConfig>): void {
+    const cache = this.apiClient.getCache();
+    if (cache) {
+      (cache as ETagCacheManager).updateConfig(newConfig);
+    }
+  }
+
+  getCircuitBreakerStats(): CircuitBreakerStats | null {
+    const cb = this.apiClient.getCircuitBreaker();
+    return cb ? cb.getStats() : null;
+  }
+
+  resetCircuitBreaker(endpoint?: string): void {
+    const cb = this.apiClient.getCircuitBreaker();
+    if (cb) {
+      cb.reset(endpoint);
+    }
+  }
+
+  getDeduplicatorStats(): { pendingRequests: number } | null {
+    return this.deduplicator
+      ? { pendingRequests: this.deduplicator.pending }
+      : null;
+  }
+}

--- a/src/core/RequestDeduplicator.ts
+++ b/src/core/RequestDeduplicator.ts
@@ -1,0 +1,28 @@
+import { logDebug } from './logger/loggerUtil';
+
+export class RequestDeduplicator {
+  private inflight = new Map<string, Promise<unknown>>();
+
+  async dedupe<T>(key: string, execute: () => Promise<T>): Promise<T> {
+    const existing = this.inflight.get(key);
+    if (existing) {
+      logDebug(`[Dedup] Coalescing request: ${key}`);
+      return existing as Promise<T>;
+    }
+
+    const promise = execute().finally(() => {
+      this.inflight.delete(key);
+    });
+
+    this.inflight.set(key, promise);
+    return promise;
+  }
+
+  get pending(): number {
+    return this.inflight.size;
+  }
+
+  clear(): void {
+    this.inflight.clear();
+  }
+}

--- a/src/core/pagination/AsyncPaginationIterator.ts
+++ b/src/core/pagination/AsyncPaginationIterator.ts
@@ -1,0 +1,55 @@
+import { ApiClient } from '../ApiClient';
+import { handleRequest } from '../ApiRequestHandler';
+import { logInfo } from '../logger/loggerUtil';
+
+export interface PageResult<T = unknown> {
+  data: T[];
+  page: number;
+  totalPages: number;
+}
+
+function extractArray<T>(body: unknown): T[] {
+  if (Array.isArray(body)) return body as T[];
+  if (body !== undefined && body !== null) return [body as T];
+  return [];
+}
+
+export async function* fetchPages<T = unknown>(
+  client: ApiClient,
+  endpoint: string,
+  method: string,
+  requiresAuth: boolean = false,
+  body?: unknown,
+): AsyncGenerator<PageResult<T>, void, undefined> {
+  const firstResponse = await handleRequest(
+    client,
+    endpoint,
+    method,
+    body,
+    requiresAuth,
+  );
+
+  const totalPages = parseInt(firstResponse.headers['x-pages'] || '1', 10);
+
+  yield { data: extractArray<T>(firstResponse.body), page: 1, totalPages };
+
+  for (let page = 2; page <= totalPages; page++) {
+    const sep = endpoint.includes('?') ? '&' : '?';
+    const pagedEndpoint = `${endpoint}${sep}page=${page}`;
+
+    logInfo(`Fetching page ${page}/${totalPages}: ${pagedEndpoint}`);
+
+    const response = await handleRequest(
+      client,
+      pagedEndpoint,
+      method,
+      body,
+      requiresAuth,
+    );
+
+    const pageData = extractArray<T>(response.body);
+    if (pageData.length === 0) break;
+
+    yield { data: pageData, page, totalPages };
+  }
+}

--- a/src/core/rateLimiter/RateLimiter.ts
+++ b/src/core/rateLimiter/RateLimiter.ts
@@ -52,15 +52,22 @@ function getTokenCost(statusCode: number): number {
   return 2; // default to 2xx cost
 }
 
+export interface RateLimiterConfig {
+  minDelayMs?: number;
+  decelerationThreshold?: number;
+}
+
 export class RateLimiter implements IRateLimiter {
   private rateLimitInfo: RateLimitInfo;
   private lastRequestTime: number = 0;
-  private readonly minDelayMs: number = 50;
+  private readonly minDelayMs: number;
   private isTestMode: boolean = false;
 
-  private readonly decelerationThreshold: number = 0.2;
+  private readonly decelerationThreshold: number;
 
-  constructor() {
+  constructor(config?: RateLimiterConfig) {
+    this.minDelayMs = config?.minDelayMs ?? 50;
+    this.decelerationThreshold = config?.decelerationThreshold ?? 0.2;
     this.rateLimitInfo = this.defaultInfo();
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,11 +94,31 @@ export {
 } from './core/circuitBreaker/CircuitBreaker';
 
 // Rate limiter & cache (for direct instantiation)
-export { RateLimiter, RateLimitInfo } from './core/rateLimiter/RateLimiter';
+export {
+  RateLimiter,
+  RateLimitInfo,
+  RateLimiterConfig,
+} from './core/rateLimiter/RateLimiter';
 export {
   ETagCacheManager,
   ETagCacheConfig,
 } from './core/cache/ETagCacheManager';
+
+// Request deduplication
+export { RequestDeduplicator } from './core/RequestDeduplicator';
+
+// Diagnostics
+export {
+  EsiDiagnostics,
+  CacheStats,
+  CircuitBreakerStats,
+} from './core/EsiDiagnostics';
+
+// Async pagination
+export {
+  fetchPages,
+  PageResult,
+} from './core/pagination/AsyncPaginationIterator';
 
 // Interfaces (for custom implementations / testing)
 export { ICache } from './core/cache/ICache';


### PR DESCRIPTION
## Summary

- **Request deduplication**: `RequestDeduplicator` coalesces concurrent identical GET requests into a single in-flight fetch. Enabled by default; disable with `enableRequestDeduplication: false`. Multiple callers fetching the same endpoint simultaneously share one network request.
- **Diagnostics API**: Extracted cache stats, circuit breaker stats, and dedup stats into `EsiDiagnostics` class, accessible via `client.diagnostics`. Old methods (`getCacheStats()`, `getCircuitBreakerStats()`, etc.) still work as thin proxies for backward compatibility.
- **Async pagination iterator**: `fetchPages()` returns an `AsyncGenerator<PageResult<T>>` for memory-efficient page-by-page processing of paginated ESI responses. Avoids buffering all pages in memory before returning.
- **Rate limiter configuration**: Exposed `RateLimiterConfig` (`minDelayMs`, `decelerationThreshold`) via `EsiClientConfig.rateLimiterConfig` so consumers can tune rate limiting for their use case.

## Usage examples

```typescript
// Request deduplication (automatic)
const [a, b] = await Promise.all([
  client.market.getMarketPrices(),
  client.market.getMarketPrices(), // coalesced — only 1 fetch
]);

// Diagnostics
const stats = client.diagnostics.getCacheStats();
const cbStats = client.diagnostics.getCircuitBreakerStats();
const dedupStats = client.diagnostics.getDeduplicatorStats();

// Async pagination
import { fetchPages } from '@lgriffin/esi.ts';
for await (const page of fetchPages(apiClient, 'markets/10000002/orders', 'GET')) {
  processOrders(page.data); // page-by-page, not all-at-once
}

// Rate limiter tuning
const client = new EsiClient({
  rateLimiterConfig: { minDelayMs: 100, decelerationThreshold: 0.3 },
});
```

## Test plan

- [x] `tsc --noEmit` compiles cleanly
- [x] All 2539 tests pass (`npm test`)
- [x] ESLint reports 0 errors (`npm run lint`)
- [ ] Verify concurrent identical GETs result in single fetch (dedup)
- [ ] Verify `client.diagnostics.getCacheStats()` returns same data as `client.getCacheStats()`
- [ ] Verify `fetchPages()` yields pages one at a time
- [ ] Verify `rateLimiterConfig: { minDelayMs: 200 }` changes delay behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)