### PR TITLE
feat: EsiResult<T> discriminated union and safeMode

### DIFF
--- a/src/core/endpoints/createClient.ts
+++ b/src/core/endpoints/createClient.ts
@@ -2,11 +2,15 @@ import { ApiClient } from '../ApiClient';
 import { handleRequest, EsiHandlerResponse } from '../ApiRequestHandler';
 import { EndpointMap, EndpointArgs } from './EndpointDefinition';
 import { CursorTokens } from '../pagination/CursorPaginationHandler';
-import { EsiResponse, EsiResponseMeta } from '../../types/api-responses';
+import {
+  EsiResponse,
+  EsiResult,
+  EsiResponseMeta,
+} from '../../types/api-responses';
 import { buildEndpointPath } from './buildEndpointPath';
 import { parseWarning } from '../util/headersUtil';
 import { logWarn } from '../logger/loggerUtil';
-import { EsiValidationError } from '../util/error';
+import { EsiError, EsiValidationError } from '../util/error';
 
 export interface CursorOptions {
   before?: string;
@@ -20,6 +24,7 @@ export interface CursorResult<T = unknown> {
 
 export interface CreateClientOptions {
   returnMetadata?: boolean;
+  safeMode?: boolean;
 }
 
 type ClientMethods<T extends EndpointMap> = {
@@ -29,6 +34,12 @@ type ClientMethods<T extends EndpointMap> = {
 export type WithMetadata<T> = {
   [K in keyof T]: T[K] extends (...args: infer A) => Promise<infer R>
     ? (...args: A) => Promise<EsiResponse<R>>
+    : T[K];
+};
+
+export type WithSafeMode<T> = {
+  [K in keyof T]: T[K] extends (...args: infer A) => Promise<infer R>
+    ? (...args: A) => Promise<EsiResult<R>>
     : T[K];
 };
 
@@ -67,45 +78,80 @@ export function createClient<T extends EndpointMap>(
 ): ClientMethods<T> {
   const client = {} as ClientMethods<T>;
   const returnMetadata = options?.returnMetadata ?? false;
+  const safeMode = options?.safeMode ?? false;
 
   for (const [methodName, def] of Object.entries(endpoints)) {
     // eslint-disable-next-line security/detect-object-injection
     (client as Record<string, (...args: unknown[]) => Promise<unknown>>)[
       methodName
     ] = async (...args: unknown[]) => {
-      if (def.deprecated) {
-        const parts = [`Endpoint '${methodName}' is deprecated.`];
-        if (def.deprecated.message) parts.push(def.deprecated.message);
-        if (def.deprecated.replacedBy)
-          parts.push(`Use '${def.deprecated.replacedBy}' instead.`);
-        if (def.deprecated.sunsetDate)
-          parts.push(`Sunset date: ${def.deprecated.sunsetDate}.`);
-        logWarn(parts.join(' '));
-      }
+      try {
+        if (def.deprecated) {
+          const parts = [`Endpoint '${methodName}' is deprecated.`];
+          if (def.deprecated.message) parts.push(def.deprecated.message);
+          if (def.deprecated.replacedBy)
+            parts.push(`Use '${def.deprecated.replacedBy}' instead.`);
+          if (def.deprecated.sunsetDate)
+            parts.push(`Sunset date: ${def.deprecated.sunsetDate}.`);
+          logWarn(parts.join(' '));
+        }
 
-      const built = buildEndpointPath(def, args, apiClient.getDatasource());
-      let path = built.path;
-      const body = built.body;
+        const built = buildEndpointPath(def, args, apiClient.getDatasource());
+        let path = built.path;
+        const body = built.body;
 
-      if (def.cursorPagination) {
-        const lastArg = args[args.length - 1];
-        const isCursorArg =
-          lastArg != null &&
-          typeof lastArg === 'object' &&
-          ('before' in lastArg || 'after' in lastArg);
-        const cursorOpts: CursorOptions | undefined = isCursorArg
-          ? (lastArg as CursorOptions)
-          : undefined;
+        if (def.cursorPagination) {
+          const lastArg = args[args.length - 1];
+          const isCursorArg =
+            lastArg != null &&
+            typeof lastArg === 'object' &&
+            ('before' in lastArg || 'after' in lastArg);
+          const cursorOpts: CursorOptions | undefined = isCursorArg
+            ? (lastArg as CursorOptions)
+            : undefined;
 
-        if (cursorOpts) {
-          const parts: string[] = [];
-          if (cursorOpts.before)
-            parts.push(`before=${encodeURIComponent(cursorOpts.before)}`);
-          if (cursorOpts.after)
-            parts.push(`after=${encodeURIComponent(cursorOpts.after)}`);
-          if (parts.length > 0) {
-            path += (path.includes('?') ? '&' : '?') + parts.join('&');
+          if (cursorOpts) {
+            const parts: string[] = [];
+            if (cursorOpts.before)
+              parts.push(`before=${encodeURIComponent(cursorOpts.before)}`);
+            if (cursorOpts.after)
+              parts.push(`after=${encodeURIComponent(cursorOpts.after)}`);
+            if (parts.length > 0) {
+              path += (path.includes('?') ? '&' : '?') + parts.join('&');
+            }
           }
+
+          const response = await handleRequest(
+            apiClient,
+            path,
+            def.method,
+            body,
+            def.requiresAuth,
+            true,
+            def.path,
+          );
+          const responseBody = response.body;
+          let data: unknown[];
+          if (Array.isArray(responseBody)) {
+            data = responseBody as unknown[];
+          } else if (responseBody !== null && responseBody !== undefined) {
+            data = [responseBody];
+          } else {
+            data = [];
+          }
+          const cursorResult: CursorResult = {
+            data,
+            cursors: response.cursors ?? { before: null, after: null },
+          };
+
+          if (returnMetadata || safeMode) {
+            const meta = buildMeta(response);
+            if (safeMode) {
+              return { ok: true, data: cursorResult, meta };
+            }
+            return { data: cursorResult, meta };
+          }
+          return cursorResult;
         }
 
         const response = await handleRequest(
@@ -117,50 +163,37 @@ export function createClient<T extends EndpointMap>(
           true,
           def.path,
         );
-        const responseBody = response.body;
-        let data: unknown[];
-        if (Array.isArray(responseBody)) {
-          data = responseBody as unknown[];
-        } else if (responseBody !== null && responseBody !== undefined) {
-          data = [responseBody];
-        } else {
-          data = [];
+        let responseBody = response.body;
+        if (def.responseSchema && apiClient.getValidateResponse()) {
+          const result = def.responseSchema.safeParse(responseBody);
+          if (!result.success) {
+            throw new EsiValidationError(
+              `${apiClient.getLink()}/${path}`,
+              result.error,
+            );
+          }
+          responseBody = result.data;
         }
-        const cursorResult: CursorResult = {
-          data,
-          cursors: response.cursors ?? { before: null, after: null },
-        };
-
+        if (safeMode) {
+          return { ok: true, data: responseBody, meta: buildMeta(response) };
+        }
         if (returnMetadata) {
-          return { data: cursorResult, meta: buildMeta(response) };
+          return { data: responseBody, meta: buildMeta(response) };
         }
-        return cursorResult;
-      }
-
-      const response = await handleRequest(
-        apiClient,
-        path,
-        def.method,
-        body,
-        def.requiresAuth,
-        true,
-        def.path,
-      );
-      let responseBody = response.body;
-      if (def.responseSchema && apiClient.getValidateResponse()) {
-        const result = def.responseSchema.safeParse(responseBody);
-        if (!result.success) {
-          throw new EsiValidationError(
-            `${apiClient.getLink()}/${path}`,
-            result.error,
-          );
+        return responseBody;
+      } catch (err) {
+        if (safeMode) {
+          const error =
+            err instanceof EsiError
+              ? err
+              : new EsiError(
+                  0,
+                  err instanceof Error ? err.message : String(err),
+                );
+          return { ok: false, error };
         }
-        responseBody = result.data;
+        throw err;
       }
-      if (returnMetadata) {
-        return { data: responseBody, meta: buildMeta(response) };
-      }
-      return responseBody;
     };
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,7 @@ export {
   CursorResult,
   CreateClientOptions,
   WithMetadata,
+  WithSafeMode,
   fetchAllCursorPages,
 } from './core/endpoints/createClient';
 export { CursorTokens } from './core/pagination/CursorPaginationHandler';

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { RateLimitMetaSchema, EsiResponseMetaSchema } from '../schemas/common';
+import type { EsiError } from '../core/util/error';
 
 export type RateLimitMeta = z.infer<typeof RateLimitMetaSchema>;
 export type EsiResponseMeta = z.infer<typeof EsiResponseMetaSchema>;
@@ -8,3 +9,7 @@ export interface EsiResponse<T> {
   data: T;
   meta: EsiResponseMeta;
 }
+
+export type EsiResult<T> =
+  | { ok: true; data: T; meta: EsiResponseMeta }
+  | { ok: false; error: EsiError; meta?: EsiResponseMeta };

--- a/tests/tdd/core/createClient.safe.test.ts
+++ b/tests/tdd/core/createClient.safe.test.ts
@@ -1,0 +1,97 @@
+import { ApiClient } from '../../../src/core/ApiClient';
+import { createClient } from '../../../src/core/endpoints/createClient';
+import { EndpointMap } from '../../../src/core/endpoints/EndpointDefinition';
+import { RateLimiter } from '../../../src/core/rateLimiter/RateLimiter';
+import { EsiError } from '../../../src/core/util/error';
+import fetchMock from 'jest-fetch-mock';
+
+fetchMock.enableMocks();
+
+const BASE_URL = 'https://esi.evetech.net';
+
+const endpoints = {
+  getStatus: {
+    path: 'latest/status/',
+    method: 'GET' as const,
+    requiresAuth: false,
+  },
+} satisfies EndpointMap;
+
+describe('createClient safeMode', () => {
+  let apiClient: ApiClient;
+  let rateLimiter: RateLimiter;
+
+  beforeEach(() => {
+    fetchMock.resetMocks();
+    rateLimiter = new RateLimiter();
+    rateLimiter.setTestMode(true);
+    apiClient = new ApiClient('test', BASE_URL);
+    apiClient.setRateLimiter(rateLimiter);
+  });
+
+  afterEach(() => {
+    rateLimiter.setTestMode(false);
+  });
+
+  it('should return { ok: true, data, meta } on success', async () => {
+    const mockData = {
+      players: 23456,
+      server_version: '2345678',
+      start_time: '2024-01-01T00:00:00Z',
+    };
+    fetchMock.mockResponseOnce(JSON.stringify(mockData), {
+      headers: {
+        'x-pages': '1',
+        'x-ratelimit-remaining': '95',
+        'x-ratelimit-limit': '100',
+        'x-ratelimit-used': '5',
+        'x-ratelimit-group': 'market',
+      },
+    });
+
+    const client = createClient(apiClient, endpoints, { safeMode: true });
+    const result = (await client.getStatus()) as {
+      ok: boolean;
+      data: unknown;
+      meta: unknown;
+    };
+
+    expect(result.ok).toBe(true);
+    expect(result.data).toEqual(mockData);
+    expect(result.meta).toBeDefined();
+  });
+
+  it('should return { ok: false, error } on failure without throwing', async () => {
+    fetchMock.mockResponseOnce('', { status: 500 });
+
+    const client = createClient(apiClient, endpoints, { safeMode: true });
+    const result = (await client.getStatus()) as {
+      ok: boolean;
+      error: EsiError;
+    };
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeInstanceOf(EsiError);
+  });
+
+  it('should still throw in default mode', async () => {
+    fetchMock.mockResponseOnce('', { status: 500 });
+
+    const client = createClient(apiClient, endpoints);
+    await expect(client.getStatus()).rejects.toThrow();
+  });
+
+  it('should wrap non-EsiError errors', async () => {
+    fetchMock.mockReject(new TypeError('Network failure'));
+
+    const client = createClient(apiClient, endpoints, { safeMode: true });
+    const result = (await client.getStatus()) as {
+      ok: boolean;
+      error: EsiError;
+    };
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeInstanceOf(EsiError);
+    expect(result.error.message).toContain('Network failure');
+  });
+});

--- a/tests/typetests/result-type.test-d.ts
+++ b/tests/typetests/result-type.test-d.ts
@@ -1,0 +1,28 @@
+import { expectType, expectAssignable } from 'tsd';
+import type {
+  EsiResult,
+  EsiResponse,
+  EsiResponseMeta,
+  EsiError,
+} from '../../src';
+
+// --- EsiResult discriminated union ---
+
+declare const result: EsiResult<{ players: number }>;
+
+if (result.ok) {
+  expectType<true>(result.ok);
+  expectType<{ players: number }>(result.data);
+  expectType<EsiResponseMeta>(result.meta);
+}
+
+if (!result.ok) {
+  expectType<false>(result.ok);
+  expectType<EsiError>(result.error);
+  expectAssignable<EsiResponseMeta | undefined>(result.meta);
+}
+
+// EsiResult success branch is assignable to EsiResponse shape
+declare const success: Extract<EsiResult<string>, { ok: true }>;
+expectType<string>(success.data);
+expectType<EsiResponseMeta>(success.meta);


### PR DESCRIPTION
## Summary
- Adds `EsiResult<T>` discriminated union type: `{ ok: true; data: T; meta } | { ok: false; error: EsiError; meta? }`
- Adds `safeMode: boolean` to `CreateClientOptions` — when enabled, errors are returned as values instead of thrown
- Exports `WithSafeMode<T>` mapped type for typing safe-mode client interfaces
- Existing throw-based behavior is completely unchanged (safeMode defaults to false)
- Non-EsiError exceptions are wrapped in `EsiError(0, message)` for consistent error typing

## Test plan
- [x] `npm run build` — compiles clean
- [x] `npm test` — 3228 tests pass (4 new safe-mode tests)
- [x] tsd type tests verify discriminated union narrowing (`result.ok` → data/error access)
- [x] Unit tests: success returns `{ ok: true }`, failure returns `{ ok: false }`, non-EsiError wrapped, default mode still throws

🤖 Generated with [Claude Code](https://claude.com/claude-code)