### PR TITLE
refactor: remove unused getHeaders test helper

### DIFF
--- a/guides/TESTING.md
+++ b/guides/TESTING.md
@@ -283,7 +283,7 @@ await expect(client.getAllianceById(99999999)).rejects.toThrow(
 
 ### Test Helpers
 
-**`src/core/util/testHelpers.ts`** — provides `getBody()` and `getHeaders()` wrappers used in TDD tests:
+**`src/core/util/testHelpers.ts`** — provides `getBody()` wrapper used in TDD tests:
 
 ```typescript
 import { getBody } from '../../../src/core/util/testHelpers';

--- a/src/config/jest/jest.setup.ts
+++ b/src/config/jest/jest.setup.ts
@@ -2,7 +2,7 @@ import { ApiClientBuilder } from '../../core/ApiClientBuilder';
 import { RateLimiter } from '../../core/rateLimiter/RateLimiter';
 import { getConfig } from '../../config/configManager';
 import fetchMock from 'jest-fetch-mock';
-import { getBody, getHeaders } from '../../../src/core/util/testHelpers';
+import { getBody } from '../../../src/core/util/testHelpers';
 import '../../../types/global.d.ts';
 
 fetchMock.enableMocks();
@@ -27,4 +27,3 @@ beforeEach(() => {
 });
 
 global.getBody = getBody;
-global.getHeaders = getHeaders;

--- a/src/core/util/testHelpers.ts
+++ b/src/core/util/testHelpers.ts
@@ -1,14 +1,5 @@
-import fetchMock from 'jest-fetch-mock';
-
-/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment */
-export const getHeaders = async (
-  apiCall: () => Promise<any>,
-): Promise<Record<string, string>> => {
-  const response = await apiCall();
-  return response.headers;
-};
-
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-return */
 export const getBody = async (apiCall: () => Promise<any>): Promise<any> => {
   return apiCall();
 };
-/* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment */
+/* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-return */

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,17 +1,15 @@
-import { getBody, getHeaders } from '../src/core/util/testHelpers';
+import { getBody } from '../src/core/util/testHelpers';
 
 declare global {
   // Extending the NodeJS Global interface
   namespace NodeJS {
     interface Global {
       getBody: typeof getBody;
-      getHeaders: typeof getHeaders;
     }
   }
 
   // Adding to globalThis (in case global is used outside NodeJS context)
   var getBody: typeof getBody;
-  var getHeaders: typeof getHeaders;
 }
 
 export {};


### PR DESCRIPTION
## Summary
- Remove dead `getHeaders` function from `testHelpers.ts` — confirmed unused across the entire codebase
- Clean up related global type declarations and jest setup registration
- Update TESTING.md guide to reflect the change

Closes #58

## Test plan
- [x] All 102 test suites pass (2760 tests)
- [x] TypeScript build clean
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)