### PR TITLE
fix: remove sunset sovereignty endpoints

### DIFF
--- a/src/clients/SovereigntyClient.ts
+++ b/src/clients/SovereigntyClient.ts
@@ -1,12 +1,7 @@
 import { ApiClient } from '../core/ApiClient';
 import { BaseEsiClient } from './BaseEsiClient';
 import { sovereigntyEndpoints } from '../core/endpoints/sovereigntyEndpoints';
-import {
-  SovereigntyCampaign,
-  SovereigntyMap,
-  SovereigntyStructure,
-  SovereigntySystem,
-} from '../types/api-responses';
+import { SovereigntyCampaign, SovereigntySystem } from '../types/api-responses';
 
 export class SovereigntyClient extends BaseEsiClient<
   typeof sovereigntyEndpoints
@@ -22,28 +17,6 @@ export class SovereigntyClient extends BaseEsiClient<
    */
   getSovereigntyCampaigns(): Promise<SovereigntyCampaign[]> {
     return this.api.getSovereigntyCampaigns() as Promise<SovereigntyCampaign[]>;
-  }
-
-  /**
-   * Retrieves the sovereignty ownership map showing which alliance holds each solar system.
-   *
-   * @deprecated Use {@link getSovereigntySystems} instead — the combined route provides occupancy, structures, and ADM indices in a single response.
-   * @returns A list of solar systems and their sovereignty holders
-   */
-  getSovereigntyMap(): Promise<SovereigntyMap[]> {
-    return this.api.getSovereigntyMap() as Promise<SovereigntyMap[]>;
-  }
-
-  /**
-   * Retrieves all sovereignty structures (TCUs, IHubs) and their vulnerability windows.
-   *
-   * @deprecated Use {@link getSovereigntySystems} instead — the combined route provides occupancy, structures, and ADM indices in a single response.
-   * @returns A list of sovereignty structures with their reinforcement and vulnerability details
-   */
-  getSovereigntyStructures(): Promise<SovereigntyStructure[]> {
-    return this.api.getSovereigntyStructures() as Promise<
-      SovereigntyStructure[]
-    >;
   }
 
   /**

--- a/src/core/endpoints/sovereigntyEndpoints.ts
+++ b/src/core/endpoints/sovereigntyEndpoints.ts
@@ -6,26 +6,6 @@ export const sovereigntyEndpoints = {
     method: 'GET',
     requiresAuth: false,
   },
-  getSovereigntyMap: {
-    path: 'sovereignty/map',
-    method: 'GET',
-    requiresAuth: false,
-    deprecated: {
-      message: 'Use getSovereigntySystems instead',
-      replacedBy: 'getSovereigntySystems',
-      sunsetDate: '2026-05-19',
-    },
-  },
-  getSovereigntyStructures: {
-    path: 'sovereignty/structures',
-    method: 'GET',
-    requiresAuth: false,
-    deprecated: {
-      message: 'Use getSovereigntySystems instead',
-      replacedBy: 'getSovereigntySystems',
-      sunsetDate: '2026-05-19',
-    },
-  },
   getSovereigntySystems: {
     path: 'sovereignty/systems',
     method: 'GET',

--- a/src/types/sovereignty.ts
+++ b/src/types/sovereignty.ts
@@ -15,23 +15,6 @@ export interface SovereigntyCampaign {
   participants?: { alliance_id: number; score: number }[];
 }
 
-export interface SovereigntyMap {
-  system_id: number;
-  alliance_id?: number;
-  corporation_id?: number;
-  faction_id?: number;
-}
-
-export interface SovereigntyStructure {
-  alliance_id: number;
-  solar_system_id: number;
-  structure_id: number;
-  structure_type_id: number;
-  vulnerability_occupancy_level?: number;
-  vulnerable_start_time?: string;
-  vulnerable_end_time?: string;
-}
-
 export interface SovereigntySystemStructure {
   structure_id: number;
   structure_type_id: number;

--- a/tests/bdd-scenarios/core/bdd-sovereignty.test.ts
+++ b/tests/bdd-scenarios/core/bdd-sovereignty.test.ts
@@ -20,82 +20,6 @@ describe('BDD: Sovereignty Management', () => {
     });
   });
 
-  describe('Feature: Retrieve Sovereignty Map', () => {
-    describe('Scenario: Get the sovereignty ownership map', () => {
-      it('Given the sovereignty endpoint is available, When I request the sovereignty map, Then I should receive system ownership data', async () => {
-        // Given
-        const expectedMap = [
-          {
-            system_id: 30000142,
-            alliance_id: 99005338,
-            corporation_id: 1344654522,
-            faction_id: undefined,
-          },
-          {
-            system_id: 30002187,
-            alliance_id: undefined,
-            corporation_id: undefined,
-            faction_id: 500001,
-          },
-          {
-            system_id: 30004759,
-            alliance_id: 99000001,
-            corporation_id: 987654321,
-            faction_id: undefined,
-          },
-        ];
-
-        jest
-          .spyOn(client.sovereignty, 'getSovereigntyMap')
-          .mockResolvedValue(expectedMap as any);
-
-        // When
-        const result = await client.sovereignty.getSovereigntyMap();
-
-        // Then
-        expect(result).toBeDefined();
-        expect(result).toHaveLength(3);
-        expect(result[0].system_id).toBe(30000142);
-        expect(result[0].alliance_id).toBe(99005338);
-        expect(result[1].faction_id).toBe(500001);
-      });
-    });
-
-    describe('Scenario: Sovereignty map contains NPC-held systems', () => {
-      it('Given systems held by NPC factions, When I request the map, Then faction IDs should be present', async () => {
-        // Given
-        const npcSystems = [
-          {
-            system_id: 30002187,
-            alliance_id: undefined,
-            corporation_id: undefined,
-            faction_id: 500001,
-          },
-          {
-            system_id: 30002188,
-            alliance_id: undefined,
-            corporation_id: undefined,
-            faction_id: 500002,
-          },
-        ];
-
-        jest
-          .spyOn(client.sovereignty, 'getSovereigntyMap')
-          .mockResolvedValue(npcSystems as any);
-
-        // When
-        const result = await client.sovereignty.getSovereigntyMap();
-
-        // Then
-        expect(result).toHaveLength(2);
-        result.forEach((system: any) => {
-          expect(system.faction_id).toBeDefined();
-          expect(system.alliance_id).toBeUndefined();
-        });
-      });
-    });
-  });
-
   describe('Feature: Retrieve Sovereignty Campaigns', () => {
     describe('Scenario: Get active sovereignty campaigns', () => {
       it('Given active sovereignty contests, When I request campaigns, Then I should receive campaign details with scores', async () => {
@@ -160,87 +84,6 @@ describe('BDD: Sovereignty Management', () => {
     });
   });
 
-  describe('Feature: Retrieve Sovereignty Structures', () => {
-    describe('Scenario: Get sovereignty structures', () => {
-      it('Given sovereignty structures exist, When I request structures, Then I should receive structure details with vulnerability data', async () => {
-        // Given
-        const expectedStructures = [
-          {
-            alliance_id: 99005338,
-            solar_system_id: 30004759,
-            structure_id: 8001,
-            structure_type_id: 32226,
-            vulnerability_occupancy_level: 4.5,
-          },
-          {
-            alliance_id: 99005338,
-            solar_system_id: 30004760,
-            structure_id: 8002,
-            structure_type_id: 32458,
-            vulnerability_occupancy_level: 3.0,
-          },
-          {
-            alliance_id: 99000001,
-            solar_system_id: 30004761,
-            structure_id: 8003,
-            structure_type_id: 32226,
-            vulnerability_occupancy_level: 6.0,
-          },
-        ];
-
-        jest
-          .spyOn(client.sovereignty, 'getSovereigntyStructures')
-          .mockResolvedValue(expectedStructures as any);
-
-        // When
-        const result = await client.sovereignty.getSovereigntyStructures();
-
-        // Then
-        expect(result).toBeDefined();
-        expect(result).toHaveLength(3);
-        expect(result[0].structure_type_id).toBe(32226);
-        expect(result[0].vulnerability_occupancy_level).toBe(4.5);
-        expect(result[2].alliance_id).toBe(99000001);
-      });
-    });
-
-    describe('Scenario: Filter structures by alliance', () => {
-      it('Given multiple alliance structures, When I retrieve all structures, Then I can filter by alliance_id', async () => {
-        // Given
-        const allStructures = [
-          {
-            alliance_id: 99005338,
-            solar_system_id: 30004759,
-            structure_id: 8001,
-            structure_type_id: 32226,
-            vulnerability_occupancy_level: 4.5,
-          },
-          {
-            alliance_id: 99000001,
-            solar_system_id: 30004761,
-            structure_id: 8003,
-            structure_type_id: 32226,
-            vulnerability_occupancy_level: 6.0,
-          },
-        ];
-
-        jest
-          .spyOn(client.sovereignty, 'getSovereigntyStructures')
-          .mockResolvedValue(allStructures as any);
-
-        // When
-        const result = await client.sovereignty.getSovereigntyStructures();
-        const goonStructures = result.filter(
-          (s: any) => s.alliance_id === 99005338,
-        );
-
-        // Then
-        expect(goonStructures).toHaveLength(1);
-        expect(goonStructures[0].structure_id).toBe(8001);
-      });
-    });
-  });
-
   describe('Feature: Sovereignty Error Handling', () => {
     describe('Scenario: Service unavailable error', () => {
       it('Given the ESI service is down, When I request sovereignty data, Then I should receive a 503 error', async () => {
@@ -248,13 +91,13 @@ describe('BDD: Sovereignty Management', () => {
         const error = TestDataFactory.createError(503);
 
         jest
-          .spyOn(client.sovereignty, 'getSovereigntyMap')
+          .spyOn(client.sovereignty, 'getSovereigntyCampaigns')
           .mockRejectedValue(error);
 
         // When & Then
-        await expect(client.sovereignty.getSovereigntyMap()).rejects.toThrow(
-          EsiError,
-        );
+        await expect(
+          client.sovereignty.getSovereigntyCampaigns(),
+        ).rejects.toThrow(EsiError);
       });
     });
   });
@@ -350,17 +193,9 @@ describe('BDD: Sovereignty Management', () => {
   });
 
   describe('Feature: Sovereignty Workflow', () => {
-    describe('Scenario: Concurrent fetch of map, campaigns, and structures', () => {
-      it('Given all sovereignty endpoints are available, When I fetch all data concurrently, Then all three should return valid data', async () => {
+    describe('Scenario: Concurrent fetch of campaigns and systems', () => {
+      it('Given all sovereignty endpoints are available, When I fetch all data concurrently, Then both should return valid data', async () => {
         // Given
-        const mapData = [
-          {
-            system_id: 30004759,
-            alliance_id: 99005338,
-            corporation_id: 1344654522,
-            faction_id: undefined,
-          },
-        ];
         const campaignData = [
           {
             campaign_id: 1001,
@@ -374,45 +209,45 @@ describe('BDD: Sovereignty Management', () => {
             defender_id: 99005338,
           },
         ];
-        const structureData = [
+        const systemsData = [
           {
+            system_id: 30004759,
             alliance_id: 99005338,
-            solar_system_id: 30004759,
-            structure_id: 8001,
-            structure_type_id: 32226,
-            vulnerability_occupancy_level: 4.5,
+            corporation_id: 1344654522,
+            military_index: 5.0,
+            industry_index: 3.2,
+            strategic_index: 1.0,
+            structures: [
+              {
+                structure_id: 8001,
+                structure_type_id: 32226,
+                vulnerability_occupancy_level: 4.5,
+              },
+            ],
           },
         ];
 
         jest
-          .spyOn(client.sovereignty, 'getSovereigntyMap')
-          .mockResolvedValue(mapData as any);
-        jest
           .spyOn(client.sovereignty, 'getSovereigntyCampaigns')
           .mockResolvedValue(campaignData as any);
         jest
-          .spyOn(client.sovereignty, 'getSovereigntyStructures')
-          .mockResolvedValue(structureData as any);
+          .spyOn(client.sovereignty, 'getSovereigntySystems')
+          .mockResolvedValue(systemsData as any);
 
         // When
-        const [map, campaigns, structures] = await Promise.all([
-          client.sovereignty.getSovereigntyMap(),
+        const [campaigns, systems] = await Promise.all([
           client.sovereignty.getSovereigntyCampaigns(),
-          client.sovereignty.getSovereigntyStructures(),
+          client.sovereignty.getSovereigntySystems(),
         ]);
 
         // Then
-        expect(map).toHaveLength(1);
-        expect(map[0].system_id).toBe(30004759);
         expect(campaigns).toHaveLength(1);
         expect(campaigns[0].campaign_id).toBe(1001);
-        expect(structures).toHaveLength(1);
-        expect(structures[0].structure_id).toBe(8001);
+        expect(systems).toHaveLength(1);
+        expect(systems[0].system_id).toBe(30004759);
 
-        // Cross-reference: campaign and structure in same system
-        expect(campaigns[0].solar_system_id).toBe(
-          structures[0].solar_system_id,
-        );
+        // Cross-reference: campaign and system in same solar system
+        expect(campaigns[0].solar_system_id).toBe(systems[0].system_id);
       });
     });
   });

--- a/tests/tdd/sovereignty/SovereigntyClient.test.ts
+++ b/tests/tdd/sovereignty/SovereigntyClient.test.ts
@@ -47,58 +47,6 @@ describe('SovereigntyClient', () => {
     );
   });
 
-  it('should get sovereignty map', async () => {
-    const mockResponse = [
-      {
-        alliance_id: 99000006,
-        corporation_id: 98000002,
-        faction_id: 500001,
-        system_id: 30000142,
-      },
-    ];
-
-    fetchMock.mockResponseOnce(JSON.stringify(mockResponse));
-
-    const result = await getBody(() => sovereigntyClient.getSovereigntyMap());
-    expect(Array.isArray(result)).toBe(true);
-    result.forEach((map: any) => {
-      expect(map).toHaveProperty('system_id');
-      expect(typeof map.system_id).toBe('number');
-    });
-    expect(fetchMock.mock.calls[0][0]).toBe(
-      'https://esi.evetech.net/sovereignty/map',
-    );
-  });
-
-  it('should get sovereignty structures', async () => {
-    const mockResponse = [
-      {
-        alliance_id: 99000006,
-        corporation_id: 98000002,
-        faction_id: 500001,
-        system_id: 30000142,
-        structure_id: 1018253388776,
-        type_id: 32226,
-        vulnerable_end_time: '2023-07-02T00:00:00Z',
-        vulnerable_start_time: '2023-07-01T17:00:00Z',
-      },
-    ];
-
-    fetchMock.mockResponseOnce(JSON.stringify(mockResponse));
-
-    const result = await getBody(() =>
-      sovereigntyClient.getSovereigntyStructures(),
-    );
-    expect(Array.isArray(result)).toBe(true);
-    result.forEach((structure: any) => {
-      expect(structure).toHaveProperty('structure_id');
-      expect(typeof structure.structure_id).toBe('number');
-    });
-    expect(fetchMock.mock.calls[0][0]).toBe(
-      'https://esi.evetech.net/sovereignty/structures',
-    );
-  });
-
   it('should get sovereignty systems (combined route)', async () => {
     const mockResponse = [
       {


### PR DESCRIPTION
## Summary
- Removes `getSovereigntyMap` and `getSovereigntyStructures` endpoints that passed their ESI sunset date (2026-05-19)
- Removes corresponding client methods, types (`SovereigntyMap`, `SovereigntyStructure`), and tests
- Updates BDD tests to use remaining active endpoints (`getSovereigntyCampaigns`, `getSovereigntySystems`)

Closes #53

## Test plan
- [x] All 102 test suites pass (2736 tests)
- [x] Build compiles cleanly
- [x] Pre-commit hooks pass (eslint, prettier)

🤖 Generated with [Claude Code](https://claude.com/claude-code)