### PR TITLE
docs: update guides with testing stats and add security guide

### DIFF
--- a/guides/ARCHITECTURE.md
+++ b/guides/ARCHITECTURE.md
@@ -453,45 +453,64 @@ graph LR
 
 ## 8. Test Architecture
 
+3,233 tests across 122 suites in 7 tiers. Coverage: 96.35% statements, 87.40% branches, 93.20% functions, 96.38% lines.
+
 ```mermaid
 graph TB
-    subgraph TestTypes["Test Types"]
-        TDD["TDD Unit Tests<br/>(tests/tdd/)"]
-        BDD["BDD Scenarios<br/>(tests/bdd-scenarios/)"]
+    subgraph TestTypes["Test Types (3,233 tests, 122 suites)"]
+        TDD["TDD Unit Tests<br/>(tests/tdd/ — 78 files, 2,784 tests)"]
+        BDD["BDD Scenarios<br/>(tests/bdd/ — 39 features, 335 tests)"]
+        IntMocked["Mocked Integration<br/>(full-stack.test.ts — 20 tests)"]
+        IntLive["Live Integration<br/>(3 files — 61 tests)"]
+        IntGated["Gated Auth<br/>(gated-auth.test.ts — 33 tests)"]
     end
 
     subgraph TDDTests["TDD Test Suites"]
         Core["Core Infrastructure<br/>ETagCache, RateLimiter,<br/>CircuitBreaker, Middleware,<br/>DI, TokenRefresh, Validation"]
         Clients["Domain Clients<br/>35 client test files<br/>(GET, POST, PUT, DELETE)"]
-        Integration["Integration Tests<br/>Pagination, ETag flow,<br/>Rate limit integration"]
+        Resilience["Resilience (12 tests)<br/>Rate limits, retry, dedup"]
+        Security["Security (23 tests)<br/>Token, HTTPS, injection"]
+        Config["Config Validation (33 tests)<br/>Builder, factory, shutdown"]
+        APISurface["API Surface (135 tests)<br/>Export snapshot detector"]
+        CrossCut["Cross-Cutting (15 tests)<br/>Diagnostics, middleware, logger"]
     end
 
     subgraph BDDTests["BDD Scenario Suites"]
-        DomainBDD["Domain Scenarios<br/>alliance, character, market,<br/>universe, wallet, ... (37)"]
+        DomainBDD["Domain Scenarios<br/>alliance, character, market,<br/>universe, wallet, ... (35)"]
         PerfBDD["Performance Scenarios<br/>Concurrency, memory,<br/>large datasets"]
         IntBDD["Integration Scenarios<br/>Cross-domain workflows"]
     end
 
+    subgraph LiveTests["Live Integration Suites"]
+        Smoke["Smoke Tests (40 tests)<br/>42 public endpoints"]
+        ClientInt["Client Integration (11 tests)<br/>EsiClient end-to-end"]
+        SpecContract["Spec Contract (10 tests)<br/>Swagger drift detection"]
+    end
+
     subgraph Coverage["Coverage Enforcement"]
-        Branches["Branches: 50%"]
-        Functions["Functions: 50%"]
-        Lines["Lines: 65%"]
-        Statements["Statements: 65%"]
+        Branches["Branches: 80% (actual 87.40%)"]
+        Functions["Functions: 75% (actual 93.20%)"]
+        Lines["Lines: 90% (actual 96.38%)"]
+        Statements["Statements: 90% (actual 96.35%)"]
     end
 
     subgraph Tools["Test Infrastructure"]
         Jest["Jest + ts-jest"]
         FetchMock["jest-fetch-mock"]
         Factory["TestDataFactory"]
+        CrossEnv["cross-env (Windows)"]
     end
 
     TDD --> TDDTests
     BDD --> BDDTests
+    IntLive --> LiveTests
     TDDTests --> Coverage
     BDDTests --> Coverage
 
     Jest --> TDD
     Jest --> BDD
+    Jest --> IntMocked
+    Jest --> IntLive
     FetchMock --> Core
     FetchMock --> Clients
     Factory --> BDDTests
@@ -499,6 +518,7 @@ graph TB
     style TestTypes fill:#e3f2fd,stroke:#1565c0
     style TDDTests fill:#e8f5e9,stroke:#2e7d32
     style BDDTests fill:#fff3e0,stroke:#e65100
+    style LiveTests fill:#e8eaf6,stroke:#283593
     style Coverage fill:#fce4ec,stroke:#c62828
     style Tools fill:#eceff1,stroke:#37474f
 ```

