### PR TITLE
fix(ci): make schema drift detection a blocking CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,8 +72,7 @@ jobs:
         run: npm audit --audit-level=high
 
       - name: Check schema drift
-        run: npm run schema:drift
-        continue-on-error: true
+        run: npm run schema:drift:ci
 
   unit-tests:
     name: Unit Tests (Node ${{ matrix.node-version }})

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -78,6 +78,9 @@ jobs:
       - name: Security audit
         run: npm audit --audit-level=high
 
+      - name: Check schema drift
+        run: npm run schema:drift:ci
+
   tests:
     name: Tests (${{ matrix.test-type }})
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -148,7 +148,8 @@
     "mutation:report": "stryker run --reporters html,clear-text",
     "api-report": "api-extractor run --local --verbose",
     "api-report:check": "api-extractor run --verbose",
-    "schema:drift": "ts-node scripts/generate-schema-drift-report.ts"
+    "schema:drift": "ts-node scripts/generate-schema-drift-report.ts",
+    "schema:drift:ci": "ts-node scripts/generate-schema-drift-report.ts --ci"
   },
   "lint-staged": {
     "src/**/*.ts": [

--- a/scripts/generate-schema-drift-report.ts
+++ b/scripts/generate-schema-drift-report.ts
@@ -5,8 +5,12 @@
  * to detect field-level drift: missing fields, extra fields, and type mismatches.
  *
  * Usage: npx ts-node scripts/generate-schema-drift-report.ts
+ *        npx ts-node scripts/generate-schema-drift-report.ts --ci
  *        npm run schema:drift
+ *        npm run schema:drift:ci
  */
+
+const ciMode = process.argv.includes('--ci');
 
 import * as fs from 'fs';
 import * as path from 'path';
@@ -228,7 +232,7 @@ async function main(): Promise<void> {
   const response = await fetch(ESI_OPENAPI_URL);
   if (!response.ok) {
     console.error(`Failed to fetch spec: ${response.status} ${response.statusText}`);
-    process.exit(0);
+    process.exit(ciMode ? 1 : 0);
   }
   const spec = (await response.json()) as OpenApiSpec;
   console.log(`Spec loaded: ${Object.keys(spec.paths).length} paths\n`);
@@ -334,10 +338,14 @@ async function main(): Promise<void> {
     console.log(
       '\nTo suppress known drift, add field names to scripts/schema-drift-exceptions.json',
     );
+
+    if (ciMode) {
+      process.exit(1);
+    }
   }
 }
 
 main().catch((err) => {
   console.error('Schema drift detection failed:', err);
-  process.exit(0);
+  process.exit(ciMode ? 1 : 0);
 });


### PR DESCRIPTION
## Summary
- Add `--ci` flag to `scripts/generate-schema-drift-report.ts` that exits non-zero when drift is detected or the spec fetch fails
- Add `schema:drift:ci` npm script for CI usage
- Update `ci.yml` to use `schema:drift:ci` and remove `continue-on-error: true`
- Add schema drift check to `pr-validation.yml` (was missing entirely)

## Test plan
- [ ] `npm run schema:drift` still exits 0 (graceful local dev experience)
- [ ] `npm run schema:drift:ci` exits 1 if drift is found
- [ ] CI pipeline runs schema drift as a blocking step
- [ ] PR validation pipeline now includes schema drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)