### PR TITLE
feat: streaming pagination via async generators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.3.0] - 2026-06-30
+
 ### Added
 
 - **Accept-Language configuration** — `language` option on `EsiClientConfig` injects the `Accept-Language` header for localized ESI responses (en, de, fr, ja, ru, zh, ko, es); changeable at runtime via `ApiClient.setLanguage()`
 - **ESI scope metadata** — generated `esi-scopes.generated.ts` with `EsiScope` union type (63 scopes) and `esiEndpointScopes` record mapping 119 authenticated endpoints to their required OAuth scopes
 - Exported `EsiScope` type and `esiEndpointScopes` map from package root
+- **Streaming pagination** — `stream*` methods on domain clients yield `PageResult<T>` one page at a time via `AsyncGenerator`, enabling backpressure and early termination for large paginated datasets
+- Streaming methods added to `MarketClient` (6), `ContractsClient` (3), `WalletClient` (3), `AssetsClient` (2), `KillmailsClient` (2)
+- `buildEndpointPath()` utility extracted from `createClient.ts` and exported from package root
+- `streamEndpoint()` protected method on `BaseEsiClient` for building custom streaming domain clients
+- Streaming pagination example (`npm run example:streaming`)
 
 ## [5.2.0] - 2026-06-29
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A type-safe TypeScript client for the [EVE Online ESI API](https://esi.evetech.n
 - ETag caching with Cache-Control TTL, stale-on-error, and write invalidation
 - Spec-aware cache TTLs — zero-request cache hits within ESI-specified windows
 - Batch requests with bounded concurrency and auto-chunking
-- Automatic offset-based pagination and cursor-based pagination support
+- Automatic offset-based pagination, cursor-based pagination, and streaming pagination support
 - Rate limiting with header-driven backoff
 - Automatic token refresh with 401 retry and concurrent coalescing
 - 35 domain clients covering the full ESI surface
@@ -367,6 +367,43 @@ const isPublic = !esiEndpointScopes['GET:universe/types/{type_id}'];
 const scope: EsiScope = 'esi-assets.read_assets.v1';
 ```
 
+## Streaming Pagination
+
+For large paginated endpoints (market orders, contracts, assets), streaming yields one page at a time via `AsyncGenerator` instead of eagerly fetching all pages into memory:
+
+```typescript
+import { EsiClient } from '@lgriffin/esi.ts';
+
+const client = new EsiClient();
+
+// Stream all market orders in The Forge, page by page
+for await (const page of client.market.streamMarketOrders(10000002)) {
+  console.log(
+    `Page ${page.page}/${page.totalPages}: ${page.data.length} orders`,
+  );
+
+  // Process each order as it arrives
+  for (const order of page.data) {
+    if (order.is_buy_order && order.price > 1_000_000) {
+      console.log(`High-value buy: ${order.type_id} @ ${order.price} ISK`);
+    }
+  }
+
+  // Early termination — stops fetching remaining pages
+  if (page.page >= 3) break;
+}
+```
+
+Available streaming methods:
+
+- **MarketClient** — `streamMarketOrders`, `streamMarketTypes`, `streamCharacterOrderHistory`, `streamCorporationOrders`, `streamCorporationOrderHistory`, `streamMarketOrdersInStructure`
+- **ContractsClient** — `streamPublicContracts`, `streamCharacterContracts`, `streamCorporationContracts`
+- **WalletClient** — `streamCharacterWalletJournal`, `streamCorporationWalletJournal`, `streamCharacterWalletTransactions`
+- **AssetsClient** — `streamCharacterAssets`, `streamCorporationAssets`
+- **KillmailsClient** — `streamCharacterRecentKillmails`, `streamCorporationRecentKillmails`
+
+Try it: `npm run example:streaming`
+
 ## Cursor-based Pagination
 
 Newer ESI routes (Freelance Jobs, and future routes) use cursor-based pagination with opaque `before`/`after` tokens in the response body. See the [ESI blog post](https://developers.eveonline.com/blog/changing-pagination-turning-a-new-page) for background.
@@ -575,6 +612,7 @@ npm run example:dogma        # Item type details + dogma attributes
 npm run example:contracts    # Public region contracts + auction bids/items
 npm run example:rate-limiting      # Rate limiter & pagination demonstration
 npm run example:cursor-pagination  # Freelance Jobs with cursor pagination
+npm run example:streaming          # Streaming pagination for large datasets
 npm run example:token-refresh      # Automatic token refresh on 401
 ```
 

--- a/examples/streaming-pagination.ts
+++ b/examples/streaming-pagination.ts
@@ -1,0 +1,138 @@
+/**
+ * ESI.ts Example: Streaming Pagination
+ *
+ * Demonstrates streaming through large paginated datasets page-by-page
+ * instead of loading everything into memory at once.
+ *
+ * Uses market orders in The Forge (Jita's region) — one of the largest
+ * paginated datasets in ESI, often 300+ pages.
+ *
+ * Usage: npm run example:streaming
+ */
+import { EsiClient } from '../src/EsiClient';
+
+const FORGE_REGION_ID = 10000002;
+
+async function streamAllOrders() {
+  const client = new EsiClient({ clientId: 'esi-ts-streaming-demo' });
+
+  try {
+    console.log('='.repeat(60));
+    console.log('Streaming Market Orders — The Forge (all pages)');
+    console.log('='.repeat(60));
+    console.log();
+
+    let totalOrders = 0;
+    let buyOrders = 0;
+    let sellOrders = 0;
+    const startTime = Date.now();
+
+    for await (const page of client.market.streamMarketOrders(
+      FORGE_REGION_ID,
+    )) {
+      totalOrders += page.data.length;
+      for (const order of page.data) {
+        if (order.is_buy_order) buyOrders++;
+        else sellOrders++;
+      }
+
+      console.log(
+        `  Page ${page.page}/${page.totalPages}: ` +
+          `${page.data.length} orders ` +
+          `(total so far: ${totalOrders.toLocaleString()})`,
+      );
+    }
+
+    const elapsed = Date.now() - startTime;
+    console.log();
+    console.log(`Done in ${(elapsed / 1000).toFixed(1)}s`);
+    console.log(`  Total orders: ${totalOrders.toLocaleString()}`);
+    console.log(`  Buy orders:   ${buyOrders.toLocaleString()}`);
+    console.log(`  Sell orders:  ${sellOrders.toLocaleString()}`);
+  } finally {
+    client.shutdown();
+  }
+}
+
+async function streamWithEarlyStop() {
+  const client = new EsiClient({ clientId: 'esi-ts-streaming-demo' });
+
+  try {
+    console.log();
+    console.log('='.repeat(60));
+    console.log('Streaming with Early Stop (first 3 pages only)');
+    console.log('='.repeat(60));
+    console.log();
+
+    let count = 0;
+
+    for await (const page of client.market.streamMarketOrders(
+      FORGE_REGION_ID,
+    )) {
+      count += page.data.length;
+      console.log(
+        `  Page ${page.page}/${page.totalPages}: ${page.data.length} orders`,
+      );
+
+      if (page.page >= 3) {
+        console.log('  → Stopping early (backpressure demo)');
+        break;
+      }
+    }
+
+    console.log();
+    console.log(
+      `Processed ${count.toLocaleString()} orders from 3 pages ` +
+        `without fetching the remaining pages`,
+    );
+  } finally {
+    client.shutdown();
+  }
+}
+
+async function streamMarketTypes() {
+  const client = new EsiClient({ clientId: 'esi-ts-streaming-demo' });
+
+  try {
+    console.log();
+    console.log('='.repeat(60));
+    console.log('Streaming Market Type IDs — The Forge');
+    console.log('='.repeat(60));
+    console.log();
+
+    let totalTypes = 0;
+
+    for await (const page of client.market.streamMarketTypes(
+      FORGE_REGION_ID,
+    )) {
+      totalTypes += page.data.length;
+      console.log(
+        `  Page ${page.page}/${page.totalPages}: ` +
+          `${page.data.length} type IDs`,
+      );
+    }
+
+    console.log();
+    console.log(
+      `Total item types with active orders: ${totalTypes.toLocaleString()}`,
+    );
+  } finally {
+    client.shutdown();
+  }
+}
+
+async function main() {
+  try {
+    await streamWithEarlyStop();
+    await streamMarketTypes();
+    await streamAllOrders();
+  } catch (err) {
+    console.error(
+      '\nError:',
+      err instanceof Error ? err.message : String(err),
+    );
+    process.exit(1);
+  }
+}
+
+main();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lgriffin/esi.ts",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "description": "This is a TypeScript Implementation for the EVE Online API offered through ESI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -56,6 +56,7 @@
     "example:cursor-pagination": "ts-node examples/cursor-pagination.ts",
     "example:token-refresh": "ts-node examples/token-refresh.ts",
     "example:retry-timeout-metadata": "ts-node examples/retry-timeout-metadata.ts",
+    "example:streaming": "ts-node examples/streaming-pagination.ts",
     "token:create": "ts-node scripts/create-token.ts",
     "lint": "eslint src --ext .ts",
     "lint:fix": "eslint src --ext .ts --fix",

--- a/src/clients/AssetsClient.ts
+++ b/src/clients/AssetsClient.ts
@@ -6,6 +6,7 @@ import {
   AssetLocation,
   AssetName,
 } from '../types/api-responses';
+import { PageResult } from '../core/pagination/AsyncPaginationIterator';
 
 export class AssetsClient extends BaseEsiClient<typeof assetEndpoints> {
   constructor(client: ApiClient) {
@@ -107,5 +108,23 @@ export class AssetsClient extends BaseEsiClient<typeof assetEndpoints> {
       corporationId,
       itemIds,
     ) as Promise<AssetName[]>;
+  }
+
+  streamCharacterAssets(
+    characterId: number,
+  ): AsyncGenerator<PageResult<CharacterAsset>, void, undefined> {
+    return this.streamEndpoint<CharacterAsset>(
+      'getCharacterAssets',
+      characterId,
+    );
+  }
+
+  streamCorporationAssets(
+    corporationId: number,
+  ): AsyncGenerator<PageResult<CharacterAsset>, void, undefined> {
+    return this.streamEndpoint<CharacterAsset>(
+      'getCorporationAssets',
+      corporationId,
+    );
   }
 }

--- a/src/clients/BaseEsiClient.ts
+++ b/src/clients/BaseEsiClient.ts
@@ -5,13 +5,18 @@ import {
   WithMetadata,
 } from '../core/endpoints/createClient';
 import { EndpointMap } from '../core/endpoints/EndpointDefinition';
+import { buildEndpointPath } from '../core/endpoints/buildEndpointPath';
+import {
+  fetchPages,
+  PageResult,
+} from '../core/pagination/AsyncPaginationIterator';
 
 type ClientMethods<T extends EndpointMap> = ReturnType<typeof createClient<T>>;
 
 export abstract class BaseEsiClient<T extends EndpointMap> {
   protected api: ClientMethods<T>;
   protected _client: ApiClient;
-  private _endpoints: T;
+  protected _endpoints: T;
   private _metaApi?: ClientMethods<T>;
 
   constructor(client: ApiClient, endpoints: T) {
@@ -20,11 +25,30 @@ export abstract class BaseEsiClient<T extends EndpointMap> {
     this.api = createClient(client, endpoints);
   }
 
+  protected streamEndpoint<R>(
+    endpointName: string & keyof T,
+    ...args: unknown[]
+  ): AsyncGenerator<PageResult<R>, void, undefined> {
+    const def = this._endpoints[endpointName]!;
+    const { path, body } = buildEndpointPath(
+      def,
+      args,
+      this._client.getDatasource(),
+    );
+    return fetchPages<R>(
+      this._client,
+      path,
+      def.method,
+      def.requiresAuth,
+      body,
+    );
+  }
+
   withMetadata(): WithMetadata<Omit<this, 'withMetadata'>> {
     if (!this._metaApi) {
       this._metaApi = createClient(this._client, this._endpoints, {
         returnMetadata: true,
-      } as CreateClientOptions);
+      });
     }
     return this._metaApi as unknown as WithMetadata<Omit<this, 'withMetadata'>>;
   }

--- a/src/clients/ContractsClient.ts
+++ b/src/clients/ContractsClient.ts
@@ -2,6 +2,7 @@ import { ApiClient } from '../core/ApiClient';
 import { BaseEsiClient } from './BaseEsiClient';
 import { contractEndpoints } from '../core/endpoints/contractEndpoints';
 import { Contract, ContractBid, ContractItem } from '../types/api-responses';
+import { PageResult } from '../core/pagination/AsyncPaginationIterator';
 
 export class ContractsClient extends BaseEsiClient<typeof contractEndpoints> {
   constructor(client: ApiClient) {
@@ -134,5 +135,26 @@ export class ContractsClient extends BaseEsiClient<typeof contractEndpoints> {
       corporationId,
       contractId,
     ) as Promise<ContractItem[]>;
+  }
+
+  streamPublicContracts(
+    regionId: number,
+  ): AsyncGenerator<PageResult<Contract>, void, undefined> {
+    return this.streamEndpoint<Contract>('getPublicContracts', regionId);
+  }
+
+  streamCharacterContracts(
+    characterId: number,
+  ): AsyncGenerator<PageResult<Contract>, void, undefined> {
+    return this.streamEndpoint<Contract>('getCharacterContracts', characterId);
+  }
+
+  streamCorporationContracts(
+    corporationId: number,
+  ): AsyncGenerator<PageResult<Contract>, void, undefined> {
+    return this.streamEndpoint<Contract>(
+      'getCorporationContracts',
+      corporationId,
+    );
   }
 }

--- a/src/clients/KillmailsClient.ts
+++ b/src/clients/KillmailsClient.ts
@@ -2,6 +2,7 @@ import { ApiClient } from '../core/ApiClient';
 import { BaseEsiClient } from './BaseEsiClient';
 import { killmailEndpoints } from '../core/endpoints/killmailEndpoints';
 import { KillmailSummary, Killmail } from '../types/api-responses';
+import { PageResult } from '../core/pagination/AsyncPaginationIterator';
 
 export class KillmailsClient extends BaseEsiClient<typeof killmailEndpoints> {
   constructor(client: ApiClient) {
@@ -45,5 +46,23 @@ export class KillmailsClient extends BaseEsiClient<typeof killmailEndpoints> {
    */
   getKillmail(killmailId: number, killmailHash: string): Promise<Killmail> {
     return this.api.getKillmail(killmailId, killmailHash) as Promise<Killmail>;
+  }
+
+  streamCharacterRecentKillmails(
+    characterId: number,
+  ): AsyncGenerator<PageResult<KillmailSummary>, void, undefined> {
+    return this.streamEndpoint<KillmailSummary>(
+      'getCharacterRecentKillmails',
+      characterId,
+    );
+  }
+
+  streamCorporationRecentKillmails(
+    corporationId: number,
+  ): AsyncGenerator<PageResult<KillmailSummary>, void, undefined> {
+    return this.streamEndpoint<KillmailSummary>(
+      'getCorporationRecentKillmails',
+      corporationId,
+    );
   }
 }

--- a/src/clients/MarketClient.ts
+++ b/src/clients/MarketClient.ts
@@ -2,6 +2,7 @@ import { ApiClient } from '../core/ApiClient';
 import { BaseEsiClient } from './BaseEsiClient';
 import { marketEndpoints } from '../core/endpoints/marketEndpoints';
 import { MarketOrder, MarketHistory } from '../types/api-responses';
+import { PageResult } from '../core/pagination/AsyncPaginationIterator';
 
 export class MarketClient extends BaseEsiClient<typeof marketEndpoints> {
   constructor(client: ApiClient) {
@@ -145,5 +146,53 @@ export class MarketClient extends BaseEsiClient<typeof marketEndpoints> {
     return this.api.getMarketOrdersInStructure(structureId) as Promise<
       MarketOrder[]
     >;
+  }
+
+  streamMarketOrders(
+    regionId: number,
+  ): AsyncGenerator<PageResult<MarketOrder>, void, undefined> {
+    return this.streamEndpoint<MarketOrder>('getMarketOrders', regionId, 'all');
+  }
+
+  streamMarketTypes(
+    regionId: number,
+  ): AsyncGenerator<PageResult<number>, void, undefined> {
+    return this.streamEndpoint<number>('getMarketTypes', regionId);
+  }
+
+  streamCharacterOrderHistory(
+    characterId: number,
+  ): AsyncGenerator<PageResult<MarketOrder>, void, undefined> {
+    return this.streamEndpoint<MarketOrder>(
+      'getCharacterOrderHistory',
+      characterId,
+    );
+  }
+
+  streamCorporationOrders(
+    corporationId: number,
+  ): AsyncGenerator<PageResult<MarketOrder>, void, undefined> {
+    return this.streamEndpoint<MarketOrder>(
+      'getCorporationOrders',
+      corporationId,
+    );
+  }
+
+  streamCorporationOrderHistory(
+    corporationId: number,
+  ): AsyncGenerator<PageResult<MarketOrder>, void, undefined> {
+    return this.streamEndpoint<MarketOrder>(
+      'getCorporationOrderHistory',
+      corporationId,
+    );
+  }
+
+  streamMarketOrdersInStructure(
+    structureId: number,
+  ): AsyncGenerator<PageResult<MarketOrder>, void, undefined> {
+    return this.streamEndpoint<MarketOrder>(
+      'getMarketOrdersInStructure',
+      structureId,
+    );
   }
 }

--- a/src/clients/WalletClient.ts
+++ b/src/clients/WalletClient.ts
@@ -2,6 +2,7 @@ import { ApiClient } from '../core/ApiClient';
 import { BaseEsiClient } from './BaseEsiClient';
 import { walletEndpoints } from '../core/endpoints/walletEndpoints';
 import { WalletJournal, WalletTransaction } from '../types/api-responses';
+import { PageResult } from '../core/pagination/AsyncPaginationIterator';
 
 export class WalletClient extends BaseEsiClient<typeof walletEndpoints> {
   constructor(client: ApiClient) {
@@ -96,5 +97,34 @@ export class WalletClient extends BaseEsiClient<typeof walletEndpoints> {
       corporationId,
       division,
     ) as Promise<WalletTransaction[]>;
+  }
+
+  streamCharacterWalletJournal(
+    characterId: number,
+  ): AsyncGenerator<PageResult<WalletJournal>, void, undefined> {
+    return this.streamEndpoint<WalletJournal>(
+      'getCharacterWalletJournal',
+      characterId,
+    );
+  }
+
+  streamCorporationWalletJournal(
+    corporationId: number,
+    division: number,
+  ): AsyncGenerator<PageResult<WalletJournal>, void, undefined> {
+    return this.streamEndpoint<WalletJournal>(
+      'getCorporationWalletJournal',
+      corporationId,
+      division,
+    );
+  }
+
+  streamCharacterWalletTransactions(
+    characterId: number,
+  ): AsyncGenerator<PageResult<WalletTransaction>, void, undefined> {
+    return this.streamEndpoint<WalletTransaction>(
+      'getCharacterWalletTransactions',
+      characterId,
+    );
   }
 }

--- a/src/core/ApiRequestHandler.ts
+++ b/src/core/ApiRequestHandler.ts
@@ -677,6 +677,23 @@ const executeRequest = async (
   }
 };
 
+export const handleSinglePageRequest = async (
+  client: ApiClient,
+  endpoint: string,
+  method: string,
+  body?: unknown,
+  requiresAuth: boolean = false,
+): Promise<EsiHandlerResponse> => {
+  const { data, parsed } = await fetchOnePage(
+    client,
+    endpoint,
+    method,
+    body,
+    requiresAuth,
+  );
+  return { headers: parsed.raw, body: data };
+};
+
 export const handleRequest = async (
   client: ApiClient,
   endpoint: string,

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -1,4 +1,4 @@
 export const PACKAGE_NAME = 'esi.ts';
-export const PACKAGE_VERSION = '5.2.0';
+export const PACKAGE_VERSION = '5.3.0';
 export const USER_AGENT = `${PACKAGE_NAME}/${PACKAGE_VERSION}`;
 export const COMPATIBILITY_DATE = '2026-05-19';

--- a/src/core/endpoints/buildEndpointPath.ts
+++ b/src/core/endpoints/buildEndpointPath.ts
@@ -1,0 +1,58 @@
+import { EndpointDefinition } from './EndpointDefinition';
+import { validatePathParam, validateQueryParam } from '../util/validation';
+
+export interface EndpointPathResult {
+  path: string;
+  body: unknown;
+}
+
+export function buildEndpointPath(
+  def: EndpointDefinition,
+  args: unknown[],
+  datasource?: string,
+): EndpointPathResult {
+  let argIndex = 0;
+  let path = def.path;
+
+  if (def.pathParams) {
+    for (const param of def.pathParams) {
+      const raw = args[argIndex++];
+      const validated = validatePathParam(param, raw);
+      path = path.replace(`{${param}}`, encodeURIComponent(validated));
+    }
+  }
+
+  if (def.queryParams) {
+    const queryParts: string[] = [];
+    for (const [paramName, queryKey] of Object.entries(def.queryParams)) {
+      const value = args[argIndex++];
+      if (value !== undefined) {
+        const validated = validateQueryParam(paramName, value);
+        queryParts.push(`${queryKey}=${encodeURIComponent(validated)}`);
+      }
+    }
+    if (queryParts.length > 0) {
+      path += (path.includes('?') ? '&' : '?') + queryParts.join('&');
+    }
+  }
+
+  let body: unknown = undefined;
+  if (def.bodyBuilder) {
+    /* eslint-disable @typescript-eslint/no-unsafe-argument */
+    body = def.bodyBuilder(
+      ...(args.slice(argIndex) as Parameters<typeof def.bodyBuilder>),
+    );
+    /* eslint-enable @typescript-eslint/no-unsafe-argument */
+  } else if (def.hasBody) {
+    // eslint-disable-next-line security/detect-object-injection
+    body = args[argIndex];
+  }
+
+  if (datasource) {
+    path +=
+      (path.includes('?') ? '&' : '?') +
+      `datasource=${encodeURIComponent(datasource)}`;
+  }
+
+  return { path, body };
+}

--- a/src/core/endpoints/createClient.ts
+++ b/src/core/endpoints/createClient.ts
@@ -3,7 +3,7 @@ import { handleRequest, EsiHandlerResponse } from '../ApiRequestHandler';
 import { EndpointMap, EndpointArgs } from './EndpointDefinition';
 import { CursorTokens } from '../pagination/CursorPaginationHandler';
 import { EsiResponse, EsiResponseMeta } from '../../types/api-responses';
-import { validatePathParam, validateQueryParam } from '../util/validation';
+import { buildEndpointPath } from './buildEndpointPath';
 import { parseWarning } from '../util/headersUtil';
 import { logWarn } from '../logger/loggerUtil';
 
@@ -82,49 +82,9 @@ export function createClient<T extends EndpointMap>(
         logWarn(parts.join(' '));
       }
 
-      let argIndex = 0;
-
-      let path = def.path;
-      if (def.pathParams) {
-        for (const param of def.pathParams) {
-          const raw = args[argIndex++];
-          const validated = validatePathParam(param, raw);
-          path = path.replace(`{${param}}`, encodeURIComponent(validated));
-        }
-      }
-
-      if (def.queryParams) {
-        const queryParts: string[] = [];
-        for (const [paramName, queryKey] of Object.entries(def.queryParams)) {
-          const value = args[argIndex++];
-          if (value !== undefined) {
-            const validated = validateQueryParam(paramName, value);
-            queryParts.push(`${queryKey}=${encodeURIComponent(validated)}`);
-          }
-        }
-        if (queryParts.length > 0) {
-          path += (path.includes('?') ? '&' : '?') + queryParts.join('&');
-        }
-      }
-
-      let body: unknown = undefined;
-      if (def.bodyBuilder) {
-        /* eslint-disable @typescript-eslint/no-unsafe-argument */
-        body = def.bodyBuilder(
-          ...(args.slice(argIndex) as Parameters<typeof def.bodyBuilder>),
-        );
-        /* eslint-enable @typescript-eslint/no-unsafe-argument */
-      } else if (def.hasBody) {
-        // eslint-disable-next-line security/detect-object-injection
-        body = args[argIndex];
-      }
-
-      const datasource = apiClient.getDatasource();
-      if (datasource) {
-        path +=
-          (path.includes('?') ? '&' : '?') +
-          `datasource=${encodeURIComponent(datasource)}`;
-      }
+      const built = buildEndpointPath(def, args, apiClient.getDatasource());
+      let path = built.path;
+      const body = built.body;
 
       if (def.cursorPagination) {
         const lastArg = args[args.length - 1];

--- a/src/core/pagination/AsyncPaginationIterator.ts
+++ b/src/core/pagination/AsyncPaginationIterator.ts
@@ -1,5 +1,5 @@
 import { ApiClient } from '../ApiClient';
-import { handleRequest } from '../ApiRequestHandler';
+import { handleSinglePageRequest } from '../ApiRequestHandler';
 import { logInfo } from '../logger/loggerUtil';
 
 export interface PageResult<T = unknown> {
@@ -21,7 +21,7 @@ export async function* fetchPages<T = unknown>(
   requiresAuth: boolean = false,
   body?: unknown,
 ): AsyncGenerator<PageResult<T>, void, undefined> {
-  const firstResponse = await handleRequest(
+  const firstResponse = await handleSinglePageRequest(
     client,
     endpoint,
     method,
@@ -39,7 +39,7 @@ export async function* fetchPages<T = unknown>(
 
     logInfo(`Fetching page ${page}/${totalPages}: ${pagedEndpoint}`);
 
-    const response = await handleRequest(
+    const response = await handleSinglePageRequest(
       client,
       pagedEndpoint,
       method,

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,6 +134,7 @@ export {
   fetchPages,
   PageResult,
 } from './core/pagination/AsyncPaginationIterator';
+export { buildEndpointPath } from './core/endpoints/buildEndpointPath';
 
 // Interfaces (for custom implementations / testing)
 export { ICache } from './core/cache/ICache';

--- a/tests/tdd/core/AsyncPaginationIterator.test.ts
+++ b/tests/tdd/core/AsyncPaginationIterator.test.ts
@@ -13,13 +13,13 @@ jest.mock('../../../src/core/ApiRequestHandler', () => {
   const original = jest.requireActual('../../../src/core/ApiRequestHandler');
   return {
     ...original,
-    handleRequest: jest.fn(),
+    handleSinglePageRequest: jest.fn(),
   };
 });
 
-import { handleRequest } from '../../../src/core/ApiRequestHandler';
-const mockHandleRequest = handleRequest as jest.MockedFunction<
-  typeof handleRequest
+import { handleSinglePageRequest } from '../../../src/core/ApiRequestHandler';
+const mockHandleRequest = handleSinglePageRequest as jest.MockedFunction<
+  typeof handleSinglePageRequest
 >;
 
 describe('AsyncPaginationIterator', () => {
@@ -200,7 +200,7 @@ describe('AsyncPaginationIterator', () => {
       expect(pages[0].data).toEqual([]);
     });
 
-    it('should pass requiresAuth and body through to handleRequest', async () => {
+    it('should pass requiresAuth and body through to handleSinglePageRequest', async () => {
       mockHandleRequest.mockResolvedValueOnce({
         headers: { 'x-pages': '1' },
         body: [{ id: 1 }],

--- a/tests/tdd/core/buildEndpointPath.test.ts
+++ b/tests/tdd/core/buildEndpointPath.test.ts
@@ -1,0 +1,157 @@
+import { buildEndpointPath } from '../../../src/core/endpoints/buildEndpointPath';
+import { EndpointDefinition } from '../../../src/core/endpoints/EndpointDefinition';
+
+describe('buildEndpointPath', () => {
+  describe('path param substitution', () => {
+    it('should substitute a single path param', () => {
+      const def: EndpointDefinition = {
+        path: 'markets/{regionId}/orders/',
+        method: 'GET',
+        requiresAuth: false,
+        pathParams: ['regionId'],
+      };
+      const { path } = buildEndpointPath(def, [10000002]);
+      expect(path).toBe('markets/10000002/orders/');
+    });
+
+    it('should substitute multiple path params', () => {
+      const def: EndpointDefinition = {
+        path: 'characters/{characterId}/contracts/{contractId}/items',
+        method: 'GET',
+        requiresAuth: true,
+        pathParams: ['characterId', 'contractId'],
+      };
+      const { path } = buildEndpointPath(def, [123456, 789]);
+      expect(path).toBe('characters/123456/contracts/789/items');
+    });
+
+    it('should encode path params', () => {
+      const def: EndpointDefinition = {
+        path: 'killmails/{killmailId}/{killmailHash}/',
+        method: 'GET',
+        requiresAuth: false,
+        pathParams: ['killmailId', 'killmailHash'],
+      };
+      const { path } = buildEndpointPath(def, [1, 'abc123']);
+      expect(path).toBe('killmails/1/abc123/');
+    });
+
+    it('should throw on empty path param', () => {
+      const def: EndpointDefinition = {
+        path: 'markets/{regionId}/orders/',
+        method: 'GET',
+        requiresAuth: false,
+        pathParams: ['regionId'],
+      };
+      expect(() => buildEndpointPath(def, [null])).toThrow(/must not be empty/);
+    });
+  });
+
+  describe('query params', () => {
+    it('should append a single query param', () => {
+      const def: EndpointDefinition = {
+        path: 'markets/{regionId}/orders/',
+        method: 'GET',
+        requiresAuth: false,
+        pathParams: ['regionId'],
+        queryParams: { orderType: 'order_type' },
+      };
+      const { path } = buildEndpointPath(def, [10000002, 'all']);
+      expect(path).toBe('markets/10000002/orders/?order_type=all');
+    });
+
+    it('should append multiple query params', () => {
+      const def: EndpointDefinition = {
+        path: 'test/',
+        method: 'GET',
+        requiresAuth: false,
+        queryParams: { foo: 'f', bar: 'b' },
+      };
+      const { path } = buildEndpointPath(def, ['val1', 'val2']);
+      expect(path).toBe('test/?f=val1&b=val2');
+    });
+
+    it('should skip undefined query params', () => {
+      const def: EndpointDefinition = {
+        path: 'markets/{regionId}/orders/',
+        method: 'GET',
+        requiresAuth: false,
+        pathParams: ['regionId'],
+        queryParams: { orderType: 'order_type' },
+      };
+      const { path } = buildEndpointPath(def, [10000002, undefined]);
+      expect(path).toBe('markets/10000002/orders/');
+    });
+  });
+
+  describe('datasource', () => {
+    it('should append datasource with no existing query string', () => {
+      const def: EndpointDefinition = {
+        path: 'status/',
+        method: 'GET',
+        requiresAuth: false,
+      };
+      const { path } = buildEndpointPath(def, [], 'tranquility');
+      expect(path).toBe('status/?datasource=tranquility');
+    });
+
+    it('should append datasource with existing query string', () => {
+      const def: EndpointDefinition = {
+        path: 'markets/{regionId}/orders/',
+        method: 'GET',
+        requiresAuth: false,
+        pathParams: ['regionId'],
+        queryParams: { orderType: 'order_type' },
+      };
+      const { path } = buildEndpointPath(def, [10000002, 'all'], 'singularity');
+      expect(path).toBe(
+        'markets/10000002/orders/?order_type=all&datasource=singularity',
+      );
+    });
+
+    it('should not append datasource when undefined', () => {
+      const def: EndpointDefinition = {
+        path: 'status/',
+        method: 'GET',
+        requiresAuth: false,
+      };
+      const { path } = buildEndpointPath(def, []);
+      expect(path).toBe('status/');
+    });
+  });
+
+  describe('body extraction', () => {
+    it('should extract body when hasBody is true', () => {
+      const def: EndpointDefinition = {
+        path: 'characters/{characterId}/assets/locations/',
+        method: 'POST',
+        requiresAuth: true,
+        pathParams: ['characterId'],
+        hasBody: true,
+      };
+      const { body } = buildEndpointPath(def, [123, [1, 2, 3]]);
+      expect(body).toEqual([1, 2, 3]);
+    });
+
+    it('should use bodyBuilder when provided', () => {
+      const def: EndpointDefinition = {
+        path: 'test/',
+        method: 'POST',
+        requiresAuth: false,
+        bodyBuilder: (ids: number[]) => ({ item_ids: ids }),
+      };
+      const { body } = buildEndpointPath(def, [[10, 20]]);
+      expect(body).toEqual({ item_ids: [10, 20] });
+    });
+
+    it('should return undefined body for GET without hasBody', () => {
+      const def: EndpointDefinition = {
+        path: 'status/',
+        method: 'GET',
+        requiresAuth: false,
+      };
+      const { body } = buildEndpointPath(def, []);
+      expect(body).toBeUndefined();
+    });
+  });
+});

--- a/tests/tdd/core/streamEndpoint.test.ts
+++ b/tests/tdd/core/streamEndpoint.test.ts
@@ -8,13 +8,13 @@ jest.mock('../../../src/core/ApiRequestHandler', () => {
   const original = jest.requireActual('../../../src/core/ApiRequestHandler');
   return {
     ...original,
-    handleRequest: jest.fn(),
+    handleSinglePageRequest: jest.fn(),
   };
 });
 
-import { handleRequest } from '../../../src/core/ApiRequestHandler';
-const mockHandleRequest = handleRequest as jest.MockedFunction<
-  typeof handleRequest
+import { handleSinglePageRequest } from '../../../src/core/ApiRequestHandler';
+const mockHandleRequest = handleSinglePageRequest as jest.MockedFunction<
+  typeof handleSinglePageRequest
 >;
 
 const testEndpoints = {

--- a/tests/tdd/core/streamEndpoint.test.ts
+++ b/tests/tdd/core/streamEndpoint.test.ts
@@ -1,0 +1,279 @@
+import { ApiClient } from '../../../src/core/ApiClient';
+import { BaseEsiClient } from '../../../src/clients/BaseEsiClient';
+import { EndpointMap } from '../../../src/core/endpoints/EndpointDefinition';
+import { PageResult } from '../../../src/core/pagination/AsyncPaginationIterator';
+import { RateLimiter } from '../../../src/core/rateLimiter/RateLimiter';
+
+jest.mock('../../../src/core/ApiRequestHandler', () => {
+  const original = jest.requireActual('../../../src/core/ApiRequestHandler');
+  return {
+    ...original,
+    handleRequest: jest.fn(),
+  };
+});
+
+import { handleRequest } from '../../../src/core/ApiRequestHandler';
+const mockHandleRequest = handleRequest as jest.MockedFunction<
+  typeof handleRequest
+>;
+
+const testEndpoints = {
+  getItems: {
+    path: 'test/{regionId}/items/',
+    method: 'GET',
+    requiresAuth: false,
+    pathParams: ['regionId'],
+    queryParams: { category: 'category' },
+  },
+  getSecureItems: {
+    path: 'secure/{characterId}/items/',
+    method: 'GET',
+    requiresAuth: true,
+    pathParams: ['characterId'],
+  },
+} as const satisfies EndpointMap;
+
+class TestClient extends BaseEsiClient<typeof testEndpoints> {
+  constructor(client: ApiClient) {
+    super(client, testEndpoints);
+  }
+
+  streamItems(
+    regionId: number,
+    category?: string,
+  ): AsyncGenerator<PageResult<{ id: number }>, void, undefined> {
+    return this.streamEndpoint<{ id: number }>('getItems', regionId, category);
+  }
+
+  streamSecureItems(
+    characterId: number,
+  ): AsyncGenerator<PageResult<{ id: number }>, void, undefined> {
+    return this.streamEndpoint<{ id: number }>('getSecureItems', characterId);
+  }
+}
+
+describe('streamEndpoint', () => {
+  let apiClient: ApiClient;
+  let testClient: TestClient;
+
+  beforeEach(() => {
+    mockHandleRequest.mockReset();
+    apiClient = new ApiClient('test', 'https://esi.evetech.net');
+    const rateLimiter = new RateLimiter();
+    rateLimiter.setTestMode(true);
+    apiClient.setRateLimiter(rateLimiter);
+    testClient = new TestClient(apiClient);
+  });
+
+  it('should yield a single page for non-paginated response', async () => {
+    mockHandleRequest.mockResolvedValueOnce({
+      headers: { 'x-pages': '1' },
+      body: [{ id: 1 }, { id: 2 }],
+    });
+
+    const pages: PageResult<{ id: number }>[] = [];
+    for await (const page of testClient.streamItems(100)) {
+      pages.push(page);
+    }
+
+    expect(pages).toHaveLength(1);
+    expect(pages[0].data).toEqual([{ id: 1 }, { id: 2 }]);
+    expect(pages[0].page).toBe(1);
+    expect(pages[0].totalPages).toBe(1);
+  });
+
+  it('should yield multiple pages sequentially', async () => {
+    mockHandleRequest
+      .mockResolvedValueOnce({
+        headers: { 'x-pages': '3' },
+        body: [{ id: 1 }],
+      })
+      .mockResolvedValueOnce({
+        headers: { 'x-pages': '3' },
+        body: [{ id: 2 }],
+      })
+      .mockResolvedValueOnce({
+        headers: { 'x-pages': '3' },
+        body: [{ id: 3 }],
+      });
+
+    const pages: PageResult<{ id: number }>[] = [];
+    for await (const page of testClient.streamItems(100)) {
+      pages.push(page);
+    }
+
+    expect(pages).toHaveLength(3);
+    expect(pages[0]).toEqual({ data: [{ id: 1 }], page: 1, totalPages: 3 });
+    expect(pages[1]).toEqual({ data: [{ id: 2 }], page: 2, totalPages: 3 });
+    expect(pages[2]).toEqual({ data: [{ id: 3 }], page: 3, totalPages: 3 });
+  });
+
+  it('should stop on early break', async () => {
+    mockHandleRequest
+      .mockResolvedValueOnce({
+        headers: { 'x-pages': '10' },
+        body: [{ id: 1 }],
+      })
+      .mockResolvedValueOnce({
+        headers: { 'x-pages': '10' },
+        body: [{ id: 2 }],
+      });
+
+    const pages: PageResult<{ id: number }>[] = [];
+    for await (const page of testClient.streamItems(100)) {
+      pages.push(page);
+      if (page.page >= 2) break;
+    }
+
+    expect(pages).toHaveLength(2);
+    expect(mockHandleRequest).toHaveBeenCalledTimes(2);
+  });
+
+  it('should stop on empty page', async () => {
+    mockHandleRequest
+      .mockResolvedValueOnce({
+        headers: { 'x-pages': '3' },
+        body: [{ id: 1 }],
+      })
+      .mockResolvedValueOnce({
+        headers: { 'x-pages': '3' },
+        body: [],
+      });
+
+    const pages: PageResult<{ id: number }>[] = [];
+    for await (const page of testClient.streamItems(100)) {
+      pages.push(page);
+    }
+
+    expect(pages).toHaveLength(1);
+  });
+
+  it('should build correct URL with path params', async () => {
+    mockHandleRequest.mockResolvedValueOnce({
+      headers: { 'x-pages': '1' },
+      body: [],
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    for await (const _ of testClient.streamItems(42)) {
+      // consume
+    }
+
+    expect(mockHandleRequest).toHaveBeenCalledWith(
+      apiClient,
+      'test/42/items/',
+      'GET',
+      undefined,
+      false,
+    );
+  });
+
+  it('should build correct URL with query params', async () => {
+    mockHandleRequest.mockResolvedValueOnce({
+      headers: { 'x-pages': '1' },
+      body: [],
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    for await (const _ of testClient.streamItems(100, 'weapons')) {
+      // consume
+    }
+
+    expect(mockHandleRequest).toHaveBeenCalledWith(
+      apiClient,
+      'test/100/items/?category=weapons',
+      'GET',
+      undefined,
+      false,
+    );
+  });
+
+  it('should append datasource to URL', async () => {
+    apiClient.setDatasource('singularity');
+    mockHandleRequest.mockResolvedValueOnce({
+      headers: { 'x-pages': '1' },
+      body: [],
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    for await (const _ of testClient.streamItems(100)) {
+      // consume
+    }
+
+    expect(mockHandleRequest).toHaveBeenCalledWith(
+      apiClient,
+      'test/100/items/?datasource=singularity',
+      'GET',
+      undefined,
+      false,
+    );
+  });
+
+  it('should pass requiresAuth through for auth endpoints', async () => {
+    mockHandleRequest.mockResolvedValueOnce({
+      headers: { 'x-pages': '1' },
+      body: [{ id: 1 }],
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    for await (const _ of testClient.streamSecureItems(999)) {
+      // consume
+    }
+
+    expect(mockHandleRequest).toHaveBeenCalledWith(
+      apiClient,
+      'secure/999/items/',
+      'GET',
+      undefined,
+      true,
+    );
+  });
+
+  it('should propagate errors to consumer', async () => {
+    mockHandleRequest.mockRejectedValueOnce(
+      Object.assign(new Error('Not Found'), { statusCode: 404 }),
+    );
+
+    await expect(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      for await (const _ of testClient.streamItems(100)) {
+        // consume
+      }
+    }).rejects.toMatchObject({ statusCode: 404 });
+  });
+
+  it('should report totalPages from response headers', async () => {
+    mockHandleRequest.mockResolvedValueOnce({
+      headers: { 'x-pages': '42' },
+      body: [{ id: 1 }],
+    });
+
+    const gen = testClient.streamItems(100);
+    const first = await gen.next();
+
+    expect(first.value!.totalPages).toBe(42);
+
+    await gen.return(undefined);
+  });
+
+  it('should handle datasource combined with query params', async () => {
+    apiClient.setDatasource('tranquility');
+    mockHandleRequest.mockResolvedValueOnce({
+      headers: { 'x-pages': '1' },
+      body: [],
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    for await (const _ of testClient.streamItems(100, 'ships')) {
+      // consume
+    }
+
+    expect(mockHandleRequest).toHaveBeenCalledWith(
+      apiClient,
+      'test/100/items/?category=ships&datasource=tranquility',
+      'GET',
+      undefined,
+      false,
+    );
+  });
+});

--- a/tests/tdd/market/MarketClient.streaming.test.ts
+++ b/tests/tdd/market/MarketClient.streaming.test.ts
@@ -1,0 +1,191 @@
+import { ApiClient } from '../../../src/core/ApiClient';
+import { MarketClient } from '../../../src/clients/MarketClient';
+import { RateLimiter } from '../../../src/core/rateLimiter/RateLimiter';
+import { PageResult } from '../../../src/core/pagination/AsyncPaginationIterator';
+import { MarketOrder } from '../../../src/types/api-responses';
+
+jest.mock('../../../src/core/ApiRequestHandler', () => {
+  const original = jest.requireActual('../../../src/core/ApiRequestHandler');
+  return {
+    ...original,
+    handleRequest: jest.fn(),
+  };
+});
+
+import { handleRequest } from '../../../src/core/ApiRequestHandler';
+const mockHandleRequest = handleRequest as jest.MockedFunction<
+  typeof handleRequest
+>;
+
+function mockOrder(overrides: Partial<MarketOrder> = {}): MarketOrder {
+  return {
+    order_id: 1,
+    type_id: 34,
+    location_id: 60003760,
+    volume_total: 1000,
+    volume_remain: 500,
+    min_volume: 1,
+    price: 5.5,
+    is_buy_order: false,
+    duration: 90,
+    issued: '2024-01-01T00:00:00Z',
+    range: 'region',
+    ...overrides,
+  };
+}
+
+describe('MarketClient streaming', () => {
+  let apiClient: ApiClient;
+  let marketClient: MarketClient;
+
+  beforeEach(() => {
+    mockHandleRequest.mockReset();
+    apiClient = new ApiClient('test', 'https://esi.evetech.net');
+    const rateLimiter = new RateLimiter();
+    rateLimiter.setTestMode(true);
+    apiClient.setRateLimiter(rateLimiter);
+    marketClient = new MarketClient(apiClient);
+  });
+
+  describe('streamMarketOrders', () => {
+    it('should build correct URL with order_type=all', async () => {
+      mockHandleRequest.mockResolvedValueOnce({
+        headers: { 'x-pages': '1' },
+        body: [mockOrder()],
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      for await (const _ of marketClient.streamMarketOrders(10000002)) {
+        // consume
+      }
+
+      expect(mockHandleRequest).toHaveBeenCalledWith(
+        apiClient,
+        'markets/10000002/orders/?order_type=all',
+        'GET',
+        undefined,
+        false,
+      );
+    });
+
+    it('should stream multiple pages of market orders', async () => {
+      const page1 = [mockOrder({ order_id: 1 }), mockOrder({ order_id: 2 })];
+      const page2 = [mockOrder({ order_id: 3 })];
+
+      mockHandleRequest
+        .mockResolvedValueOnce({
+          headers: { 'x-pages': '2' },
+          body: page1,
+        })
+        .mockResolvedValueOnce({
+          headers: { 'x-pages': '2' },
+          body: page2,
+        });
+
+      const pages: PageResult<MarketOrder>[] = [];
+      for await (const page of marketClient.streamMarketOrders(10000002)) {
+        pages.push(page);
+      }
+
+      expect(pages).toHaveLength(2);
+      expect(pages[0].data).toHaveLength(2);
+      expect(pages[0].data[0].order_id).toBe(1);
+      expect(pages[1].data).toHaveLength(1);
+      expect(pages[1].data[0].order_id).toBe(3);
+    });
+
+    it('should allow early termination', async () => {
+      mockHandleRequest
+        .mockResolvedValueOnce({
+          headers: { 'x-pages': '100' },
+          body: [mockOrder()],
+        })
+        .mockResolvedValueOnce({
+          headers: { 'x-pages': '100' },
+          body: [mockOrder()],
+        })
+        .mockResolvedValueOnce({
+          headers: { 'x-pages': '100' },
+          body: [mockOrder()],
+        });
+
+      let pagesConsumed = 0;
+      for await (const page of marketClient.streamMarketOrders(10000002)) {
+        pagesConsumed++;
+        if (page.page >= 3) break;
+      }
+
+      expect(pagesConsumed).toBe(3);
+      expect(mockHandleRequest).toHaveBeenCalledTimes(3);
+    });
+
+    it('should support aggregation during streaming', async () => {
+      const buyOrder = mockOrder({ is_buy_order: true, price: 10 });
+      const sellOrder = mockOrder({ is_buy_order: false, price: 20 });
+
+      mockHandleRequest.mockResolvedValueOnce({
+        headers: { 'x-pages': '1' },
+        body: [buyOrder, sellOrder],
+      });
+
+      let buyCount = 0;
+      let sellCount = 0;
+      for await (const page of marketClient.streamMarketOrders(10000002)) {
+        for (const order of page.data) {
+          if (order.is_buy_order) buyCount++;
+          else sellCount++;
+        }
+      }
+
+      expect(buyCount).toBe(1);
+      expect(sellCount).toBe(1);
+    });
+  });
+
+  describe('streamMarketTypes', () => {
+    it('should build correct URL', async () => {
+      mockHandleRequest.mockResolvedValueOnce({
+        headers: { 'x-pages': '1' },
+        body: [34, 35, 36],
+      });
+
+      const pages: PageResult<number>[] = [];
+      for await (const page of marketClient.streamMarketTypes(10000002)) {
+        pages.push(page);
+      }
+
+      expect(mockHandleRequest).toHaveBeenCalledWith(
+        apiClient,
+        'markets/10000002/types/',
+        'GET',
+        undefined,
+        false,
+      );
+      expect(pages[0].data).toEqual([34, 35, 36]);
+    });
+  });
+
+  describe('streamMarketOrdersInStructure', () => {
+    it('should build correct URL with structureId', async () => {
+      mockHandleRequest.mockResolvedValueOnce({
+        headers: { 'x-pages': '1' },
+        body: [mockOrder()],
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      for await (const _ of marketClient.streamMarketOrdersInStructure(
+        1234567890,
+      )) {
+        // consume
+      }
+
+      expect(mockHandleRequest).toHaveBeenCalledWith(
+        apiClient,
+        'markets/structures/1234567890/',
+        'GET',
+        undefined,
+        false,
+      );
+    });
+  });
+});

--- a/tests/tdd/market/MarketClient.streaming.test.ts
+++ b/tests/tdd/market/MarketClient.streaming.test.ts
@@ -8,13 +8,13 @@ jest.mock('../../../src/core/ApiRequestHandler', () => {
   const original = jest.requireActual('../../../src/core/ApiRequestHandler');
   return {
     ...original,
-    handleRequest: jest.fn(),
+    handleSinglePageRequest: jest.fn(),
   };
 });
 
-import { handleRequest } from '../../../src/core/ApiRequestHandler';
-const mockHandleRequest = handleRequest as jest.MockedFunction<
-  typeof handleRequest
+import { handleSinglePageRequest } from '../../../src/core/ApiRequestHandler';
+const mockHandleRequest = handleSinglePageRequest as jest.MockedFunction<
+  typeof handleSinglePageRequest
 >;
 
 function mockOrder(overrides: Partial<MarketOrder> = {}): MarketOrder {


### PR DESCRIPTION
## Summary

- **Streaming pagination** on domain clients via `stream*` methods that yield `PageResult<T>` one page at a time through `AsyncGenerator`, enabling backpressure and early termination for large paginated datasets
- Extracted `buildEndpointPath()` from `createClient.ts` as a shared URL-building utility used by both eager and streaming paths
- Added `streamEndpoint()` protected method on `BaseEsiClient` so custom domain clients can add streaming with minimal boilerplate
- 16 streaming methods across 5 domain clients: MarketClient (6), ContractsClient (3), WalletClient (3), AssetsClient (2), KillmailsClient (2)
- 30 new tests (buildEndpointPath: 13, streamEndpoint: 11, MarketClient.streaming: 6)
- Worked example (`npm run example:streaming`) with three demos: early stop, stream market types, stream all orders
- Bumps version to 5.3.0

## Test plan

- [x] `npx tsc --noEmit` — compiles clean
- [x] `npm test` — 112 suites, 2901 tests all passing
- [x] `npm run example:streaming` — runs against live ESI, streams pages with progress output
- [ ] Review streaming methods match endpoint definitions in each domain client
- [ ] Verify `buildEndpointPath` refactor didn't change `createClient.ts` behavior (existing tests cover this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)