### PR TITLE
feat: add OKF v0.2 knowledge bundle generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,5 +84,8 @@ docs/*
 # Stryker mutation testing
 .stryker-tmp/
 
+# Generated OKF knowledge bundle
+okf/
+
 # Local planning docs
 ideas.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,7 @@ Coverage thresholds: branches 80%, functions 75%, lines 90%, statements 90%.
 ```bash
 npm run generate:types    # Generate TS interfaces + Zod schemas + metadata from live ESI OpenAPI spec
 npm run generate:clients  # Generate typed client wrappers from endpoint definitions
+npm run generate:okf      # Generate OKF v0.2 knowledge bundle from live ESI OpenAPI spec
 npm run schema:drift      # Check hand-written Zod schemas against OpenAPI spec
 npm run api-report        # Update API surface report (etc/esi.ts.api.md)
 ```
@@ -62,6 +63,7 @@ CI verifies generated types are fresh via `git diff --exit-code`.
 - `tests/contract/` — Contract tests against live OpenAPI spec
 - `tests/fuzz/` — Property-based fuzz tests (fast-check)
 - `tests/typetests/` — Type-level tests (tsd)
+- `okf/` — Generated OKF v0.2 knowledge bundle (per-endpoint + per-schema concepts)
 
 ## Key Patterns
 
@@ -101,3 +103,4 @@ Key middleware in the pipeline:
 - `src/core/endpoints/esi-*.generated.ts` — auto-generated cache TTLs, rate limits, scopes
 - `dist/` — build output
 - `etc/esi.ts.api.md` — auto-generated API surface report
+- `okf/` — auto-generated OKF knowledge bundle from OpenAPI spec

--- a/docs/okf-guide.md
+++ b/docs/okf-guide.md
@@ -1,0 +1,142 @@
+# Open Knowledge Format (OKF) for ESI
+
+This project generates an [OKF v0.2](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf) knowledge bundle that catalogs every endpoint and response schema in the EVE Swagger Interface (ESI) API.
+
+## What is OKF?
+
+OKF is an open, vendor-neutral specification for representing knowledge as **plain markdown files with YAML frontmatter** in a directory hierarchy. Created by Google Cloud, it formalizes a pattern for making organizational knowledge consumable by both humans and AI agents.
+
+Key properties:
+
+- **No SDK required** -- standard markdown with YAML frontmatter, readable by any tool (Obsidian, MkDocs, GitHub, LLMs).
+- **Provenance built in** -- every concept records who generated it, when, and from what source.
+- **Trust tiers** -- `generated`, `verified`, and `status` fields let consumers assess trustworthiness without runtime logic.
+- **Graph structure** -- directory hierarchy provides taxonomy; markdown cross-links create a richer relationship graph.
+- **Progressive disclosure** -- `index.md` files at each level let agents navigate one layer at a time instead of loading everything.
+
+## Bundle structure
+
+```
+okf/
+  index.md                              # Bundle root (okf_version: "0.2")
+  log.md                                # Generation changelog
+  domains/
+    index.md                            # Lists all 33 API domains
+    alliance/
+      index.md                          # Lists endpoints in this domain
+      get-alliances.md                  # One concept per endpoint
+      get-alliances-alliance-id.md
+      ...
+    market/
+      index.md
+      get-markets-region-id-orders.md
+      ...
+    ...  (33 domain directories)
+  schemas/
+    index.md                            # Lists all response schemas by domain
+    alliance-detail.md                  # One concept per response data model
+    markets-region-id-orders-get.md
+    ...  (161 schema concepts)
+```
+
+## Concept types
+
+### ESI Endpoint
+
+Each endpoint concept captures the full operational profile:
+
+```yaml
+---
+type: ESI Endpoint
+title: Get Markets Region ID Orders
+description: List orders in a region
+resource: "https://esi.evetech.net/ui/#/Market/GetMarketsRegionIdOrders"
+tags: [market, public, paginated]
+generated:
+  by: process:generate-okf
+  at: 2026-08-05T08:51:36Z
+status: stable
+sources:
+  - id: esi-openapi
+    resource: "https://esi.evetech.net/meta/openapi.json"
+    title: ESI OpenAPI Specification
+---
+```
+
+The body includes:
+
+| Section | Contents |
+|---------|----------|
+| **Endpoint** | HTTP method, path, auth requirement, cache TTL, rate limit group and budget |
+| **Scopes** | Required OAuth2 scopes (when authenticated) |
+| **Parameters** | Path and query parameters with types and descriptions |
+| **Response** | Link to the response schema concept, noting if it returns an array |
+
+### ESI Response Schema
+
+Each schema concept documents the fields of a response object:
+
+```yaml
+---
+type: ESI Response Schema
+title: Alliance Detail
+description: Public information about an alliance
+tags: [alliance, schema]
+generated:
+  by: process:generate-okf
+  at: 2026-08-05T08:51:36Z
+status: stable
+sources:
+  - id: esi-openapi
+    resource: "https://esi.evetech.net/meta/openapi.json"
+    title: ESI OpenAPI Specification
+---
+```
+
+The body contains a **Schema** table (field name, type, required, description) and a **Used By** section linking back to every endpoint that returns this schema.
+
+## How to use the bundle
+
+### With an LLM or AI agent
+
+Load concept files directly into context. Start with `okf/index.md` for an overview, drill into a domain via `okf/domains/<domain>/index.md`, then read individual endpoint concepts. The progressive disclosure pattern keeps token usage efficient.
+
+### As browsable documentation
+
+The bundle is valid markdown -- open it in any markdown viewer:
+
+- **GitHub** renders it natively when committed to a repository.
+- **Obsidian** treats it as a vault with working cross-links.
+- **MkDocs / Hugo / Jekyll** can serve it as a static site.
+
+### For programmatic consumption
+
+Parse YAML frontmatter from any concept file to extract structured metadata. The `type` field distinguishes endpoint concepts from schema concepts. Tags, scopes, and rate limit data are all available as structured YAML.
+
+## Regenerating the bundle
+
+```bash
+npm run generate:okf
+```
+
+This fetches the live ESI OpenAPI spec from `https://esi.evetech.net/meta/openapi.json` and regenerates the entire `okf/` directory. The previous bundle is replaced on each run.
+
+The generator script is `scripts/generate-okf.ts`. It extracts:
+
+- Endpoint paths, methods, and descriptions
+- Authentication requirements and OAuth2 scopes
+- Cache TTLs (`x-cache-age` extension)
+- Rate limit groups and budgets (`x-rate-limit` extension)
+- Path and query parameters (header parameters are filtered out)
+- Response schemas with field-level metadata
+
+## OKF specification reference
+
+The bundle conforms to [OKF v0.2](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md). Key conformance rules:
+
+1. Every non-reserved `.md` file has parseable YAML frontmatter with a non-empty `type` field.
+2. Reserved filenames (`index.md`, `log.md`) follow the spec-defined structure.
+3. Cross-links use bundle-relative paths (starting with `/`).
+4. Unknown frontmatter keys are preserved (the spec requires consumers to tolerate them).
+
+For the full specification, see the [OKF SPEC.md](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) and the [Google Cloud blog post](https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing) introducing the format.

--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "test:types": "tsd --files 'tests/typetests/*.test-d.ts'",
     "generate:types": "ts-node scripts/generate-esi-types.ts",
     "generate:clients": "ts-node scripts/generate-clients.ts",
+    "generate:okf": "ts-node scripts/generate-okf.ts",
     "knip": "knip",
     "validate:esi": "ts-node scripts/validate-esi-endpoints.ts",
     "validate:spec": "redocly lint",

--- a/scripts/generate-okf.ts
+++ b/scripts/generate-okf.ts
@@ -1,0 +1,796 @@
+/**
+ * ESI Open Knowledge Format (OKF) Bundle Generator
+ *
+ * Fetches the ESI OpenAPI 3.1 spec and generates an OKF v0.2 knowledge bundle
+ * cataloging every endpoint as a concept with full operational metadata
+ * (auth, scopes, cache TTLs, rate limits, parameters, response schemas).
+ *
+ * Usage: npx ts-node scripts/generate-okf.ts
+ *        npm run generate:okf
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ESI_OPENAPI_URL =
+  'https://esi.evetech.net/meta/openapi.json?compatibility_date=2025-12-16';
+const OKF_OUTPUT = path.resolve(__dirname, '../okf');
+
+// --- OpenAPI type definitions (subset needed for OKF generation) ---
+
+interface OpenApiSchema {
+  type?: string;
+  format?: string;
+  description?: string;
+  title?: string;
+  properties?: Record<string, OpenApiSchema>;
+  items?: OpenApiSchema;
+  required?: string[];
+  enum?: (string | number)[];
+  $ref?: string;
+}
+
+interface OpenApiRateLimitExtension {
+  group: string;
+  'max-tokens'?: number;
+  'window-size'?: string;
+}
+
+interface OpenApiParameter {
+  name: string;
+  in: string;
+  schema?: { type?: string; format?: string; enum?: string[] };
+  required?: boolean;
+  description?: string;
+  $ref?: string;
+}
+
+interface OpenApiOperation {
+  operationId?: string;
+  tags?: string[];
+  description?: string;
+  summary?: string;
+  'x-cache-age'?: number;
+  'x-rate-limit'?: OpenApiRateLimitExtension;
+  parameters?: OpenApiParameter[];
+  responses?: Record<
+    string,
+    {
+      description?: string;
+      content?: Record<string, { schema?: OpenApiSchema }>;
+    }
+  >;
+  security?: Record<string, string[]>[];
+  deprecated?: boolean;
+}
+
+interface OpenApiSpec {
+  info: { title: string; version: string };
+  paths: Record<string, Record<string, OpenApiOperation>>;
+  components?: {
+    schemas?: Record<string, OpenApiSchema>;
+    parameters?: Record<string, OpenApiParameter>;
+  };
+}
+
+// --- Helpers ---
+
+function resolveRef(spec: OpenApiSpec, ref: string): OpenApiSchema | undefined {
+  const prefix = '#/components/schemas/';
+  if (!ref.startsWith(prefix)) return undefined;
+  return spec.components?.schemas?.[ref.slice(prefix.length)];
+}
+
+function resolveSchema(
+  spec: OpenApiSpec,
+  schema: OpenApiSchema,
+): OpenApiSchema {
+  if (schema.$ref) {
+    const resolved = resolveRef(spec, schema.$ref);
+    if (resolved) return resolveSchema(spec, resolved);
+  }
+  return schema;
+}
+
+function resolveParameter(
+  spec: OpenApiSpec,
+  param: OpenApiParameter,
+): OpenApiParameter {
+  if (param.$ref) {
+    const prefix = '#/components/parameters/';
+    if (param.$ref.startsWith(prefix)) {
+      const name = param.$ref.slice(prefix.length);
+      const resolved = spec.components?.parameters?.[name];
+      if (resolved) return resolved;
+    }
+  }
+  return param;
+}
+
+function kebab(s: string): string {
+  return s
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/[\s_]+/g, '-')
+    .toLowerCase();
+}
+
+function titleCase(s: string): string {
+  return s
+    .split(/[-_\s]+/)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+}
+
+function operationIdToTitle(opId: string): string {
+  // Split PascalCase: "GetMarketsRegionIdOrders" -> "Get Markets Region Id Orders"
+  const words = opId
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
+    .replace(/_/g, ' ')
+    .split(' ');
+  return words
+    .map((w) => {
+      const lower = w.toLowerCase();
+      if (lower === 'id' || lower === 'ids') return 'ID';
+      if (lower === 'fw') return 'FW';
+      if (lower === 'ui') return 'UI';
+      if (lower === 'npc') return 'NPC';
+      if (lower === 'cspa') return 'CSPA';
+      return w.charAt(0).toUpperCase() + w.slice(1).toLowerCase();
+    })
+    .join(' ');
+}
+
+function operationIdToSlug(opId: string): string {
+  return kebab(opId.replace(/_/g, '-'));
+}
+
+function parseWindowSize(windowSize: string): number {
+  const match = windowSize.match(/^(\d+)([smh])$/);
+  if (!match || !match[1] || !match[2]) return 900_000;
+  const value = parseInt(match[1], 10);
+  switch (match[2]) {
+    case 's': return value * 1000;
+    case 'm': return value * 60 * 1000;
+    case 'h': return value * 60 * 60 * 1000;
+    default: return 900_000;
+  }
+}
+
+function formatDuration(seconds: number): string {
+  if (seconds >= 86400) return `${seconds / 86400}d`;
+  if (seconds >= 3600) return `${seconds / 3600}h`;
+  if (seconds >= 60) return `${seconds / 60}m`;
+  return `${seconds}s`;
+}
+
+function formatWindowMs(ms: number): string {
+  return formatDuration(ms / 1000);
+}
+
+function escapeYaml(s: string): string {
+  if (/[:#\[\]{}|>&*!?,]/.test(s) || s.includes("'") || s.includes('"')) {
+    return `"${s.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+  }
+  return s;
+}
+
+function schemaTypeLabel(schema: OpenApiSchema, spec: OpenApiSpec): string {
+  if (schema.$ref) {
+    const resolved = resolveRef(spec, schema.$ref);
+    if (resolved) return schemaTypeLabel(resolved, spec);
+    return 'unknown';
+  }
+  if (schema.enum) {
+    const vals = schema.enum.map((v) => (typeof v === 'string' ? `'${v}'` : String(v)));
+    return `enum(${vals.join(', ')})`;
+  }
+  if (schema.type === 'array' && schema.items) {
+    return `${schemaTypeLabel(schema.items, spec)}[]`;
+  }
+  if (schema.type === 'object' && schema.properties) return 'object';
+  if (schema.type === 'integer') return 'integer';
+  return schema.type ?? 'unknown';
+}
+
+// --- Extracted data structures ---
+
+interface EndpointConcept {
+  operationId: string;
+  slug: string;
+  title: string;
+  description: string;
+  tag: string;
+  tagSlug: string;
+  path: string;
+  method: string;
+  deprecated: boolean;
+  requiresAuth: boolean;
+  scopes: string[];
+  cacheTtl: number | null;
+  rateLimit: { group: string; maxTokens: number; windowMs: number } | null;
+  parameters: Array<{
+    name: string;
+    in: string;
+    type: string;
+    required: boolean;
+    description: string;
+  }>;
+  responseSchemaRef: string | null;
+  responseSchemaName: string | null;
+  responseIsArray: boolean;
+  responsePrimitive: string | null;
+}
+
+interface SchemaField {
+  name: string;
+  type: string;
+  required: boolean;
+  description: string;
+}
+
+interface EndpointRef {
+  slug: string;
+  tagSlug: string;
+}
+
+interface SchemaConcept {
+  refName: string;
+  slug: string;
+  title: string;
+  description: string;
+  tag: string;
+  fields: SchemaField[];
+  usedByEndpoints: EndpointRef[];
+}
+
+// --- Extraction ---
+
+function extractEndpoints(spec: OpenApiSpec): EndpointConcept[] {
+  const endpoints: EndpointConcept[] = [];
+  const httpMethods = ['get', 'post', 'put', 'delete'];
+
+  for (const [routePath, methods] of Object.entries(spec.paths)) {
+    for (const method of httpMethods) {
+      const op = methods[method] as OpenApiOperation | undefined;
+      if (!op) continue;
+
+      const operationId = op.operationId ?? `${method}_${routePath.replace(/\//g, '_')}`;
+      const tag = op.tags?.[0] ?? 'Uncategorized';
+      const cleanPath = routePath.replace(/^\//, '').replace(/\/$/, '');
+
+      // Auth
+      const scopes: string[] = [];
+      let requiresAuth = false;
+      if (op.security?.length) {
+        requiresAuth = true;
+        for (const req of op.security) {
+          for (const scopeList of Object.values(req)) {
+            scopes.push(...scopeList);
+          }
+        }
+      }
+
+      // Cache TTL
+      const cacheTtl = typeof op['x-cache-age'] === 'number' ? op['x-cache-age'] : null;
+
+      // Rate limit
+      let rateLimit: EndpointConcept['rateLimit'] = null;
+      if (op['x-rate-limit']?.group) {
+        rateLimit = {
+          group: op['x-rate-limit'].group,
+          maxTokens: op['x-rate-limit']['max-tokens'] ?? 300,
+          windowMs: parseWindowSize(op['x-rate-limit']['window-size'] ?? '15m'),
+        };
+      }
+
+      // Parameters (filter out headers — they're common across all endpoints)
+      const parameters: EndpointConcept['parameters'] = [];
+      if (op.parameters) {
+        for (const rawParam of op.parameters) {
+          const param = resolveParameter(spec, rawParam);
+          if (param.in === 'header') continue;
+          parameters.push({
+            name: param.name,
+            in: param.in,
+            type: param.schema?.type ?? 'string',
+            required: param.required ?? false,
+            description: param.description ?? '',
+          });
+        }
+      }
+
+      // Response schema
+      let responseSchemaRef: string | null = null;
+      let responseSchemaName: string | null = null;
+      let responseIsArray = false;
+      let responsePrimitive: string | null = null;
+
+      const response200 = op.responses?.['200'];
+      if (response200?.content?.['application/json']?.schema) {
+        let schema = response200.content['application/json'].schema;
+        const prefix = '#/components/schemas/';
+
+        // Resolve top-level $ref, keeping the ref name
+        if (schema.$ref) {
+          responseSchemaRef = schema.$ref;
+          if (schema.$ref.startsWith(prefix)) {
+            responseSchemaName = schema.$ref.slice(prefix.length);
+          }
+          schema = resolveSchema(spec, schema);
+        }
+
+        if (schema.type === 'array' && schema.items) {
+          responseIsArray = true;
+          // If items have their own $ref, prefer that name over the array wrapper
+          if (schema.items.$ref) {
+            responseSchemaRef = schema.items.$ref;
+            if (schema.items.$ref.startsWith(prefix)) {
+              responseSchemaName = schema.items.$ref.slice(prefix.length);
+            }
+          } else if (
+            schema.items.type === 'integer' ||
+            schema.items.type === 'number' ||
+            schema.items.type === 'string'
+          ) {
+            responsePrimitive = schema.items.type;
+            responseSchemaName = null;
+            responseSchemaRef = null;
+          }
+          // else: inline objects in array — keep the array wrapper's $ref name
+        }
+      }
+
+      endpoints.push({
+        operationId,
+        slug: operationIdToSlug(operationId),
+        title: operationIdToTitle(operationId),
+        description: op.summary ?? op.description?.split('\n')[0] ?? '',
+        tag,
+        tagSlug: kebab(tag),
+        path: cleanPath,
+        method: method.toUpperCase(),
+        deprecated: op.deprecated ?? false,
+        requiresAuth,
+        scopes: [...new Set(scopes)],
+        cacheTtl,
+        rateLimit,
+        parameters: parameters.filter((p) => p.name !== 'datasource'),
+        responseSchemaRef,
+        responseSchemaName,
+        responseIsArray,
+        responsePrimitive,
+      });
+    }
+  }
+
+  return endpoints;
+}
+
+function extractSchemas(
+  spec: OpenApiSpec,
+  endpoints: EndpointConcept[],
+): SchemaConcept[] {
+  const schemaRefs = new Map<string, { name: string; endpoints: EndpointRef[] }>();
+
+  for (const ep of endpoints) {
+    if (ep.responseSchemaName) {
+      const existing = schemaRefs.get(ep.responseSchemaName);
+      const ref: EndpointRef = { slug: ep.slug, tagSlug: ep.tagSlug };
+      if (existing) {
+        existing.endpoints.push(ref);
+      } else {
+        schemaRefs.set(ep.responseSchemaName, {
+          name: ep.responseSchemaName,
+          endpoints: [ref],
+        });
+      }
+    }
+  }
+
+  const schemas: SchemaConcept[] = [];
+
+  for (const [refName, info] of schemaRefs) {
+    const raw = spec.components?.schemas?.[refName];
+    if (!raw) continue;
+
+    let schema = resolveSchema(spec, raw);
+
+    // Unwrap array schemas to get the item object
+    if (schema.type === 'array' && schema.items) {
+      schema = resolveSchema(spec, schema.items);
+    }
+
+    if (!schema.properties) continue;
+
+    const required = new Set(schema.required ?? []);
+    const fields: SchemaField[] = [];
+
+    for (const [fieldName, fieldSchema] of Object.entries(schema.properties)) {
+      const resolved = resolveSchema(spec, fieldSchema);
+      fields.push({
+        name: fieldName,
+        type: schemaTypeLabel(resolved, spec),
+        required: required.has(fieldName),
+        description: resolved.description ?? '',
+      });
+    }
+
+    const tag = endpoints.find((e) => e.responseSchemaName === refName)?.tag ?? 'Uncategorized';
+
+    schemas.push({
+      refName,
+      slug: kebab(refName),
+      title: titleCase(refName),
+      description: schema.description ?? schema.title ?? `${titleCase(refName)} response object`,
+      tag,
+      fields,
+      usedByEndpoints: info.endpoints,
+    });
+  }
+
+  return schemas;
+}
+
+// --- OKF Markdown Generation ---
+
+function generateTimestamp(): string {
+  const now = new Date();
+  return now.toISOString().replace(/\.\d{3}Z$/, 'Z');
+}
+
+function generateBundleIndex(
+  tags: string[],
+  endpointCount: number,
+  schemaCount: number,
+): string {
+  const lines = [
+    '---',
+    'okf_version: "0.2"',
+    '---',
+    '',
+    '# EVE Online ESI API Knowledge Bundle',
+    '',
+    `This bundle catalogs **${endpointCount} endpoints** and **${schemaCount} response schemas** from the EVE Swagger Interface (ESI), the official API for EVE Online.`,
+    '',
+    '## Domains',
+    '',
+  ];
+
+  for (const tag of tags.sort()) {
+    lines.push(`* [${titleCase(tag)}](domains/${kebab(tag)}/index.md) - ${titleCase(tag)} API endpoints`);
+  }
+
+  lines.push('');
+  lines.push('## Response Schemas');
+  lines.push('');
+  lines.push('* [All Schemas](schemas/index.md) - Response data models used by ESI endpoints');
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+function generateLog(
+  endpointCount: number,
+  schemaCount: number,
+  specVersion: string,
+): string {
+  const date = new Date().toISOString().split('T')[0];
+  return [
+    '# Bundle Update Log',
+    '',
+    `## ${date}`,
+    '',
+    `* **Generation**: Generated OKF bundle from ESI OpenAPI spec v${specVersion}`,
+    `* **Coverage**: ${endpointCount} endpoint concepts, ${schemaCount} schema concepts`,
+    `* **Generator**: \`scripts/generate-okf.ts\``,
+    '',
+  ].join('\n');
+}
+
+function generateDomainIndex(
+  tag: string,
+  endpoints: EndpointConcept[],
+): string {
+  const lines = [
+    `# ${titleCase(tag)}`,
+    '',
+    `${titleCase(tag)} API endpoints.`,
+    '',
+    '## Endpoints',
+    '',
+  ];
+
+  const sorted = endpoints.sort((a, b) => a.slug.localeCompare(b.slug));
+  for (const ep of sorted) {
+    const authBadge = ep.requiresAuth ? ' (auth)' : '';
+    lines.push(`* [${ep.title}](${ep.slug}.md) - \`${ep.method} /${ep.path}\`${authBadge}`);
+  }
+
+  lines.push('');
+  return lines.join('\n');
+}
+
+function generateDomainsIndex(tags: string[]): string {
+  const lines = [
+    '# API Domains',
+    '',
+    'ESI endpoints organized by domain.',
+    '',
+  ];
+
+  for (const tag of tags.sort()) {
+    lines.push(`* [${titleCase(tag)}](${kebab(tag)}/index.md)`);
+  }
+
+  lines.push('');
+  return lines.join('\n');
+}
+
+function generateEndpointConcept(
+  ep: EndpointConcept,
+  timestamp: string,
+): string {
+  const tags: string[] = [ep.tagSlug];
+  if (!ep.requiresAuth) tags.push('public');
+  if (ep.requiresAuth) tags.push('authenticated');
+  if (ep.deprecated) tags.push('deprecated');
+  const hasPagination = ep.parameters.some((p) => p.name === 'page');
+  if (hasPagination) tags.push('paginated');
+
+  const lines = [
+    '---',
+    'type: ESI Endpoint',
+    `title: ${escapeYaml(ep.title)}`,
+    `description: ${escapeYaml(ep.description || `${ep.method} /${ep.path}`)}`,
+    `resource: "https://esi.evetech.net/ui/#/${encodeURIComponent(ep.tag)}/${ep.operationId}"`,
+    `tags: [${tags.join(', ')}]`,
+    'generated:',
+    '  by: process:generate-okf',
+    `  at: ${timestamp}`,
+    `status: ${ep.deprecated ? 'deprecated' : 'stable'}`,
+    'sources:',
+    '  - id: esi-openapi',
+    '    resource: "https://esi.evetech.net/meta/openapi.json"',
+    '    title: ESI OpenAPI Specification',
+    '---',
+    '',
+    '# Endpoint',
+    '',
+    '| Property | Value |',
+    '|----------|-------|',
+    `| Path | \`${ep.method} /${ep.path}\` |`,
+    `| Authentication | ${ep.requiresAuth ? 'Required' : 'None'} |`,
+  ];
+
+  if (ep.cacheTtl !== null) {
+    lines.push(`| Cache TTL | ${ep.cacheTtl}s (${formatDuration(ep.cacheTtl)}) |`);
+  }
+
+  if (ep.rateLimit) {
+    lines.push(
+      `| Rate Limit Group | ${ep.rateLimit.group} |`,
+      `| Rate Limit | ${ep.rateLimit.maxTokens} tokens / ${formatWindowMs(ep.rateLimit.windowMs)} |`,
+    );
+  }
+
+  if (ep.scopes.length > 0) {
+    lines.push('', '# Scopes', '', 'Required OAuth2 scopes:', '');
+    for (const scope of ep.scopes) {
+      lines.push(`- \`${scope}\``);
+    }
+  }
+
+  const paramsByLocation = new Map<string, typeof ep.parameters>();
+  for (const p of ep.parameters) {
+    const group = paramsByLocation.get(p.in) ?? [];
+    group.push(p);
+    paramsByLocation.set(p.in, group);
+  }
+
+  if (ep.parameters.length > 0) {
+    lines.push('', '# Parameters', '');
+    lines.push('| Name | In | Type | Required | Description |');
+    lines.push('|------|-----|------|----------|-------------|');
+    for (const p of ep.parameters) {
+      lines.push(`| ${p.name} | ${p.in} | ${p.type} | ${p.required ? 'yes' : 'no'} | ${p.description} |`);
+    }
+  }
+
+  lines.push('', '# Response', '');
+
+  if (ep.responseSchemaName) {
+    const schemaSlug = kebab(ep.responseSchemaName);
+    const schemaLink = `[${titleCase(ep.responseSchemaName)}](/schemas/${schemaSlug}.md)`;
+    if (ep.responseIsArray) {
+      lines.push(`Returns an array of ${schemaLink} objects.`);
+    } else {
+      lines.push(`Returns a ${schemaLink} object.`);
+    }
+  } else if (ep.responsePrimitive) {
+    lines.push(`Returns an array of \`${ep.responsePrimitive}\` values.`);
+  } else {
+    lines.push('No structured response body.');
+  }
+
+  lines.push('');
+  return lines.join('\n');
+}
+
+function generateSchemaConcept(
+  schema: SchemaConcept,
+  timestamp: string,
+): string {
+  const lines = [
+    '---',
+    'type: ESI Response Schema',
+    `title: ${escapeYaml(schema.title)}`,
+    `description: ${escapeYaml(schema.description)}`,
+    `tags: [${kebab(schema.tag)}, schema]`,
+    'generated:',
+    '  by: process:generate-okf',
+    `  at: ${timestamp}`,
+    'status: stable',
+    'sources:',
+    '  - id: esi-openapi',
+    '    resource: "https://esi.evetech.net/meta/openapi.json"',
+    '    title: ESI OpenAPI Specification',
+    '---',
+    '',
+    '# Schema',
+    '',
+    '| Field | Type | Required | Description |',
+    '|-------|------|----------|-------------|',
+  ];
+
+  for (const field of schema.fields) {
+    lines.push(
+      `| ${field.name} | ${field.type} | ${field.required ? 'yes' : 'no'} | ${field.description} |`,
+    );
+  }
+
+  if (schema.usedByEndpoints.length > 0) {
+    lines.push('', '# Used By', '');
+    for (const ep of schema.usedByEndpoints) {
+      lines.push(`- [${ep.slug}](/domains/${ep.tagSlug}/${ep.slug}.md)`);
+    }
+  }
+
+  lines.push('');
+  return lines.join('\n');
+}
+
+function generateSchemasIndex(schemas: SchemaConcept[]): string {
+  const lines = [
+    '# Response Schemas',
+    '',
+    'Data models returned by ESI API endpoints.',
+    '',
+  ];
+
+  const byTag = new Map<string, SchemaConcept[]>();
+  for (const s of schemas) {
+    const group = byTag.get(s.tag) ?? [];
+    group.push(s);
+    byTag.set(s.tag, group);
+  }
+
+  for (const [tag, group] of Array.from(byTag.entries()).sort((a, b) => a[0].localeCompare(b[0]))) {
+    lines.push(`## ${titleCase(tag)}`, '');
+    for (const s of group.sort((a, b) => a.slug.localeCompare(b.slug))) {
+      lines.push(`* [${s.title}](${s.slug}.md) - ${s.description}`);
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+// --- File writing ---
+
+function writeFile(filePath: string, content: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content, 'utf-8');
+}
+
+// --- Main ---
+
+async function main(): Promise<void> {
+  console.log(`Fetching ESI OpenAPI spec from ${ESI_OPENAPI_URL}...`);
+
+  let spec: OpenApiSpec;
+  try {
+    const response = await fetch(ESI_OPENAPI_URL);
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+    spec = (await response.json()) as OpenApiSpec;
+  } catch (err) {
+    console.error(`Failed to fetch ESI OpenAPI spec: ${err}`);
+    process.exit(1);
+  }
+
+  console.log(`Spec version: ${spec.info.version}`);
+
+  // Extract data
+  const endpoints = extractEndpoints(spec);
+  console.log(`Extracted ${endpoints.length} endpoints`);
+
+  const schemas = extractSchemas(spec, endpoints);
+  console.log(`Extracted ${schemas.length} response schemas`);
+
+  const tags = [...new Set(endpoints.map((e) => e.tag))];
+  console.log(`Found ${tags.length} domains: ${tags.sort().join(', ')}`);
+
+  const timestamp = generateTimestamp();
+
+  // Clean output directory
+  if (fs.existsSync(OKF_OUTPUT)) {
+    fs.rmSync(OKF_OUTPUT, { recursive: true });
+  }
+
+  // Bundle root
+  writeFile(
+    path.join(OKF_OUTPUT, 'index.md'),
+    generateBundleIndex(tags, endpoints.length, schemas.length),
+  );
+  writeFile(
+    path.join(OKF_OUTPUT, 'log.md'),
+    generateLog(endpoints.length, schemas.length, spec.info.version),
+  );
+
+  // Domains index
+  writeFile(
+    path.join(OKF_OUTPUT, 'domains', 'index.md'),
+    generateDomainsIndex(tags),
+  );
+
+  // Per-domain directories + endpoint concepts
+  const byTag = new Map<string, EndpointConcept[]>();
+  for (const ep of endpoints) {
+    const group = byTag.get(ep.tag) ?? [];
+    group.push(ep);
+    byTag.set(ep.tag, group);
+  }
+
+  let endpointFiles = 0;
+  for (const [tag, eps] of byTag) {
+    const tagDir = path.join(OKF_OUTPUT, 'domains', kebab(tag));
+
+    writeFile(
+      path.join(tagDir, 'index.md'),
+      generateDomainIndex(tag, eps),
+    );
+
+    for (const ep of eps) {
+      writeFile(
+        path.join(tagDir, `${ep.slug}.md`),
+        generateEndpointConcept(ep, timestamp),
+      );
+      endpointFiles++;
+    }
+  }
+
+  // Schemas
+  writeFile(
+    path.join(OKF_OUTPUT, 'schemas', 'index.md'),
+    generateSchemasIndex(schemas),
+  );
+
+  let schemaFiles = 0;
+  for (const schema of schemas) {
+    writeFile(
+      path.join(OKF_OUTPUT, 'schemas', `${schema.slug}.md`),
+      generateSchemaConcept(schema, timestamp),
+    );
+    schemaFiles++;
+  }
+
+  console.log(`\nOKF bundle written to ${OKF_OUTPUT}/`);
+  console.log(`  ${endpointFiles} endpoint concepts`);
+  console.log(`  ${schemaFiles} schema concepts`);
+  console.log(`  ${tags.length} domain indexes`);
+  console.log(`  ${endpointFiles + schemaFiles + tags.length + 3} total files`);
+}
+
+main();


### PR DESCRIPTION
## Summary

- Adds `scripts/generate-okf.ts` — a generator that fetches the live ESI OpenAPI spec and produces an [OKF v0.2](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf) knowledge bundle cataloging all ESI endpoints and response schemas
- **208 endpoint concepts** across 33 API domains, each with auth requirements, OAuth2 scopes, cache TTLs, rate limit groups, parameters, and response schema cross-links
- **161 response schema concepts** with field-level metadata and "Used By" back-links to endpoints
- Progressive disclosure via `index.md` at every directory level for efficient LLM/agent navigation
- `docs/okf-guide.md` explains the format, bundle structure, and usage patterns (LLM context, Obsidian, MkDocs, programmatic)
- `npm run generate:okf` to regenerate; `okf/` is gitignored as generated output

## Context

OKF is Google Cloud's open, vendor-neutral format for representing knowledge as markdown + YAML frontmatter. Blog post: https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing

This makes the ESI API surface consumable by AI agents, browsable in markdown tools, and queryable via YAML frontmatter — without requiring the ESI OpenAPI spec directly.

## Test plan

- [x] `npm run generate:okf` runs successfully, produces 405 files
- [x] `npm run typecheck` passes
- [x] Bundle root has `okf_version: "0.2"` frontmatter
- [x] Endpoint concepts include auth, scopes, cache TTL, rate limits, parameters
- [x] Schema concepts include field tables and Used By cross-links
- [x] Array responses correctly say "Returns an array of" (not "Returns a")
- [x] Header parameters (Accept-Language, If-None-Match, etc.) are filtered out
- [x] Paginated tag only applied to endpoints with a `page` query parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)