--- a/guides/SECURITY.md
+++ b/guides/SECURITY.md
@@ -1,0 +1,174 @@
+# Security Guide for ESI.ts
+
+## Security Policy
+
+### Supported Versions
+
+| Version | Supported |
+| ------- | --------- |
+| 5.x     | Yes       |
+| 4.x     | No        |
+| 3.x     | No        |
+
+### Reporting a Vulnerability
+
+If you discover a security vulnerability in ESI.ts, please report it responsibly. **Do not open a public GitHub issue for security vulnerabilities.**
+
+- **GitHub Security Advisories (preferred):** Use the [Security Advisories](https://github.com/lgriffin/ESI.ts/security/advisories/new) feature to report privately.
+- **Email:** Contact the maintainer directly via the email address listed on the [GitHub profile](https://github.com/lgriffin).
+
+Include a clear description, steps to reproduce, potential impact, and any suggested fixes.
+
+### Response Timeline
+
+| Severity         | Response               |
+| ---------------- | ---------------------- |
+| Acknowledgment   | Within 48 hours        |
+| Critical fix     | Within 7 days          |
+| Non-critical fix | Next scheduled release |
+
+## Built-in Security Measures
+
+ESI.ts implements several layers of security protection in the request pipeline.
+
+### Token Protection
+
+Tokens are only attached to requests that require authentication. Public ESI endpoints never receive an `Authorization` header, even when the client is configured with an access token.
+
+**How it works:** The `ApiRequestHandler` checks the endpoint's scope requirements before building headers. If the endpoint has no required scope, the token is omitted entirely — not sent and redacted, but never attached in the first place.
+
+**Test coverage:** `security.test.ts` — 23 tests verifying:
+
+- Token is not sent to public endpoints (`/status/`, `/alliances/`, etc.)
+- Token is sent only to authenticated endpoints (`/characters/{id}/wallet/`)
+- Token appears in the `Authorization: Bearer` header, not in query strings or URLs
+
+### HTTPS Enforcement
+
+All requests enforce HTTPS. The library rejects any base URL that does not use the `https://` scheme.
+
+**Test coverage:** `security.test.ts` validates that `http://` URLs are rejected at client construction time.
+
+### Host Allowlist (SSRF Protection)
+
+By default, outbound requests are restricted to known EVE Online ESI endpoints:
+
+- `esi.evetech.net`
+- `login.eveonline.com`
+
+Custom hosts require the `unsafeAllowCustomHost: true` flag, making SSRF bypass an explicit opt-in rather than a silent misconfiguration.
+
+**Test coverage:** `security.test.ts` validates that requests to non-allowlisted hosts are rejected unless the unsafe flag is set.
+
+### Path Parameter Injection Prevention
+
+All path parameters are validated before URL construction. The `validatePathParam()` function rejects values containing:
+
+- Path traversal sequences (`../`, `..\\`)
+- URL-encoded traversal (`%2f`, `%2e`)
+- Null bytes (`%00`)
+- Characters outside the expected alphanumeric + limited punctuation set
+
+**Test coverage:** `security.test.ts` validates that crafted path parameters (e.g., `../../etc/passwd`, `123%2f456`) are rejected.
+
+### Query Parameter Validation
+
+Query parameters are validated for:
+
+- Maximum length (prevents excessively long query strings)
+- Rejection of `NaN`, `Infinity`, and `null` values that could cause unexpected behavior
+- Type coercion safety
+
+**Test coverage:** `security.test.ts` validates rejection of invalid query parameter values.
+
+### URL Sanitization in Logs
+
+API tokens and sensitive parameters are redacted from logged URLs and error messages. If an error occurs during an authenticated request, the token value is replaced with `[REDACTED]` in any output.
+
+## Security Test Suite
+
+The dedicated security test file (`tests/tdd/core/security.test.ts`) contains 23 tests organized into the following categories:
+
+| Category                 | Tests | What's Validated                                                    |
+| ------------------------ | ----: | ------------------------------------------------------------------- |
+| Token leakage prevention |     4 | Token not sent to public endpoints, sent only to auth endpoints     |
+| HTTPS enforcement        |     2 | HTTP URLs rejected, HTTPS required                                  |
+| Host allowlist           |     3 | Non-ESI hosts rejected, allowlisted hosts accepted, unsafe override |
+| Path injection           |     5 | Path traversal, encoded traversal, null bytes, special characters   |
+| Query parameter limits   |     4 | Length limits, NaN/Infinity rejection, null handling                |
+| Input sanitization       |     5 | Combined injection attempts, header injection, type coercion        |
+
+### Running Security Tests
+
+```bash
+# Run security tests specifically
+npx jest --config jest.unit.config.cjs tests/tdd/core/security.test.ts
+
+# Run all unit tests (includes security)
+npm test
+```
+
+## Dependency Security
+
+### Automated Scanning
+
+- **npm audit** runs as part of `npm run check:all` and CI validation
+- **Dependabot** monitors dependencies for known CVEs and creates automated PRs
+- **GitHub Security Advisories** are enabled on the repository
+
+### What Counts as a Security Issue
+
+| Category            | Example                                                            | Report via        |
+| ------------------- | ------------------------------------------------------------------ | ----------------- |
+| Credential exposure | API tokens leaked in logs, URLs, or error messages                 | Security Advisory |
+| Injection           | Code injection, command injection, header injection via user input | Security Advisory |
+| SSRF bypass         | Circumventing host allowlist to reach unintended endpoints         | Security Advisory |
+| Path traversal      | Accessing resources outside intended scope via crafted input       | Security Advisory |
+| Dependency CVE      | Known CVE in a direct dependency exploitable in this context       | Security Advisory |
+| General bugs        | Non-security bugs, typos, feature requests                         | GitHub Issues     |
+
+## Scope
+
+This policy applies to the ESI.ts library itself (`@lgriffin/esi.ts`). Vulnerabilities in the upstream EVE Online ESI API should be reported to CCP Games directly.
+
+## Security Architecture
+
+```
+Request Pipeline Security Checks
+─────────────────────────────────────────────────────
+
+Consumer Request
+       │
+       ▼
+┌──────────────────┐
+│  HTTPS Check     │  Reject http:// base URLs
+└──────┬───────────┘
+       │
+       ▼
+┌──────────────────┐
+│  Host Allowlist   │  Only esi.evetech.net, login.eveonline.com
+└──────┬───────────┘  (unless unsafeAllowCustomHost: true)
+       │
+       ▼
+┌──────────────────┐
+│  Path Validation  │  Reject traversal, null bytes, encoded attacks
+└──────┬───────────┘
+       │
+       ▼
+┌──────────────────┐
+│  Query Validation │  Length limits, reject NaN/Infinity/null
+└──────┬───────────┘
+       │
+       ▼
+┌──────────────────┐
+│  Token Gating     │  Only attach token if endpoint requires auth scope
+└──────┬───────────┘
+       │
+       ▼
+┌──────────────────┐
+│  URL Sanitization │  Redact tokens from logs and error messages
+└──────┬───────────┘
+       │
+       ▼
+    fetch()
+```

--- a/guides/TESTING.md
+++ b/guides/TESTING.md
@@ -1,10 +1,49 @@
 # Testing Guide for ESI.ts
 
+## Overview
+
+ESI.ts uses a multi-tier testing strategy to ensure correctness at every level — from individual functions to live API contract validation.
+
+| Tier                 |     Tests |  Suites | Purpose                                                                     |
+| -------------------- | --------: | ------: | --------------------------------------------------------------------------- |
+| TDD (unit)           |     2,784 |      78 | Per-module unit tests with mocked HTTP                                      |
+| BDD (behavioral)     |       335 |      39 | Gherkin-style scenarios covering user-facing behaviors                      |
+| Integration (mocked) |        20 |       1 | Full request lifecycle with mocked fetch                                    |
+| Integration (live)   |        61 |       3 | Real HTTP against live ESI — smoke tests, client integration, spec contract |
+| Integration (gated)  |        33 |       1 | Authenticated endpoints with real OAuth token                               |
+| **Total**            | **3,233** | **122** |                                                                             |
+
+## Coverage
+
+Current coverage (unit + BDD, measured by Jest):
+
+| Metric     |  Value | Threshold |
+| ---------- | -----: | --------: |
+| Statements | 96.35% |       90% |
+| Branches   | 87.40% |       80% |
+| Functions  | 93.20% |       75% |
+| Lines      | 96.38% |       90% |
+
+Coverage is collected from `src/**/*.ts` (excluding `.d.ts` and `src/types/`).
+
+### Per-File Test Breakdown (New Test Suites)
+
+| File                          | Tests | Category                                        |
+| ----------------------------- | ----: | ----------------------------------------------- |
+| `resilience.test.ts`          |    12 | Rate limits, malformed responses, retry, dedup  |
+| `security.test.ts`            |    23 | Token leakage, HTTPS, host allowlist, injection |
+| `configValidation.test.ts`    |    33 | Builder, factory, config combos, shutdown       |
+| `publicApiSurface.test.ts`    |   135 | Export snapshot — breaking-change detector      |
+| `crossCutting.test.ts`        |    15 | Diagnostics, middleware ordering, logger        |
+| `esi-spec-contract.test.ts`   |    10 | Live swagger drift detection                    |
+| `client-integration.test.ts`  |    11 | Full EsiClient against live ESI                 |
+| `live-esi.test.ts` (expanded) |    40 | Smoke tests across 42 endpoints                 |
+
 ## Test Structure
 
 ```
 tests/
-├── tdd/                          # Unit tests (one per domain client)
+├── tdd/                          # Unit tests (one per domain client + core)
 │   ├── access-lists/AccessListsClient.test.ts
 │   ├── alliances/AllianceClient.test.ts
 │   ├── assets/AssetsClient.test.ts
@@ -18,30 +57,37 @@ tests/
 │   │   ├── ApiRequestHandler.test.ts
 │   │   ├── AsyncPaginationIterator.test.ts
 │   │   ├── BatchRequestHandler.test.ts
+│   │   ├── buildEndpointPath.test.ts
+│   │   ├── circuitBreaker.test.ts
+│   │   ├── configValidation.test.ts        # Config combos, builder, factory
+│   │   ├── constants.test.ts
+│   │   ├── createClient.test.ts
+│   │   ├── crossCutting.test.ts            # Diagnostics, middleware, logger
 │   │   ├── CursorPaginationHandler.test.ts
 │   │   ├── CursorPaginationIntegration.test.ts
-│   │   ├── ETagCacheManager.test.ts
-│   │   ├── ETagIntegration.test.ts
+│   │   ├── dependencyInjection.test.ts
+│   │   ├── endpointDefinitions.test.ts
 │   │   ├── EsiDiagnostics.test.ts
 │   │   ├── EsiError.test.ts
+│   │   ├── ETagCacheManager.test.ts
+│   │   ├── ETagIntegration.test.ts
+│   │   ├── headersUtil.test.ts
+│   │   ├── middleware.test.ts
 │   │   ├── PaginationHandler.test.ts
 │   │   ├── PaginationIntegration.test.ts
+│   │   ├── publicApiSurface.test.ts        # 135 export snapshot tests
 │   │   ├── RateLimitIntegration.test.ts
 │   │   ├── RateLimiter.test.ts
 │   │   ├── RequestDeduplicator.test.ts
+│   │   ├── resilience.test.ts              # Rate limit, retry, dedup
 │   │   ├── RetryBackoff.test.ts
+│   │   ├── security.test.ts               # Token, HTTPS, injection
 │   │   ├── SpecAwareCaching.test.ts
+│   │   ├── streamEndpoint.test.ts
 │   │   ├── Timeout.test.ts
-│   │   ├── WithMetadata.test.ts
-│   │   ├── circuitBreaker.test.ts
-│   │   ├── constants.test.ts
-│   │   ├── createClient.test.ts
-│   │   ├── dependencyInjection.test.ts
-│   │   ├── endpointDefinitions.test.ts
-│   │   ├── headersUtil.test.ts
-│   │   ├── middleware.test.ts
 │   │   ├── tokenRefresh.test.ts
-│   │   └── validation.test.ts
+│   │   ├── validation.test.ts
+│   │   └── WithMetadata.test.ts
 │   ├── corporations/CorporationsClient.test.ts
 │   ├── dogma/DogmaClient.test.ts
 │   ├── factions/FactionClient.test.ts
@@ -54,7 +100,9 @@ tests/
 │   ├── location/LocationClient.test.ts
 │   ├── loyalty/LoyaltyClient.test.ts
 │   ├── mail/MailClient.test.ts
-│   ├── market/MarketClient.test.ts
+│   ├── market/
+│   │   ├── MarketClient.test.ts
+│   │   └── MarketClient.streaming.test.ts
 │   ├── mercenary/MercenaryClient.test.ts
 │   ├── meta/MetaClient.test.ts
 │   ├── pi/PiClient.test.ts
@@ -68,61 +116,43 @@ tests/
 │   ├── universe/UniverseClient.test.ts
 │   ├── wallet/WalletClient.test.ts
 │   └── wars/WarsClient.test.ts
-├── bdd-scenarios/                # BDD scenario tests
-│   ├── core/
-│   │   ├── bdd-access-lists.test.ts
-│   │   ├── bdd-alliance.test.ts
-│   │   ├── bdd-assets.test.ts
-│   │   ├── bdd-calendar.test.ts
-│   │   ├── bdd-character.test.ts
-│   │   ├── bdd-clones.test.ts
-│   │   ├── bdd-contacts.test.ts
-│   │   ├── bdd-contracts.test.ts
-│   │   ├── bdd-corporation.test.ts
-│   │   ├── bdd-dogma.test.ts
-│   │   ├── bdd-etag-caching.test.ts
-│   │   ├── bdd-factions.test.ts
-│   │   ├── bdd-fittings.test.ts
-│   │   ├── bdd-fleets.test.ts
-│   │   ├── bdd-freelance-jobs.test.ts
-│   │   ├── bdd-incursions.test.ts
-│   │   ├── bdd-industry.test.ts
-│   │   ├── bdd-insurance.test.ts
-│   │   ├── bdd-killmails.test.ts
-│   │   ├── bdd-location.test.ts
-│   │   ├── bdd-loyalty.test.ts
-│   │   ├── bdd-mail.test.ts
-│   │   ├── bdd-market.test.ts
-│   │   ├── bdd-mercenary.test.ts
-│   │   ├── bdd-meta.test.ts
-│   │   ├── bdd-pi.test.ts
-│   │   ├── bdd-response-headers.test.ts
-│   │   ├── bdd-route.test.ts
-│   │   ├── bdd-search.test.ts
-│   │   ├── bdd-skills.test.ts
-│   │   ├── bdd-skyhooks.test.ts
-│   │   ├── bdd-sovereignty.test.ts
-│   │   ├── bdd-status.test.ts
-│   │   ├── bdd-ui.test.ts
-│   │   ├── bdd-universe.test.ts
-│   │   ├── bdd-wallet.test.ts
-│   │   └── bdd-wars.test.ts
-│   ├── integration/
-│   │   └── bdd-integration-workflows.test.ts
-│   └── performance/
-│       └── bdd-performance.test.ts
-├── bdd/
-│   └── simple-bdd-demo.test.ts
-└── integration/                  # Integration tests (real ESI API)
-    ├── full-stack.test.ts        # Full-stack integration workflows
-    ├── gated-auth.test.ts        # Tier 1: authenticated endpoint stubs
-    └── live-esi.test.ts          # Tier 2: live ESI API smoke tests
+├── bdd/                          # BDD tests (Gherkin features + step definitions)
+│   ├── features/
+│   │   ├── core/                 # 35 domain feature files
+│   │   │   ├── alliance.feature
+│   │   │   ├── market.feature
+│   │   │   ├── universe.feature
+│   │   │   └── ... (35 total)
+│   │   ├── integration/
+│   │   │   └── integration-workflows.feature
+│   │   └── performance/
+│   │       └── performance.feature
+│   ├── step-definitions/
+│   │   ├── core/                 # 35 domain step files
+│   │   │   ├── alliance.steps.ts
+│   │   │   ├── market.steps.ts
+│   │   │   └── ... (35 total)
+│   │   ├── integration/
+│   │   │   └── integration-workflows.steps.ts
+│   │   ├── performance/
+│   │   │   └── performance.steps.ts
+│   │   └── shared/
+│   │       └── common.ts
+│   └── support/
+│       └── world.ts
+└── integration/                  # Integration tests
+    ├── full-stack.test.ts        # Mocked full-lifecycle (20 tests)
+    ├── live-esi.test.ts          # Live API smoke tests (40 tests)
+    ├── client-integration.test.ts # Live EsiClient integration (11 tests)
+    ├── esi-spec-contract.test.ts  # ESI spec drift detection (10 tests)
+    ├── gated-auth.test.ts        # Authenticated endpoint tests (33 tests)
+    └── gated-auth-setup.ts       # Auth test setup/helpers
 ```
 
 ## Running Tests
 
 ```bash
-# All unit + BDD tests — 104 suites, 2785 tests
+# All unit + BDD tests (default) — 117 suites, 3,119 tests
 npm test
 
 # Watch mode for development
@@ -149,68 +179,178 @@ npm run bdd:performance
 
 # All other BDD domains are also runnable individually:
 # npm run bdd:access-lists, bdd:assets, bdd:calendar, bdd:clones,
-# bdd:contacts, bdd:contracts, bdd:dogma, bdd:etag-caching,
-# bdd:factions, bdd:fittings, bdd:fleets, bdd:freelance,
-# bdd:incursions, bdd:industry, bdd:insurance, bdd:killmails,
-# bdd:location, bdd:loyalty, bdd:mail, bdd:mercenary, bdd:meta,
-# bdd:pi, bdd:route, bdd:search, bdd:skills, bdd:skyhooks,
-# bdd:sovereignty, bdd:status, bdd:ui, bdd:wallet, bdd:wars
+# npm run bdd:contacts, bdd:contracts, bdd:dogma, bdd:etag-caching,
+# npm run bdd:factions, bdd:fittings, bdd:fleets, bdd:freelance,
+# npm run bdd:incursions, bdd:industry, bdd:insurance, bdd:killmails,
+# npm run bdd:location, bdd:loyalty, bdd:mail, bdd:mercenary, bdd:meta,
+# npm run bdd:pi, bdd:route, bdd:search, bdd:skills, bdd:skyhooks,
+# npm run bdd:sovereignty, bdd:status, bdd:ui, bdd:wallet, bdd:wars
 ```
+
+## Test Tiers
+
+### Tier 1: TDD Unit Tests
+
+**Location:** `tests/tdd/`
+**Config:** `jest.unit.config.cjs`
+**Run:** `npm test`
+
+78 test files covering:
+
+- **Domain clients** (35 files) — One per ESI API module (AllianceClient, MarketClient, etc.). Each mocks `fetch` and verifies correct URL construction, response parsing, and type safety.
+- **Core infrastructure** (35+ files) — Circuit breaker, rate limiter, pagination (offset + cursor), ETag cache, request deduplication, retry with backoff, middleware pipeline, endpoint definitions, validation, error handling, timeout behavior, diagnostics, and configuration.
+- **Resilience** (`resilience.test.ts`) — 429/420 rate limit handling, malformed JSON, truncated responses, empty bodies, stale cache fallback on 5xx, retry with backoff, network timeout, request deduplication under concurrent load.
+- **Security** (`security.test.ts`) — Token not leaked to public endpoints, token sent only to authenticated endpoints, HTTPS enforcement, host allowlist, path parameter injection prevention, query parameter length limits, NaN/Infinity rejection.
+- **Configuration** (`configValidation.test.ts`) — Default config, all features enabled simultaneously, EsiClientBuilder selective/full client registration, EsiApiFactory methods, token provider, datasource/language config, shutdown idempotency, legacy retry config.
+- **Public API Surface** (`publicApiSurface.test.ts`) — Snapshot of all 35 domain client exports, 21 class/function exports, 8 type guard functions, 35 domain accessors on EsiClient, and 13 EsiClient methods. Acts as a contract — if a public export is accidentally removed, this test breaks.
+- **Cross-Cutting** (`crossCutting.test.ts`) — Diagnostics accuracy (cache stats, circuit breaker stats, clearCache, resetCircuitBreaker), middleware ordering (request before response, registration order, remove at runtime, constructor config), and custom logger integration.
+
+### Tier 2: BDD Behavioral Tests
+
+**Location:** `tests/bdd/`
+**Config:** `jest.unit.config.cjs` (same runner as TDD)
+**Run:** `npm run bdd`
+
+39 feature files written in Gherkin, with matching step definitions. Covers:
+
+- All 35 domain API modules (alliance, market, universe, etc.)
+- Cross-cutting behaviors: ETag caching, response header extraction, deprecation warnings
+- Integration workflows: character profile assembly, market analysis, fleet operations
+- Performance scenarios: concurrency, large datasets, memory efficiency
+
+Individual modules can be run selectively: `npm run bdd:market`, `npm run bdd:alliance`, etc.
+
+#### BDD Test Categories
+
+- **Core** (`bdd/features/core/`): Domain-specific scenarios for all 35 domain clients plus cross-cutting concerns (ETag caching, response headers)
+- **Integration** (`bdd/features/integration/`): Cross-domain workflows — character profile assembly, market analysis, fleet operations
+- **Performance** (`bdd/features/performance/`): Concurrent requests, large dataset handling, memory efficiency, error handling performance
+
+### Tier 3: Integration Tests (Mocked)
+
+**Location:** `tests/integration/full-stack.test.ts`
+**Config:** `jest.integration.config.cjs`
+**Run:** `npm run test:integration`
+
+20 tests verifying the full request lifecycle with mocked fetch:
+
+- EsiClient → StatusClient → ApiClient → ApiRequestHandler → fetch (mocked)
+- ETag cache round-trip (first request caches, second returns cached)
+- Circuit breaker trip and recovery
+- Middleware pipeline (request/response interceptors, ordering, removal)
+- Token refresh flow (401 → refresh → retry)
+- Pagination assembly (multi-page into single array)
+- Error propagation (404, 403, stale cache on 5xx)
+- Client creation patterns (constructor, builder, factory)
+- DI isolation (separate caches per client)
+
+### Tier 4: Live API Smoke Tests
+
+**Location:** `tests/integration/live-esi.test.ts`
+**Run:** `ESI_LIVE_TESTS=true npm run test:integration`
+
+40 tests making real HTTP requests to `https://esi.evetech.net/latest/`:
+
+| Category           | Tests | Endpoints Tested                                                                                                                                                                                                                                                                                                        |
+| ------------------ | ----: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Status             |     1 | `/status/`                                                                                                                                                                                                                                                                                                              |
+| Alliances          |     2 | `/alliances/`, `/alliances/{id}/`                                                                                                                                                                                                                                                                                       |
+| Market             |     5 | `/markets/prices/`, `/markets/{region}/history/`, `/markets/{region}/orders/`, `/markets/{region}/types/`, `/markets/groups/`                                                                                                                                                                                           |
+| Universe           |    13 | `/universe/types/`, `/universe/types/{id}/`, `/universe/systems/{id}/`, `/universe/categories/`, `/universe/regions/`, `/universe/constellations/`, `/universe/stations/{id}/`, `/universe/groups/`, `/universe/races/`, `/universe/bloodlines/`, `/universe/ancestries/`, `/universe/factions/`, `/universe/graphics/` |
+| Dogma              |     3 | `/dogma/attributes/`, `/dogma/effects/`, `/dogma/attributes/{id}/`                                                                                                                                                                                                                                                      |
+| Wars               |     2 | `/wars/`, `/wars/{id}/`                                                                                                                                                                                                                                                                                                 |
+| Industry           |     2 | `/industry/systems/`, `/industry/facilities/`                                                                                                                                                                                                                                                                           |
+| Insurance          |     1 | `/insurance/prices/`                                                                                                                                                                                                                                                                                                    |
+| Incursions         |     1 | `/incursions/`                                                                                                                                                                                                                                                                                                          |
+| Sovereignty        |     3 | `/sovereignty/campaigns/`, `/sovereignty/map/`, `/sovereignty/structures/`                                                                                                                                                                                                                                              |
+| Route              |     1 | `/route/{origin}/{destination}/`                                                                                                                                                                                                                                                                                        |
+| Faction Warfare    |     4 | `/fw/stats/`, `/fw/wars/`, `/fw/systems/`, `/fw/leaderboards/`                                                                                                                                                                                                                                                          |
+| Killmails          |     1 | `/killmails/{id}/{hash}/`                                                                                                                                                                                                                                                                                               |
+| Rate Limit Headers |     1 | Validates `x-ratelimit-*` headers                                                                                                                                                                                                                                                                                       |
+
+Note: Opportunities endpoints (`/opportunities/groups/`, `/opportunities/tasks/`) were removed — CCP has retired these from the ESI spec.
+
+Each test validates HTTP 200, response shape (required properties, correct types), and array/object structure.
+
+### Tier 5: Client Integration Tests (Live)
+
+**Location:** `tests/integration/client-integration.test.ts`
+**Run:** `ESI_LIVE_TESTS=true npm run test:integration`
+
+11 tests using the actual `EsiClient` against live ESI (no mocks):
+
+- Full-stack status, market prices, alliance info, universe type lookups
+- ETag cache round-trip with real responses
+- Rate limit tracking with real headers
+- Multi-page pagination assembly (universe/types — 30k+ items)
+- Error handling (404 for non-existent alliance)
+- Route calculation (Jita → Amarr)
+- Diagnostics reporting after real requests
+
+### Tier 6: ESI Spec Contract Tests (Live)
+
+**Location:** `tests/integration/esi-spec-contract.test.ts`
+**Run:** `ESI_LIVE_TESTS=true npm run test:integration`
+
+10 tests that fetch the live ESI swagger spec and validate:
+
+- **Endpoint coverage** — Phantom endpoints, HTTP method mismatches, and uncovered spec endpoints are reported as warnings (known drift from newer EVE features not yet in public spec)
+- **Type drift** — Missing fields and optionality mismatches are reported as warnings (known gap: ~45 fields, ~14 optionality mismatches)
+- **Cache TTL drift** — `esi-cache-ttls.generated.ts` matches `x-cached-seconds` in live spec (**hard fail** — indicates stale generated files)
+- **Scope drift** — `esi-scopes.generated.ts` matches security requirements in live spec (**hard fail** — indicates stale generated files)
+
+Known-drift tests warn rather than fail because the discrepancies are tracked debt, not regressions. Cache TTL and scope drift remain hard failures because they indicate the generated files need regeneration (`npm run generate:types`).
+
+### Tier 7: Gated Auth Tests (Live)
+
+**Location:** `tests/integration/gated-auth.test.ts`
+**Run:** `ESI_GATED_TESTS=true ESI_ACCESS_TOKEN=... npm run test:integration:gated`
+
+33 tests for authenticated endpoints using a real OAuth token:
+
+- Location, Skills, Wallet, Assets, Characters, Clones, Contacts, Killmails, Mail, Fittings, Industry, Market (auth), Loyalty, Contracts, Calendar, Search, Faction Warfare
 
 ## Integration Tests
 
 Integration tests live in `tests/integration/` and hit the real ESI API. They are **not** part of the default `npm test` run and require a separate config.
 
 ```bash
-# Run integration tests
-npx jest --config jest.integration.config.cjs
+# Mocked integration tests (no network required)
+npm run test:integration
+
+# Live smoke tests (requires network)
+ESI_LIVE_TESTS=true npm run test:integration
+
+# On Windows (PowerShell), use cross-env:
+npx cross-env ESI_LIVE_TESTS=true npm run test:integration
+
+# Authenticated endpoint tests (requires OAuth token)
+ESI_GATED_TESTS=true ESI_ACCESS_TOKEN=<token> npm run test:integration:gated
+
+# On Windows:
+npx cross-env ESI_GATED_TESTS=true ESI_ACCESS_TOKEN=<token> npm run test:integration:gated
 ```
 
-### Tier 1: Gated Auth Tests (`gated-auth.test.ts`)
-
-Full-stack integration tests that exercise the real request pipeline (rate limiter, circuit breaker, middleware, ETag caching) against live ESI endpoints. These use public endpoints that don't require authentication.
-
-**What they cover:**
-
-- Rate limiter throttling with real ESI rate limit headers
-- ETag cache hit/miss behavior with real `304 Not Modified` responses
-- Circuit breaker state transitions with real server errors
-- Middleware request/response interception in the live pipeline
-- Error handling with real `404`, `400` responses
+### Running Specific Integration Suites
 
 ```bash
-# Run Tier 1 only
+# Mocked full-stack only
+npx jest --config jest.integration.config.cjs --testPathPattern=full-stack
+
+# Live smoke tests only
+npx jest --config jest.integration.config.cjs --testPathPattern=live-esi
+
+# Client integration only
+npx jest --config jest.integration.config.cjs --testPathPattern=client-integration
+
+# Spec contract only
+npx jest --config jest.integration.config.cjs --testPathPattern=esi-spec-contract
+
+# Gated auth only
 npx jest --config jest.integration.config.cjs --testPathPattern=gated-auth
 ```
 
-### Tier 2: Live ESI Smoke Tests (`live-esi.test.ts`)
-
-Lightweight smoke tests that verify the library can talk to real ESI and get correct response shapes. Designed to catch regressions that mocks wouldn't surface (e.g. ESI schema changes, header format changes).
-
-**What they cover:**
-
-- Server status endpoint returns valid player count and version
-- Alliance lookup returns expected fields
-- Market prices returns array of type/price pairs
-- Character info returns expected fields
-- Universe system lookup returns valid system data
-- 404 handling for nonexistent resources
-
-```bash
-# Run Tier 2 only
-npx jest --config jest.integration.config.cjs --testPathPattern=live-esi
-```
-
-### Full-Stack Integration (`full-stack.test.ts`)
-
-End-to-end workflows that exercise multiple clients together through the full request pipeline.
-
-```bash
-# Run full-stack only
-npx jest --config jest.integration.config.cjs --testPathPattern=full-stack
-```
-
-**Note:** Integration tests are rate-limited and have longer timeouts. They may fail if ESI is experiencing downtime. CI runs them on a schedule rather than on every push.
+**Note:** Integration tests are rate-limited and have longer timeouts (30s). They may fail if ESI is experiencing downtime. CI runs them on a schedule rather than on every push.
 
 ### Live API Verification
 
@@ -258,7 +398,7 @@ npm run example:token-refresh      # Token refresh flow demo
 Two Jest configs drive the test suites:
 
 - **Unit + BDD**: `jest.unit.config.cjs` — runs TDD and BDD tests with `jest-fetch-mock`
-- **Integration**: `jest.integration.config.cjs` — runs integration tests against live ESI
+- **Integration**: `jest.integration.config.cjs` — runs integration tests against live ESI (30s timeout)
 
 Common setup:
 
@@ -267,7 +407,7 @@ Common setup:
 
 ### Mocking
 
-All unit and BDD tests use [jest-fetch-mock](https://github.com/jefflau/jest-fetch-mock) to intercept `fetch` calls. No real HTTP requests are made during tests.
+All unit and BDD tests use [jest-fetch-mock](https://github.com/jefflau/jest-fetch-mock) to intercept `fetch` calls. No real HTTP requests are made during unit/BDD tests.
 
 ```typescript
 import fetchMock from 'jest-fetch-mock';
@@ -422,13 +562,25 @@ describe('AllianceClient', () => {
 
 ## BDD Test Pattern
 
-BDD tests use `EsiClient` with `jest.spyOn` to mock at the client method level. Tests follow a Given/When/Then narrative structure.
+BDD tests use proper Gherkin `.feature` files with matching step definition files using `jest-cucumber`.
+
+**Feature file** (`tests/bdd/features/core/alliance.feature`):
+
+```gherkin
+Feature: Alliance API
+  Scenario: Get alliance details for valid ID
+    Given a valid alliance ID
+    When I request alliance details
+    Then I receive alliance information with name and ticker
+```
+
+**Step definitions** (`tests/bdd/step-definitions/core/alliance.steps.ts`):
 
 ```typescript
 import { EsiClient } from '../../../src/EsiClient';
 import { TestDataFactory } from '../../../src/testing/TestDataFactory';
 
-describe('Feature: Retrieve Alliance Information', () => {
+describe('Feature: Alliance API', () => {
   let client: EsiClient;
 
   beforeEach(() => {
@@ -437,7 +589,6 @@ describe('Feature: Retrieve Alliance Information', () => {
 
   describe('Scenario: Get alliance details for valid ID', () => {
     it('Given a valid alliance ID, When I request details, Then I receive alliance info', async () => {
-      // Given
       const expected = TestDataFactory.createAllianceInfo({
         name: 'Goonswarm Federation',
       });
@@ -445,22 +596,14 @@ describe('Feature: Retrieve Alliance Information', () => {
         .spyOn(client.alliance, 'getAllianceById')
         .mockResolvedValue(expected);
 
-      // When
       const result = await client.alliance.getAllianceById(99005338);
 
-      // Then
       expect(result.name).toBe('Goonswarm Federation');
       expect(result).toHaveProperty('ticker');
     });
   });
 });
 ```
-
-### BDD Test Categories
-
-- **Core** (`bdd-scenarios/core/`): Domain-specific scenarios for all 35 domain clients plus cross-cutting concerns (ETag caching, response headers)
-- **Integration** (`bdd-scenarios/integration/`): Cross-domain workflows — character profile assembly, market analysis, fleet operations
-- **Performance** (`bdd-scenarios/performance/`): Concurrent requests, large dataset handling, memory efficiency, error handling performance
 
 ## Error Handling in Tests
 
@@ -480,14 +623,57 @@ const error = TestDataFactory.createError(429, 'Rate limit exceeded');
 jest.spyOn(client.alliance, 'getAllianceById').mockRejectedValue(error);
 ```
 
+## Test Architecture Decisions
+
+### Why seven tiers?
+
+- **TDD unit tests** — fast, deterministic, cover every code path with mocked fetch. Run on every push.
+- **BDD behavioral tests** — Gherkin scenarios readable by non-engineers, verify user-facing behaviors. Run on every push.
+- **Mocked integration** (`full-stack.test.ts`) — verifies the full request pipeline (cache → rate limit → circuit breaker → fetch → middleware) with deterministic mocked responses. Run on every push.
+- **Live smoke tests** (`live-esi.test.ts`) — catches URL construction bugs, response shape changes, and real HTTP behavior that mocks can't replicate. Run on-demand or scheduled.
+- **Client integration** (`client-integration.test.ts`) — verifies the full `EsiClient` facade works end-to-end against live ESI, including pagination and ETag caching. Run on-demand.
+- **Spec contract tests** (`esi-spec-contract.test.ts`) — catches API drift by comparing the codebase against the live ESI swagger spec before it causes runtime failures. Run weekly.
+- **Gated auth tests** (`gated-auth.test.ts`) — verifies authenticated endpoints with a real OAuth token. Run weekly with token refresh.
+
+### Why both TDD and BDD?
+
+TDD tests cover implementation details (internal functions, edge cases, error paths). BDD tests describe user-facing behaviors in Gherkin that can be read by non-engineers. The overlap is intentional — TDD catches the how, BDD verifies the what.
+
+### Why snapshot the public API surface?
+
+`publicApiSurface.test.ts` acts as a breaking-change detector. If someone renames a method, removes an export, or changes a class hierarchy, this test fails immediately — before the change ships as a semver-violating release.
+
 ## Adding New Tests
 
 1. **TDD test**: Create `tests/tdd/<domain>/<ClientName>.test.ts`. Mock fetch responses, call client methods, assert results.
-2. **BDD test**: Add scenarios to existing files in `tests/bdd-scenarios/core/` or create new ones. Use `jest.spyOn` on `EsiClient` properties.
+2. **BDD test**: Add a `.feature` file in `tests/bdd/features/core/` and a matching `.steps.ts` in `tests/bdd/step-definitions/core/`. Use `jest.spyOn` on `EsiClient` properties.
 3. **Integration test**: Add to `tests/integration/`. Use real fetch (no mocks). Keep tests idempotent and read-only against ESI.
 4. **Test data**: Add factory methods to `src/testing/TestDataFactory.ts` if new response types are needed.
 
 Unit and BDD tests run through `jest.unit.config.cjs`. Integration tests use `jest.integration.config.cjs`.
+
+## Gaps and Future Work
+
+### Known gaps
+
+| Gap                      | Severity | Notes                                                                                                                     |
+| ------------------------ | -------- | ------------------------------------------------------------------------------------------------------------------------- |
+| Phantom endpoints        | Low      | 17 codebase endpoints not yet in public ESI spec (access-lists, freelance-jobs, mercenary, skyhooks — newer EVE features) |
+| Type drift               | Medium   | ~45 fields in spec not yet in hand-written types; ~14 optionality mismatches                                              |
+| Route method mismatch    | Low      | Route endpoint is POST in code but GET in spec — needs investigation                                                      |
+| No chaos/fault injection | Low      | No tests for partial network failures, DNS resolution failures, or TLS errors                                             |
+| No load/soak testing     | Low      | Performance BDD tests use mocks; no real-world latency benchmarking                                                       |
+| Corporate auth endpoints | Medium   | Gated tests only cover character-level auth, not corporation director endpoints                                           |
+
+### Recommended CI schedule
+
+| Job                      | Frequency                   | Config                                                                                |
+| ------------------------ | --------------------------- | ------------------------------------------------------------------------------------- |
+| Unit + BDD               | Every push                  | `npm test`                                                                            |
+| Mocked integration       | Every push                  | `npm run test:integration`                                                            |
+| Live smoke tests         | Daily/weekly                | `ESI_LIVE_TESTS=true npm run test:integration`                                        |
+| Spec contract validation | Weekly                      | `ESI_LIVE_TESTS=true npm run test:integration -- --testPathPattern=esi-spec-contract` |
+| Gated auth tests         | Weekly (with token refresh) | `ESI_GATED_TESTS=true npm run test:integration:gated`                                 |
 
 ## Debugging
 
@@ -501,3 +687,34 @@ npx jest --config jest.unit.config.cjs --testNamePattern="should return valid al
 # Debug with Node inspector
 node --inspect-brk node_modules/.bin/jest --config jest.unit.config.cjs --runInBand
 ```
+
+## Other Commands
+
+```bash
+# Full validation (lint + format + build + test + ESI validation)
+npm run check:all
+
+# ESI spec validation script (standalone)
+npm run validate:esi
+
+# Regenerate types from live spec
+npm run generate:types
+```
+
+## File Reference
+
+| Path                                           | Purpose                                      |
+| ---------------------------------------------- | -------------------------------------------- |
+| `jest.unit.config.cjs`                         | Unit + BDD test config (coverage thresholds) |
+| `jest.integration.config.cjs`                  | Integration test config (30s timeout)        |
+| `tests/tdd/`                                   | 78 TDD test files                            |
+| `tests/bdd/features/`                          | 39 Gherkin feature files                     |
+| `tests/bdd/step-definitions/`                  | 39 step definition files + shared helpers    |
+| `tests/integration/full-stack.test.ts`         | Mocked full-lifecycle integration (20 tests) |
+| `tests/integration/live-esi.test.ts`           | Live API smoke tests (40 tests)              |
+| `tests/integration/client-integration.test.ts` | Live EsiClient integration (11 tests)        |
+| `tests/integration/esi-spec-contract.test.ts`  | ESI spec drift detection (10 tests)          |
+| `tests/integration/gated-auth.test.ts`         | Authenticated endpoint tests (33 tests)      |
+| `src/testing/TestDataFactory.ts`               | Mock data factory for tests                  |
+| `scripts/validate-esi-endpoints.ts`            | Standalone ESI spec validation script        |
+| `scripts/generate-esi-types.ts`                | Type/cache/scope generator from live spec    |


### PR DESCRIPTION
## Summary

- **Rewrite `guides/TESTING.md`** — incorporates all content from root `TESTING.md`: 7-tier test structure (3,233 tests / 122 suites), current coverage stats (96.35% statements, 93.20% functions), per-file test breakdown, updated directory tree reflecting BDD migration from `bdd-scenarios/` to `bdd/features/` + `bdd/step-definitions/`, smoke test endpoint table, gaps/future work, CI schedule recommendations, Windows `cross-env` instructions
- **Create `guides/SECURITY.md`** — security policy (reporting, timelines), built-in protections (token gating, HTTPS enforcement, host allowlist/SSRF, path injection prevention, query validation, URL sanitization), security test suite breakdown (23 tests across 6 categories), dependency scanning, and ASCII pipeline diagram
- **Update `guides/ARCHITECTURE.md`** — test architecture diagram (section 8) updated with current test counts, coverage actuals vs thresholds, and live integration test tiers

## Test plan

- [x] No code changes — documentation only
- [ ] Verify guides render correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)