### PR TITLE
fix: align Zod schemas and examples with live ESI responses

### DIFF
--- a/examples/access-lists.ts
+++ b/examples/access-lists.ts
@@ -44,7 +44,7 @@ async function main() {
       if (entries.length > 10) console.log(`  ... and ${entries.length - 10} more`);
     }
   } catch (err) {
-    if (err instanceof EsiError && err.status === 401) {
+    if (err instanceof EsiError && err.statusCode === 401) {
       console.error('Authentication required. Set ESI_ACCESS_TOKEN to a valid SSO token.');
     } else {
       console.error('Error:', err instanceof Error ? err.message : err);

--- a/examples/contacts.ts
+++ b/examples/contacts.ts
@@ -49,23 +49,23 @@ async function main() {
       console.log('  No contacts');
     } else {
       // Group by standing
-      const standingGroups: Record<string, typeof contacts> = {
-        'Excellent (+10)': [],
-        'Good (+5)': [],
-        'Neutral (0)': [],
-        'Bad (-5)': [],
-        'Terrible (-10)': [],
-      };
+      const standingGroups = new Map<string, typeof contacts>([
+        ['Excellent (+10)', []],
+        ['Good (+5)', []],
+        ['Neutral (0)', []],
+        ['Bad (-5)', []],
+        ['Terrible (-10)', []],
+      ]);
 
       for (const c of contacts) {
-        if (c.standing >= 10) standingGroups['Excellent (+10)'].push(c);
-        else if (c.standing > 0) standingGroups['Good (+5)'].push(c);
-        else if (c.standing === 0) standingGroups['Neutral (0)'].push(c);
-        else if (c.standing > -10) standingGroups['Bad (-5)'].push(c);
-        else standingGroups['Terrible (-10)'].push(c);
+        if (c.standing >= 10) standingGroups.get('Excellent (+10)')!.push(c);
+        else if (c.standing > 0) standingGroups.get('Good (+5)')!.push(c);
+        else if (c.standing === 0) standingGroups.get('Neutral (0)')!.push(c);
+        else if (c.standing > -10) standingGroups.get('Bad (-5)')!.push(c);
+        else standingGroups.get('Terrible (-10)')!.push(c);
       }
 
-      for (const [group, members] of Object.entries(standingGroups)) {
+      for (const [group, members] of standingGroups) {
         if (members.length > 0) {
           console.log(`\n  ${group}: ${members.length} contact${members.length > 1 ? 's' : ''}`);
           for (const c of members.slice(0, 5)) {

--- a/examples/cursor-pagination.ts
+++ b/examples/cursor-pagination.ts
@@ -28,8 +28,8 @@ async function fetchFirstPage() {
         const result: FreelanceJobsListing = await client.freelanceJobs.getFreelanceJobs();
 
         console.log(`  Fetched ${result.freelance_jobs.length} jobs`);
-        console.log(`  Cursor before: ${result.cursor.before}`);
-        console.log(`  Cursor after:  ${result.cursor.after}`);
+        console.log(`  Cursor before: ${result.cursor?.before}`);
+        console.log(`  Cursor after:  ${result.cursor?.after}`);
         console.log();
 
         for (const job of result.freelance_jobs.slice(0, 3)) {
@@ -72,12 +72,12 @@ async function manualCursorPagination() {
 
             totalJobs += result.freelance_jobs.length;
 
-            if (!result.cursor.after) {
+            if (!result.cursor?.after) {
                 console.log('  No more pages.');
                 break;
             }
 
-            afterToken = result.cursor.after;
+            afterToken = result.cursor?.after ?? undefined;
         }
 
         console.log(`\n  Total jobs fetched: ${totalJobs} across ${pageCount} pages`);
@@ -97,7 +97,7 @@ async function autoFetchAll() {
         const allJobs = await fetchAllCursorPages(
             (before, after) => client.freelanceJobs.getFreelanceJobs(before, after),
             (response) => response.freelance_jobs,
-            (response) => response.cursor,
+            (response) => response.cursor ?? { before: null, after: null },
         );
 
         console.log(`  Fetched ${allJobs.length} total freelance jobs`);

--- a/scripts/create-token.ts
+++ b/scripts/create-token.ts
@@ -189,7 +189,7 @@ type CallbackResult =
 
 function parseInvalidScope(description: string): string | null {
   const match = description.match(/'([^']+)'/);
-  return match ? match[1] : null;
+  return match?.[1] ?? null;
 }
 
 function waitForCallback(

--- a/src/schemas/assets.ts
+++ b/src/schemas/assets.ts
@@ -5,7 +5,7 @@ export const CharacterAssetSchema = z.looseObject({
   type_id: z.number(),
   quantity: z.number(),
   location_id: z.number(),
-  location_type: z.enum(['station', 'solar_system', 'other']),
+  location_type: z.enum(['station', 'solar_system', 'item', 'other']),
   location_flag: z.string(),
   is_singleton: z.boolean(),
   is_blueprint_copy: z.boolean().optional(),

--- a/src/schemas/fittings.ts
+++ b/src/schemas/fittings.ts
@@ -8,7 +8,7 @@ export const FittingSchema = z.looseObject({
   items: z.array(
     z.looseObject({
       type_id: z.number(),
-      flag: z.number(),
+      flag: z.union([z.number(), z.string()]),
       quantity: z.number(),
     }),
   ),

--- a/src/schemas/freelance-jobs.ts
+++ b/src/schemas/freelance-jobs.ts
@@ -23,7 +23,7 @@ export const FreelanceJobSummarySchema = z.looseObject({
 });
 
 export const FreelanceJobsListingSchema = z.looseObject({
-  cursor: EsiCursorSchema,
+  cursor: EsiCursorSchema.optional(),
   freelance_jobs: z.array(FreelanceJobSummarySchema),
 });
 
@@ -65,8 +65,8 @@ export const FreelanceJobDetailSchema = z.looseObject({
   }),
   contribution: z.looseObject({
     max_committed_participants: z.number(),
-    reward_per_contribution: z.number(),
-    submission_multiplier: z.number(),
+    reward_per_contribution: z.number().optional(),
+    submission_multiplier: z.number().optional(),
   }),
   access_and_visibility: z.looseObject({
     acl_protected: z.boolean(),
@@ -80,7 +80,7 @@ export const FreelanceJobDetailSchema = z.looseObject({
 });
 
 export const CharacterFreelanceJobsListingSchema = z.looseObject({
-  cursor: EsiCursorSchema,
+  cursor: EsiCursorSchema.optional(),
   freelance_jobs: z.array(FreelanceJobSummarySchema),
 });
 
@@ -93,7 +93,7 @@ export const FreelanceJobParticipationSchema = z.looseObject({
 });
 
 export const CorporationFreelanceJobsListingSchema = z.looseObject({
-  cursor: EsiCursorSchema,
+  cursor: EsiCursorSchema.optional(),
   freelance_jobs: z.array(FreelanceJobSummarySchema),
 });
 

--- a/src/schemas/mail.ts
+++ b/src/schemas/mail.ts
@@ -7,6 +7,7 @@ export const MailMessageSchema = z.looseObject({
   timestamp: z.string().optional(),
   labels: z.array(z.number()).optional(),
   is_read: z.boolean().optional(),
+  body: z.string().optional(),
   recipients: z
     .array(
       z.looseObject({

--- a/tests/bdd/step-definitions/core/freelance-jobs.steps.ts
+++ b/tests/bdd/step-definitions/core/freelance-jobs.steps.ts
@@ -64,8 +64,8 @@ defineFeature(feature, (test) => {
       expect(result.freelance_jobs[0]).toHaveProperty('state');
       expect(result.freelance_jobs[0]).toHaveProperty('progress');
       expect(result.cursor).toBeDefined();
-      expect(result.cursor.before).toBeNull();
-      expect(result.cursor.after).toBe('cursor_abc123');
+      expect(result.cursor?.before).toBeNull();
+      expect(result.cursor?.after).toBe('cursor_abc123');
     });
   });
 
@@ -94,8 +94,8 @@ defineFeature(feature, (test) => {
     then('the client shall return an empty listing', () => {
       expect(result.freelance_jobs).toBeInstanceOf(Array);
       expect(result.freelance_jobs).toHaveLength(0);
-      expect(result.cursor.before).toBeNull();
-      expect(result.cursor.after).toBeNull();
+      expect(result.cursor?.before).toBeNull();
+      expect(result.cursor?.after).toBeNull();
     });
   });
 
@@ -229,7 +229,7 @@ defineFeature(feature, (test) => {
       expect(result.freelance_jobs).toHaveLength(1);
       expect(result.freelance_jobs[0].id).toBe('job-010');
       expect(result.freelance_jobs[0].state).toBe('in_progress');
-      expect(result.cursor.after).toBe('char_cursor_xyz');
+      expect(result.cursor?.after).toBe('char_cursor_xyz');
     });
   });
 
@@ -309,7 +309,7 @@ defineFeature(feature, (test) => {
       expect(result).toBeDefined();
       expect(result.freelance_jobs).toHaveLength(1);
       expect(result.freelance_jobs[0].id).toBe('job-050');
-      expect(result.cursor.after).toBeNull();
+      expect(result.cursor?.after).toBeNull();
     });
   });
 
@@ -354,11 +354,11 @@ defineFeature(feature, (test) => {
       'the client requests the next page using the after token',
       async () => {
         const page1 = await client.freelanceJobs.getFreelanceJobs();
-        expect(page1.cursor.after).toBe('page2_token');
+        expect(page1.cursor?.after).toBe('page2_token');
 
         page2 = await client.freelanceJobs.getFreelanceJobs(
           undefined,
-          page1.cursor.after!,
+          page1.cursor!.after!,
         );
       },
     );
@@ -366,8 +366,8 @@ defineFeature(feature, (test) => {
     then('the client shall return the second page of results', () => {
       expect(page2.freelance_jobs).toHaveLength(1);
       expect(page2.freelance_jobs[0].id).toBe('job-002');
-      expect(page2.cursor.before).toBe('page2_token');
-      expect(page2.cursor.after).toBeNull();
+      expect(page2.cursor?.before).toBe('page2_token');
+      expect(page2.cursor?.after).toBeNull();
     });
   });
 
@@ -405,7 +405,7 @@ defineFeature(feature, (test) => {
     then('the client shall return the first page of results', () => {
       expect(firstPage.freelance_jobs).toHaveLength(1);
       expect(firstPage.freelance_jobs[0].id).toBe('job-001');
-      expect(firstPage.cursor.before).toBeNull();
+      expect(firstPage.cursor?.before).toBeNull();
     });
   });
 

--- a/tests/tdd/clients/FreelanceJobsClient.test.ts
+++ b/tests/tdd/clients/FreelanceJobsClient.test.ts
@@ -83,8 +83,8 @@ describe('FreelanceJobsClient', () => {
 
       const result = await client.getFreelanceJobs();
 
-      expect(result.cursor.before).toBe('b1');
-      expect(result.cursor.after).toBe('a1');
+      expect(result.cursor?.before).toBe('b1');
+      expect(result.cursor?.after).toBe('a1');
       expect(result.freelance_jobs).toHaveLength(2);
       expect(result.freelance_jobs[0].name).toBe('Veldspar Collection');
       expect(fetchMock.mock.calls[0][0]).toBe(
@@ -122,7 +122,7 @@ describe('FreelanceJobsClient', () => {
       const result = await client.getFreelanceJobs(undefined, 'last-cursor');
 
       expect(result.freelance_jobs).toHaveLength(0);
-      expect(result.cursor.after).toBeNull();
+      expect(result.cursor?.after).toBeNull();
     });
   });
 


### PR DESCRIPTION
## Summary
- **Schemas**: Fix 4 Zod schemas that rejected valid live ESI responses — assets `location_type` missing `'item'`, fittings `flag` is string not number, freelance-jobs `cursor` is optional on final pages, mail missing `body` field, and freelance-job detail `reward_per_contribution`/`submission_multiplier` are optional
- **Examples**: Fix 3 compile errors — `access-lists.ts` wrong property name, `contacts.ts` noUncheckedIndexedAccess issue, `cursor-pagination.ts` required optional chaining for cursor
- **Token script**: Fix type narrowing in `create-token.ts` regex match

All 30 examples now run successfully against the live ESI API. 121 test suites, 3222 tests passing.

## Test plan
- [x] `npm test` — 121 suites, 3222 tests passing
- [x] `npx tsc --noEmit` — clean compile
- [x] All 30 examples verified against live ESI with a real token
- [x] Output captured in `output.txt` for review

🤖 Generated with [Claude Code](https://claude.com/claude-code)