### PR TITLE
fix: restore @emnapi lockfile entries for Linux CI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1040,6 +1040,29 @@
         "kuler": "^2.0.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",


### PR DESCRIPTION
## Summary

- Restores top-level `@emnapi/core@1.11.1` and `@emnapi/runtime@1.11.1` entries to `package-lock.json`
- These were stripped when the commitlint v21 bump (`59336ed`) regenerated the lockfile on Windows, which prunes Linux-specific optional peer deps
- Without these entries, `npm ci` on Ubuntu CI fails with "Missing: @emnapi/core@1.11.1 from lock file"

## Root cause

The `@emnapi` packages are optional native binding deps of `@oxc-parser` (via `knip` → `@oxc-resolver`). Windows npm doesn't resolve them, so any lockfile regeneration on Windows strips them. This is a recurring cross-platform lockfile issue tracked in project memory.

## Test plan

- [ ] CI passes (`npm ci` succeeds on Ubuntu runners)
- [ ] All existing test suites remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)