### PR TITLE
fix: correct POST body format for /universe/ids and /universe/names

### DIFF
--- a/src/clients/UniverseClient.ts
+++ b/src/clients/UniverseClient.ts
@@ -297,11 +297,11 @@ export class UniverseClient extends BaseEsiClient<typeof universeEndpoints> {
   /**
    * Resolves a list of names to their corresponding IDs via a bulk POST operation.
    *
-   * @param ids - An array of names to resolve to IDs
+   * @param names - An array of names to resolve to IDs
    * @returns The resolved IDs grouped by entity category
    */
-  postBulkNamesToIds(ids: number[]): Promise<BulkIdResult> {
-    return this.api.postBulkNamesToIds(ids) as Promise<BulkIdResult>;
+  postBulkNamesToIds(names: string[]): Promise<BulkIdResult> {
+    return this.api.postBulkNamesToIds(names) as Promise<BulkIdResult>;
   }
 
   /**

--- a/src/core/endpoints/universeEndpoints.ts
+++ b/src/core/endpoints/universeEndpoints.ts
@@ -70,7 +70,7 @@ export const universeEndpoints = {
     path: 'universe/ids',
     method: 'POST',
     requiresAuth: false,
-    bodyBuilder: (ids: number[]) => ({ ids }),
+    bodyBuilder: (names: string[]) => names,
   },
   getMoonById: {
     path: 'universe/moons/{moonId}',
@@ -82,7 +82,7 @@ export const universeEndpoints = {
     path: 'universe/names',
     method: 'POST',
     requiresAuth: false,
-    bodyBuilder: (ids: number[]) => ({ ids }),
+    bodyBuilder: (ids: number[]) => ids,
   },
   getPlanetById: {
     path: 'universe/planets/{planetId}',

--- a/tests/tdd/universe/UniverseClient.test.ts
+++ b/tests/tdd/universe/UniverseClient.test.ts
@@ -543,12 +543,14 @@ describe('UniverseClient', () => {
       JSON.stringify({ characters: [{ id: 123, name: 'Pilot' }] }),
     );
     const result = await getBody(() =>
-      universeClient.postBulkNamesToIds([123]),
+      universeClient.postBulkNamesToIds(['Pilot']),
     );
     expect(result).toHaveProperty('characters');
     expect(fetchMock.mock.calls[0][0]).toBe(
       'https://esi.evetech.net/latest/universe/ids',
     );
+    const sentBody = fetchMock.mock.calls[0][1]?.body;
+    expect(sentBody).toBe(JSON.stringify(['Pilot']));
   });
 
   it('should resolve IDs to names via postNamesAndCategories', async () => {
@@ -563,5 +565,7 @@ describe('UniverseClient', () => {
     expect(fetchMock.mock.calls[0][0]).toBe(
       'https://esi.evetech.net/latest/universe/names',
     );
+    const sentBody = fetchMock.mock.calls[0][1]?.body;
+    expect(sentBody).toBe(JSON.stringify([123]));
   });
 });


### PR DESCRIPTION
## Summary
- Fix `postBulkNamesToIds` and `postNamesAndCategories` bodyBuilders to return plain JSON arrays instead of wrapping in `{ids: [...]}`
- Fix `postBulkNamesToIds` parameter type from `number[]` to `string[]` (ESI `/universe/ids` accepts entity names, not numeric IDs)
- Add test assertions verifying the correct body format is sent

Closes #40

## Details

The ESI API expects a plain JSON array for both endpoints:
- `POST /universe/ids` — `["Pilot Name", "Corp Name"]`
- `POST /universe/names` — `[123, 456, 789]`

The previous bodyBuilders wrapped the array: `(ids) => ({ ids })`, producing `{"ids":[...]}` which the ESI API rejects.

## Test plan
- [x] All 102 test suites pass (2760 tests)
- [x] New assertions verify `fetchMock` receives `JSON.stringify([...])` not `JSON.stringify({ids: [...]})`
- [x] TypeScript build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)