### PR TITLE
test: expand type-level tests with tsd

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "fuzz": "jest --config jest.fuzz.config.cjs",
     "fuzz:api": "bash scripts/run-schemathesis.sh",
     "mock:esi": "prism mock https://esi.evetech.net/meta/openapi.json -p 4010",
-    "test:types": "tsd --files tests/typetests/index.test-d.ts",
+    "test:types": "tsd --files 'tests/typetests/*.test-d.ts'",
     "generate:types": "ts-node scripts/generate-esi-types.ts",
     "knip": "knip",
     "validate:esi": "ts-node scripts/validate-esi-endpoints.ts",

--- a/tests/typetests/domain-responses.test-d.ts
+++ b/tests/typetests/domain-responses.test-d.ts
@@ -1,0 +1,86 @@
+import { expectType, expectAssignable } from 'tsd';
+import type {
+  EsiResponse,
+  EsiResponseMeta,
+  AllianceInfo,
+  AllianceIcon,
+  CharacterInfo,
+  CharacterPortrait,
+  MarketOrder,
+  MarketHistory,
+  ServerStatus,
+  Killmail,
+  InsurancePrice,
+  Incursion,
+  SovereigntyCampaign,
+} from '../../src';
+
+// --- EsiResponse shape ---
+
+declare const response: EsiResponse<AllianceInfo>;
+expectType<AllianceInfo>(response.data);
+expectType<EsiResponseMeta>(response.meta);
+
+// --- EsiResponseMeta fields ---
+
+declare const meta: EsiResponseMeta;
+expectType<Record<string, string>>(meta.headers);
+expectType<boolean>(meta.fromCache);
+expectType<boolean>(meta.stale);
+
+// --- Domain response types have expected fields ---
+
+declare const alliance: AllianceInfo;
+expectType<string>(alliance.name);
+expectType<string>(alliance.ticker);
+expectType<number>(alliance.creator_id);
+expectType<number>(alliance.creator_corporation_id);
+expectType<string>(alliance.date_founded);
+
+declare const icon: AllianceIcon;
+expectAssignable<string | undefined>(icon.px64x64);
+expectAssignable<string | undefined>(icon.px128x128);
+
+declare const character: CharacterInfo;
+expectType<string>(character.name);
+expectType<number>(character.corporation_id);
+expectType<number>(character.bloodline_id);
+expectType<number>(character.race_id);
+expectType<string>(character.birthday);
+
+declare const portrait: CharacterPortrait;
+expectAssignable<string | undefined>(portrait.px64x64);
+expectAssignable<string | undefined>(portrait.px128x128);
+
+declare const order: MarketOrder;
+expectType<number>(order.order_id);
+expectType<number>(order.type_id);
+expectType<number>(order.location_id);
+expectType<number>(order.price);
+expectType<boolean>(order.is_buy_order);
+expectType<number>(order.duration);
+expectType<string>(order.issued);
+expectType<string>(order.range);
+
+declare const history: MarketHistory;
+expectType<string>(history.date);
+expectType<number>(history.order_count);
+expectType<number>(history.volume);
+expectType<number>(history.highest);
+expectType<number>(history.lowest);
+expectType<number>(history.average);
+
+declare const status: ServerStatus;
+expectType<number>(status.players);
+expectType<string>(status.server_version);
+expectType<string>(status.start_time);
+
+declare const killmail: Killmail;
+expectType<number>(killmail.killmail_id);
+expectType<string>(killmail.killmail_time);
+expectType<number>(killmail.solar_system_id);
+
+declare const campaign: SovereigntyCampaign;
+expectType<number>(campaign.campaign_id);
+expectType<number>(campaign.structure_id);
+expectType<number>(campaign.solar_system_id);

