### PR TITLE
feat: branded ID types for type-safe entity references

### DIFF
--- a/src/types/api-responses.ts
+++ b/src/types/api-responses.ts
@@ -30,4 +30,5 @@ export * from './freelance-jobs';
 export * from './skyhooks';
 export * from './mercenary';
 export * from './access-lists';
+export * from './branded';
 export * as EsiSpec from './generated/esi-spec.generated';

--- a/src/types/branded.ts
+++ b/src/types/branded.ts
@@ -1,0 +1,24 @@
+declare const __brand: unique symbol;
+
+type Brand<T, B extends string> = T & { readonly [__brand]: B };
+
+export type CharacterId = Brand<number, 'CharacterId'>;
+export type CorporationId = Brand<number, 'CorporationId'>;
+export type AllianceId = Brand<number, 'AllianceId'>;
+export type TypeId = Brand<number, 'TypeId'>;
+export type RegionId = Brand<number, 'RegionId'>;
+export type SystemId = Brand<number, 'SystemId'>;
+export type StationId = Brand<number, 'StationId'>;
+export type StructureId = Brand<number, 'StructureId'>;
+export type OrderId = Brand<number, 'OrderId'>;
+export type ContractId = Brand<number, 'ContractId'>;
+export type KillmailId = Brand<number, 'KillmailId'>;
+export type FactionId = Brand<number, 'FactionId'>;
+export type CorporationAllianceId = Brand<number, 'CorporationAllianceId'>;
+export type FleetId = Brand<number, 'FleetId'>;
+export type PlanetId = Brand<number, 'PlanetId'>;
+export type WarId = Brand<number, 'WarId'>;
+
+export function brand<T>(value: number): T {
+  return value as unknown as T;
+}

--- a/tests/typetests/branded-ids.test-d.ts
+++ b/tests/typetests/branded-ids.test-d.ts
@@ -1,0 +1,41 @@
+import { expectType, expectAssignable, expectNotAssignable } from 'tsd';
+import {
+  CharacterId,
+  CorporationId,
+  AllianceId,
+  TypeId,
+  RegionId,
+  SystemId,
+  OrderId,
+  brand,
+} from '../../src';
+
+// Branded IDs are assignable to number (backwards compat)
+declare const charId: CharacterId;
+expectAssignable<number>(charId);
+
+declare const corpId: CorporationId;
+expectAssignable<number>(corpId);
+
+declare const allianceId: AllianceId;
+expectAssignable<number>(allianceId);
+
+// Plain number is NOT assignable to a branded ID
+expectNotAssignable<CharacterId>(42 as number);
+expectNotAssignable<CorporationId>(42 as number);
+expectNotAssignable<AllianceId>(42 as number);
+expectNotAssignable<TypeId>(42 as number);
+expectNotAssignable<RegionId>(42 as number);
+expectNotAssignable<SystemId>(42 as number);
+expectNotAssignable<OrderId>(42 as number);
+
+// Cross-contamination is prevented
+expectNotAssignable<CorporationId>(charId);
+expectNotAssignable<CharacterId>(corpId);
+expectNotAssignable<AllianceId>(charId);
+expectNotAssignable<TypeId>(charId);
+expectNotAssignable<RegionId>(charId);
+
+// brand() helper creates branded values
+const branded = brand<CharacterId>(12345);
+expectType<CharacterId>(branded);


### PR DESCRIPTION
## Summary
- Adds `src/types/branded.ts` with 16 branded ID types covering all major ESI entities (CharacterId, CorporationId, AllianceId, TypeId, RegionId, SystemId, etc.)
- Uses the `Brand<T, B>` pattern with a `unique symbol` to create nominal types that are assignable to `number` but not vice versa
- Exports `brand<T>(value: number): T` helper for consumers to create branded values from raw API data
- Fully opt-in — existing code using plain `number` for IDs is unaffected
- Re-exports from `src/types/api-responses.ts` (available via package root)

## Test plan
- [x] `npm run build` — compiles clean
- [x] `npm test` — 3224 tests pass
- [x] tsd type tests verify: branded → number assignable, number → branded NOT assignable, cross-brand NOT assignable

🤖 Generated with [Claude Code](https://claude.com/claude-code)