### PR TITLE
fix: treat 420/429 as circuit breaker failures

### DIFF
--- a/src/core/ApiRequestHandler.ts
+++ b/src/core/ApiRequestHandler.ts
@@ -445,8 +445,15 @@ async function executeSingleFetch(
   rateLimiter.updateFromResponse(parsed.raw, response.status);
 
   if (cb) {
-    if (response.status >= 500) cb.recordFailure(endpoint, response.status);
-    else cb.recordSuccess(endpoint);
+    if (
+      response.status >= 500 ||
+      response.status === 420 ||
+      response.status === 429
+    ) {
+      cb.recordFailure(endpoint, response.status);
+    } else {
+      cb.recordSuccess(endpoint);
+    }
   }
 
   if (parsed.warning) {

--- a/src/core/circuitBreaker/CircuitBreaker.ts
+++ b/src/core/circuitBreaker/CircuitBreaker.ts
@@ -89,7 +89,7 @@ export class CircuitBreaker {
   }
 
   recordFailure(endpoint: string, statusCode: number): void {
-    if (statusCode < 500) return;
+    if (statusCode < 500 && statusCode !== 420 && statusCode !== 429) return;
 
     const key = this.getKey(endpoint);
     const record = this.getOrCreate(key);
@@ -108,7 +108,7 @@ export class CircuitBreaker {
     if (record.failures >= this.failureThreshold) {
       record.state = 'open';
       logWarn(
-        `Circuit opened for ${key} after ${record.failures} consecutive 5xx failures`,
+        `Circuit opened for ${key} after ${record.failures} consecutive failures`,
       );
     }
   }

--- a/tests/tdd/core/ApiRequestHandler.test.ts
+++ b/tests/tdd/core/ApiRequestHandler.test.ts
@@ -2,6 +2,7 @@ import { ApiClient } from '../../../src/core/ApiClient';
 import { handleRequest } from '../../../src/core/ApiRequestHandler';
 import { RateLimiter } from '../../../src/core/rateLimiter/RateLimiter';
 import { ETagCacheManager } from '../../../src/core/cache/ETagCacheManager';
+import { CircuitBreaker } from '../../../src/core/circuitBreaker/CircuitBreaker';
 import { EsiError } from '../../../src/core/util/error';
 import fetchMock from 'jest-fetch-mock';
 
@@ -174,6 +175,69 @@ describe('ApiRequestHandler', () => {
       await expect(
         handleRequest(client, 'v1/characters/123/', 'GET'),
       ).rejects.toThrow(EsiError);
+    });
+  });
+
+  describe('circuit breaker rate-limit integration', () => {
+    let cb: CircuitBreaker;
+
+    beforeEach(() => {
+      cb = new CircuitBreaker({ failureThreshold: 5 });
+      client.setCircuitBreaker(cb);
+    });
+
+    afterEach(() => {
+      cb.shutdown();
+    });
+
+    it('should record circuit breaker failure on 429 response', async () => {
+      fetchMock.mockResponseOnce('Too Many Requests', { status: 429 });
+
+      await expect(handleRequest(client, 'v1/status/', 'GET')).rejects.toThrow(
+        EsiError,
+      );
+
+      const stats = cb.getStats();
+      expect(stats.circuits['v1/status/']).toBeDefined();
+      expect(stats.circuits['v1/status/'].failures).toBe(1);
+    });
+
+    it('should record circuit breaker failure on 420 response', async () => {
+      fetchMock.mockResponseOnce('Error Limited', { status: 420 });
+
+      await expect(handleRequest(client, 'v1/status/', 'GET')).rejects.toThrow(
+        EsiError,
+      );
+
+      const stats = cb.getStats();
+      expect(stats.circuits['v1/status/']).toBeDefined();
+      expect(stats.circuits['v1/status/'].failures).toBe(1);
+    });
+
+    it('should record circuit breaker success on 200 response', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ players: 100 }));
+
+      await handleRequest(client, 'v1/status/', 'GET');
+
+      const stats = cb.getStats();
+      expect(stats.circuits['v1/status/'].state).toBe('closed');
+      expect(stats.circuits['v1/status/'].failures).toBe(0);
+    });
+
+    it('should record circuit breaker success on 200 and reset prior failures', async () => {
+      // First, record a failure
+      fetchMock.mockResponseOnce('Internal Server Error', { status: 500 });
+      await expect(handleRequest(client, 'v1/status/', 'GET')).rejects.toThrow(
+        EsiError,
+      );
+
+      expect(cb.getStats().circuits['v1/status/'].failures).toBe(1);
+
+      // Then a success should reset failures
+      fetchMock.mockResponseOnce(JSON.stringify({ players: 100 }));
+      await handleRequest(client, 'v1/status/', 'GET');
+
+      expect(cb.getStats().circuits['v1/status/'].failures).toBe(0);
     });
   });
 });

--- a/tests/tdd/core/circuitBreaker.test.ts
+++ b/tests/tdd/core/circuitBreaker.test.ts
@@ -134,6 +134,46 @@ describe('CircuitBreaker', () => {
     });
   });
 
+  describe('rate-limit responses', () => {
+    it('should count 429 Too Many Requests as a failure', () => {
+      const cb = new CircuitBreaker({ failureThreshold: 2 });
+
+      cb.recordFailure('v1/status/', 429);
+      cb.recordFailure('v1/status/', 429);
+
+      expect(cb.getState('v1/status/')).toBe('open');
+    });
+
+    it('should count 420 Error Limited as a failure', () => {
+      const cb = new CircuitBreaker({ failureThreshold: 2 });
+
+      cb.recordFailure('v1/status/', 420);
+      cb.recordFailure('v1/status/', 420);
+
+      expect(cb.getState('v1/status/')).toBe('open');
+    });
+
+    it('should not count other 4xx as failures', () => {
+      const cb = new CircuitBreaker({ failureThreshold: 2 });
+
+      cb.recordFailure('v1/status/', 400);
+      cb.recordFailure('v1/status/', 403);
+      cb.recordFailure('v1/status/', 404);
+
+      expect(cb.getState('v1/status/')).toBe('closed');
+    });
+
+    it('should open circuit with mixed rate-limit and 5xx failures', () => {
+      const cb = new CircuitBreaker({ failureThreshold: 3 });
+
+      cb.recordFailure('v1/status/', 429);
+      cb.recordFailure('v1/status/', 500);
+      cb.recordFailure('v1/status/', 420);
+
+      expect(cb.getState('v1/status/')).toBe('open');
+    });
+  });
+
   describe('CircuitOpenError', () => {
     it('should include endpoint and failure count', () => {
       const cb = new CircuitBreaker({ failureThreshold: 2 });


### PR DESCRIPTION
## Summary
- Circuit breaker now records 420 (Error Limited) and 429 (Too Many Requests) as failures, not successes
- Updated `CircuitBreaker.recordFailure()` guard: `statusCode < 500 && statusCode !== 420 && statusCode !== 429`
- Updated `ApiRequestHandler.executeSingleFetch()` to route 420/429 to `cb.recordFailure()`
- Added 8 new tests (4 unit + 4 integration)

Closes #54

## Test plan
- [x] All 102 test suites pass (2768 tests)
- [x] Build compiles cleanly
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)