--- a/tests/typetests/endpoint-args.test-d.ts
+++ b/tests/typetests/endpoint-args.test-d.ts
@@ -1,0 +1,85 @@
+import { expectType, expectAssignable } from 'tsd';
+import type {
+  EndpointArgs,
+  EndpointDefinition,
+  HttpMethod,
+} from '../../src/core/endpoints/EndpointDefinition';
+import type {
+  WithMetadata,
+  CreateClientOptions,
+} from '../../src/core/endpoints/createClient';
+import type { EsiResponse, EsiResponseMeta } from '../../src';
+
+// --- HttpMethod is a string union ---
+
+expectAssignable<HttpMethod>('GET' as const);
+expectAssignable<HttpMethod>('POST' as const);
+expectAssignable<HttpMethod>('PUT' as const);
+expectAssignable<HttpMethod>('DELETE' as const);
+
+// --- EndpointArgs: no params produces empty tuple ---
+
+type NoParamEndpoint = {
+  path: 'status/';
+  method: 'GET';
+  requiresAuth: false;
+};
+expectType<[]>(null as unknown as EndpointArgs<NoParamEndpoint>);
+
+// --- EndpointArgs: path params produce positional number|string args ---
+
+type OneParamEndpoint = {
+  path: 'alliances/{allianceId}/';
+  method: 'GET';
+  requiresAuth: false;
+  pathParams: readonly ['allianceId'];
+};
+expectType<[number | string]>(
+  null as unknown as EndpointArgs<OneParamEndpoint>,
+);
+
+type TwoParamEndpoint = {
+  path: 'characters/{characterId}/mail/{mailId}/';
+  method: 'GET';
+  requiresAuth: true;
+  pathParams: readonly ['characterId', 'mailId'];
+};
+expectType<[number | string, number | string]>(
+  null as unknown as EndpointArgs<TwoParamEndpoint>,
+);
+
+// --- EndpointArgs: hasBody adds body param ---
+
+type BodyEndpoint = {
+  path: 'characters/{characterId}/mail/';
+  method: 'POST';
+  requiresAuth: true;
+  pathParams: readonly ['characterId'];
+  hasBody: true;
+};
+expectType<[number | string, body: object]>(
+  null as unknown as EndpointArgs<BodyEndpoint>,
+);
+
+// --- WithMetadata wraps return types in EsiResponse ---
+
+type SimpleMethods = {
+  getStatus: () => Promise<{ players: number }>;
+  getInfo: (id: number) => Promise<string>;
+};
+
+type WrappedMethods = WithMetadata<SimpleMethods>;
+
+expectType<() => Promise<EsiResponse<{ players: number }>>>(
+  null as unknown as WrappedMethods['getStatus'],
+);
+
+expectType<(id: number) => Promise<EsiResponse<string>>>(
+  null as unknown as WrappedMethods['getInfo'],
+);
+
+// --- CreateClientOptions shape ---
+
+expectAssignable<CreateClientOptions>({});
+expectAssignable<CreateClientOptions>({ returnMetadata: true });
+expectAssignable<CreateClientOptions>({ returnMetadata: false });

--- a/tests/typetests/error-guards.test-d.ts
+++ b/tests/typetests/error-guards.test-d.ts
@@ -1,0 +1,63 @@
+import { expectType, expectAssignable } from 'tsd';
+import {
+  EsiError,
+  isEsiError,
+  isRateLimited,
+  isNotFound,
+  isServerError,
+  isTimeout,
+  isValidationError,
+} from '../../src';
+import { TimeoutError, EsiValidationError } from '../../src/core/util/error';
+
+// --- Type guard narrowing ---
+
+declare const err: unknown;
+
+if (isEsiError(err)) {
+  expectType<EsiError>(err);
+  expectType<number>(err.statusCode);
+  expectType<string>(err.message);
+  expectType<string | undefined>(err.url);
+}
+
+if (isRateLimited(err)) {
+  expectType<EsiError>(err);
+  expectType<number>(err.statusCode);
+}
+
+if (isNotFound(err)) {
+  expectType<EsiError>(err);
+}
+
+if (isServerError(err)) {
+  expectType<EsiError>(err);
+}
+
+if (isTimeout(err)) {
+  expectType<TimeoutError>(err);
+  expectType<number>(err.timeoutMs);
+}
+
+if (isValidationError(err)) {
+  expectType<EsiValidationError>(err);
+  expectType<unknown>(err.validationError);
+}
+
+// --- EsiError instance methods ---
+
+const esiErr = new EsiError(404, 'Not found', 'https://esi.evetech.net/test');
+expectType<boolean>(esiErr.isRateLimited());
+expectType<boolean>(esiErr.isNotFound());
+expectType<boolean>(esiErr.isUnauthorized());
+expectType<boolean>(esiErr.isForbidden());
+expectType<boolean>(esiErr.isServerError());
+expectType<boolean>(esiErr.isTimeout());
+expectType<boolean>(esiErr.retryable);
+expectType<string | undefined>(esiErr.requestId);
+
+// TimeoutError extends EsiError
+const timeout = new TimeoutError(5000, 'https://esi.evetech.net/test');
+expectAssignable<EsiError>(timeout);
+expectType<number>(timeout.timeoutMs);
+expectType<number>(timeout.statusCode);


### PR DESCRIPTION
## Summary
- Adds 3 new tsd test files expanding type-level coverage from 15 to ~60 assertions
- `error-guards.test-d.ts` — verifies all 6 error type guards narrow correctly (isEsiError → EsiError, isTimeout → TimeoutError, etc.)
- `endpoint-args.test-d.ts` — verifies EndpointArgs conditional type produces correct parameter tuples for no-param, path-param, and body endpoints; tests WithMetadata wrapper
- `domain-responses.test-d.ts` — verifies field shapes of 10 domain response types (alliance, character, market, status, killmails, sovereignty)
- Updates `test:types` script to glob all `*.test-d.ts` files

## Test plan
- [x] `npm run test:types` — all type tests pass
- [x] `npm run build` — compiles clean
- [x] `npm test` — 3224 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)