### PR TITLE
refactor: decompose ApiRequestHandler into requestPipeline modules

### DIFF
--- a/src/core/ApiRequestHandler.ts
+++ b/src/core/ApiRequestHandler.ts
@@ -1,610 +1,26 @@
 import { ApiClient } from './ApiClient';
-import { buildError, EsiError, TimeoutError } from '../core/util/error';
+
 import {
-  logInfo,
-  logWarn,
-  logError,
-  logDebug,
-} from '../core/logger/loggerUtil';
-import { parseHeaders, ParsedHeaders } from '../core/util/headersUtil';
-import { ICache } from './cache/ICache';
-import { IRateLimiter } from './rateLimiter/IRateLimiter';
-import { PaginationHandler, PageFetcher } from './pagination/PaginationHandler';
-import { CursorTokens } from './pagination/CursorPaginationHandler';
-import { USER_AGENT, COMPATIBILITY_DATE } from './constants';
-import { RequestContext, ResponseContext } from './middleware/Middleware';
-import { ICircuitBreaker } from './circuitBreaker/ICircuitBreaker';
-import { esiCacheTtls } from './endpoints/esi-cache-ttls.generated';
-import { CircuitOpenError } from './circuitBreaker/CircuitBreaker';
-import { IRetryStrategy } from './IRetryStrategy';
-import { RetryStrategy } from './RetryStrategy';
+  trySpecAwareCacheHit,
+  cacheResponse,
+  handleEarlyStatus,
+  handleErrorResponse,
+  wrapError,
+  handleCursorPagination,
+  handleOffsetPagination,
+  applyResponseInterceptors,
+  executeSingleFetch,
+  fetchOnePage,
+  parseJsonBody,
+  resolveCache,
+  resolveRateLimiter,
+  resolveCircuitBreaker,
+  resolveRetryStrategy,
+} from './requestPipeline';
+export type { EsiHandlerResponse } from './requestPipeline';
+import type { EsiHandlerResponse } from './requestPipeline';
 
-export interface EsiHandlerResponse {
-  headers: Record<string, string>;
-  body: unknown;
-  fromCache?: boolean;
-  stale?: boolean;
-  cacheHitType?: 'spec-ttl' | 'etag-304' | 'stale-on-error';
-  responseTimeMs?: number;
-  cursors?: CursorTokens;
-}
-
-const STATUS_MESSAGES: Record<number, string> = {
-  201: 'Created',
-  204: 'No Content',
-  304: 'Not Modified',
-  400: 'Bad Request',
-  401: 'Unauthorized',
-  403: 'Forbidden',
-  404: 'Resource not found',
-  420: 'Error Limited',
-  422: 'Unprocessable Entity',
-  429: 'Too many requests',
-  500: 'Internal server error',
-  503: 'Service Unavailable',
-  504: 'Gateway Timeout',
-  520: 'Internal server error, did the request terminate too soon?',
-};
-
-// --- Dependency resolution ---
-
-function resolveCache(client: ApiClient): ICache | null {
-  return client.getCache();
-}
-
-function resolveRateLimiter(client: ApiClient): IRateLimiter {
-  const limiter = client.getRateLimiter();
-  if (!limiter) {
-    throw buildError(
-      'No rate limiter configured on ApiClient. ' +
-        'Set one via apiClient.setRateLimiter(new RateLimiter()).',
-      'CONFIGURATION_ERROR',
-    );
-  }
-  return limiter;
-}
-
-function resolveCircuitBreaker(client: ApiClient): ICircuitBreaker | null {
-  return client.getCircuitBreaker();
-}
-
-function resolveRetryStrategy(client: ApiClient): IRetryStrategy {
-  return (
-    client.getRetryStrategy() ??
-    new RetryStrategy(client.getRetryConfig() ?? undefined)
-  );
-}
-
-// --- Pure helpers ---
-
-import { camelToSnake } from './util/stringUtil';
-
-function lookupSpecTtl(
-  method: string,
-  templatePath: string,
-): number | undefined {
-  const normalized = templatePath
-    .replace(/\/$/, '')
-    .replace(/\{(\w+)\}/g, (_, name: string) => `{${camelToSnake(name)}}`);
-  const key = `${method}:${normalized}`;
-  const seconds = esiCacheTtls[key];
-  return typeof seconds === 'number' ? seconds * 1000 : undefined;
-}
-
-function trySpecAwareCacheHit(
-  client: ApiClient,
-  url: string,
-  method: string,
-  templatePath?: string,
-): EsiHandlerResponse | null {
-  if (method !== 'GET' || !templatePath) return null;
-  const specTtlMs = lookupSpecTtl(method, templatePath);
-  if (!specTtlMs) return null;
-  const cache = resolveCache(client);
-  if (!cache) return null;
-  const entry = cache.get(url);
-  if (!entry) return null;
-  const age = Date.now() - entry.timestamp;
-  if (age < specTtlMs) {
-    logDebug(
-      `Spec-aware cache hit for ${url} (age=${Math.round(age / 1000)}s, ttl=${Math.round(specTtlMs / 1000)}s)`,
-    );
-    return {
-      headers: entry.headers,
-      body: entry.data,
-      fromCache: true,
-      cacheHitType: 'spec-ttl',
-    };
-  }
-  return null;
-}
-
-const parseCacheControlTtl = (
-  headers: Record<string, string>,
-): number | undefined => {
-  const cacheControl = headers['cache-control'] ?? headers['Cache-Control'];
-  if (!cacheControl) return undefined;
-  const match = /max-age=(\d+)/.exec(cacheControl);
-  return match ? parseInt(match[1]!, 10) * 1000 : undefined;
-};
-
-function buildRequestHeaders(
-  client: ApiClient,
-  url: string,
-  method: string,
-  requiresAuth: boolean,
-  useETag: boolean,
-  body: unknown,
-): HeadersInit {
-  const headers: HeadersInit = {
-    Accept: 'application/json',
-    'Accept-Encoding': 'gzip, deflate, br',
-    'User-Agent': USER_AGENT,
-    'X-Compatibility-Date': COMPATIBILITY_DATE,
-  };
-
-  const language = client.getLanguage();
-  if (language) {
-    headers['Accept-Language'] = language;
-  }
-
-  if (requiresAuth) {
-    const authHeader = client.getAuthorizationHeader();
-    if (!authHeader) {
-      throw buildError(
-        'Authorization header is required but not provided',
-        'NO_AUTH_TOKEN',
-      );
-    }
-    headers['Authorization'] = authHeader;
-  }
-
-  const cache = resolveCache(client);
-  if (useETag && method === 'GET' && cache) {
-    const cachedETag = cache.getETag(url);
-    if (cachedETag) {
-      headers['If-None-Match'] = cachedETag;
-      logDebug(`Adding If-None-Match header: ${cachedETag}`);
-    }
-  }
-
-  if (body) {
-    headers['Content-Type'] = 'application/json';
-  }
-
-  return headers;
-}
-
-function handleEarlyStatus(
-  client: ApiClient,
-  status: number,
-  url: string,
-  parsed: ParsedHeaders,
-  useETag: boolean,
-): EsiHandlerResponse | null {
-  if (status === 201) {
-    return { headers: parsed.raw, body: undefined };
-  }
-
-  if (status === 204) {
-    logInfo(`No Content for endpoint: ${url}`);
-    return { headers: parsed.raw, body: undefined };
-  }
-
-  if (status === 304) {
-    const cache = resolveCache(client);
-    if (useETag && cache) {
-      const cachedEntry = cache.get(url);
-      if (cachedEntry) {
-        logInfo(`Cache hit (304) for endpoint: ${url}`);
-        return {
-          headers: { ...cachedEntry.headers, ...parsed.raw },
-          body: cachedEntry.data,
-          fromCache: true,
-          cacheHitType: 'etag-304',
-        };
-      }
-    }
-    throw new EsiError(
-      304,
-      'Not Modified — no cached data available',
-      url,
-      parsed.requestId ?? undefined,
-    );
-  }
-
-  return null;
-}
-
-function tryStaleCacheResponse(
-  client: ApiClient,
-  url: string,
-  parsed: ParsedHeaders,
-): EsiHandlerResponse | null {
-  const cache = resolveCache(client);
-  if (!cache) return null;
-  const cachedEntry = cache.get(url);
-  if (!cachedEntry) return null;
-  return {
-    headers: { ...cachedEntry.headers, ...parsed.raw },
-    body: cachedEntry.data,
-    fromCache: true,
-    stale: true,
-    cacheHitType: 'stale-on-error',
-  };
-}
-
-function cacheResponse(
-  client: ApiClient,
-  url: string,
-  method: string,
-  endpoint: string,
-  parsed: ParsedHeaders,
-  data: unknown,
-  useETag: boolean,
-  templatePath?: string,
-): void {
-  const cache = resolveCache(client);
-  if (useETag && method === 'GET' && cache && parsed.etag) {
-    const headerTtl = parseCacheControlTtl(parsed.raw);
-    const specTtlMs = templatePath
-      ? lookupSpecTtl(method, templatePath)
-      : undefined;
-    const ttl = specTtlMs ?? headerTtl;
-    cache.set(url, parsed.etag, data, parsed.raw, ttl);
-    const ttlInfo = ttl ? ` (ttl=${ttl}ms)` : '';
-    logDebug(`Cached response for ${url} with ETag ${parsed.etag}${ttlInfo}`);
-  }
-
-  if (method !== 'GET' && cache) {
-    cache.deleteByPath(endpoint.split('?')[0]!);
-  }
-}
-
-async function parseJsonBody(
-  response: Response,
-  _url: string,
-): Promise<unknown> {
-  try {
-    return (await response.json()) as unknown;
-  } catch (jsonError) {
-    const msg =
-      jsonError instanceof Error ? jsonError.message : String(jsonError);
-    logError(`Failed to parse JSON response: ${msg}`);
-    throw buildError(`Invalid JSON response: ${msg}`, 'JSON_PARSE_ERROR');
-  }
-}
-
-function handleCursorPagination(
-  parsed: ParsedHeaders,
-  data: unknown,
-): EsiHandlerResponse | null {
-  if (!parsed.hasCursorPagination) return null;
-
-  const cursors: CursorTokens = {
-    before: parsed.cursorBefore,
-    after: parsed.cursorAfter,
-  };
-
-  return { headers: parsed.raw, body: data, cursors };
-}
-
-async function handleOffsetPagination(
-  client: ApiClient,
-  endpoint: string,
-  method: string,
-  requiresAuth: boolean,
-  parsed: ParsedHeaders,
-  data: unknown,
-  body: unknown,
-  url: string,
-  useETag: boolean,
-  pageFetch: PageFetcher,
-  templatePath?: string,
-): Promise<EsiHandlerResponse> {
-  const totalPages = parsed.xPages;
-
-  if (totalPages <= 1) {
-    return { headers: parsed.raw, body: data };
-  }
-
-  logInfo(
-    `Found ${totalPages} pages, fetching additional pages with rate limiting...`,
-  );
-
-  try {
-    const firstPageData = Array.isArray(data) ? data : [data];
-    const allData = await PaginationHandler.fetchRemainingPages(
-      client,
-      endpoint,
-      method,
-      requiresAuth,
-      firstPageData,
-      totalPages,
-      body,
-      {
-        maxPages: Math.min(totalPages, 1000),
-        stopOnEmptyPage: true,
-        maxRetries: 3,
-      },
-      pageFetch,
-      templatePath,
-    );
-
-    cacheResponse(
-      client,
-      url,
-      method,
-      endpoint,
-      parsed,
-      allData,
-      useETag,
-      templatePath,
-    );
-    return { headers: parsed.raw, body: allData };
-  } catch (paginationError: unknown) {
-    const msg =
-      paginationError instanceof Error
-        ? paginationError.message
-        : String(paginationError);
-    logWarn(`Pagination failed for ${url}: ${msg}`);
-    if (
-      paginationError instanceof EsiError ||
-      paginationError instanceof CircuitOpenError
-    ) {
-      throw paginationError;
-    }
-    throw buildError(
-      `Pagination incomplete for ${url}: ${msg}`,
-      'PAGINATION_INCOMPLETE',
-      url,
-    );
-  }
-}
-
-// --- Response interceptor wrapper ---
-
-async function applyResponseInterceptors(
-  client: ApiClient,
-  result: EsiHandlerResponse,
-  url: string,
-  endpoint: string,
-  method: string,
-  startTime: number,
-): Promise<EsiHandlerResponse> {
-  const middleware = client.getMiddleware();
-  if (!middleware.hasInterceptors()) return result;
-
-  const responseCtx: ResponseContext = {
-    url,
-    endpoint,
-    method,
-    status: 200,
-    headers: result.headers,
-    body: result.body,
-    durationMs: Date.now() - startTime,
-    fromCache: result.fromCache ?? false,
-  };
-
-  const modified = await middleware.applyResponseInterceptors(responseCtx);
-  return {
-    ...result,
-    headers: modified.headers,
-    body: modified.body,
-  };
-}
-
-// --- Main request functions ---
-
-async function applyRequestMiddleware(
-  client: ApiClient,
-  url: string,
-  endpoint: string,
-  method: string,
-  headers: Record<string, string>,
-  body: unknown,
-): Promise<{ url: string; headers: Record<string, string>; body: unknown }> {
-  const middleware = client.getMiddleware();
-  if (!middleware.hasInterceptors()) {
-    return { url, headers, body };
-  }
-  const reqCtx: RequestContext = {
-    url,
-    endpoint,
-    method,
-    headers: { ...headers },
-    body,
-  };
-  const modified = await middleware.applyRequestInterceptors(reqCtx);
-  return {
-    url: modified.url,
-    headers: modified.headers,
-    body: modified.body,
-  };
-}
-
-function handleErrorResponse(
-  client: ApiClient,
-  response: Response,
-  url: string,
-  parsed: ParsedHeaders,
-  useETag: boolean,
-): EsiHandlerResponse | never {
-  const errorMessage = STATUS_MESSAGES[response.status] || response.statusText;
-
-  if (response.status >= 500 && useETag) {
-    const staleResult = tryStaleCacheResponse(client, url, parsed);
-    if (staleResult) {
-      logWarn(`${errorMessage} for ${url} — serving stale cache`);
-      return staleResult;
-    }
-  }
-
-  if (response.status === 420 || response.status === 429) {
-    logWarn(`Rate limited (${response.status}) on ${url}`);
-  }
-
-  throw new EsiError(
-    response.status,
-    errorMessage,
-    url,
-    parsed.requestId ?? undefined,
-  );
-}
-
-function wrapError(error: unknown): never {
-  if (error instanceof EsiError || error instanceof CircuitOpenError) {
-    throw error;
-  }
-  if (error instanceof Error) {
-    logError(`Unexpected error: ${error.message}`);
-    throw buildError(error.message, 'ESIJS_ERROR');
-  }
-  logError(`Unexpected error: ${String(error)}`);
-  throw buildError(String(error), 'ESIJS_ERROR');
-}
-
-interface RawFetchResult {
-  response: Response;
-  parsed: ParsedHeaders;
-  url: string;
-}
-
-async function executeSingleFetch(
-  client: ApiClient,
-  endpoint: string,
-  method: string,
-  body: unknown,
-  requiresAuth: boolean,
-  useETag: boolean,
-  requestTimeout?: number,
-  templatePath?: string,
-): Promise<RawFetchResult> {
-  const rawUrl = `${client.getLink()}/${endpoint}`;
-  const builtHeaders = buildRequestHeaders(
-    client,
-    rawUrl,
-    method,
-    requiresAuth,
-    useETag,
-    body,
-  ) as Record<string, string>;
-
-  const req = await applyRequestMiddleware(
-    client,
-    rawUrl,
-    endpoint,
-    method,
-    builtHeaders,
-    body,
-  );
-
-  const options: RequestInit = {
-    method,
-    headers: req.headers,
-    body: req.body ? JSON.stringify(req.body) : undefined,
-  };
-
-  const url = req.url;
-  logInfo(`Hitting endpoint: ${url}`);
-
-  const cb = resolveCircuitBreaker(client);
-  if (cb) cb.checkCircuit(endpoint);
-
-  const rateLimiter = resolveRateLimiter(client);
-  await rateLimiter.checkRateLimit(templatePath, method, req.headers);
-
-  const timeoutMs = requestTimeout ?? client.getTimeout();
-  const controller = new AbortController();
-  const timer = globalThis.setTimeout(() => controller.abort(), timeoutMs);
-  options.signal = controller.signal;
-
-  let response: Response;
-  try {
-    response = await fetch(url, options);
-  } catch (err) {
-    clearTimeout(timer);
-    if (cb) {
-      // Status 0 = network/timeout failure — counts toward opening the circuit
-      cb.recordFailure(endpoint, 0);
-    }
-    if (err instanceof Error && err.name === 'AbortError') {
-      throw new TimeoutError(timeoutMs, url);
-    }
-    throw err;
-  }
-  clearTimeout(timer);
-
-  const parsed = parseHeaders(response.headers);
-
-  rateLimiter.updateFromResponse(
-    parsed.raw,
-    response.status,
-    templatePath,
-    method,
-    req.headers,
-  );
-
-  if (cb) {
-    if (
-      response.status >= 500 ||
-      response.status === 420 ||
-      response.status === 429
-    ) {
-      cb.recordFailure(endpoint, response.status);
-    } else {
-      cb.recordSuccess(endpoint);
-    }
-  }
-
-  if (parsed.warning) {
-    logWarn(
-      `ESI Warning ${parsed.warning.code} for ${url}: ${parsed.warning.message}`,
-    );
-  }
-
-  return { response, parsed, url };
-}
-
-interface SingleFetchResult {
-  data: unknown;
-  parsed: ParsedHeaders;
-  url: string;
-}
-
-async function fetchOnePage(
-  client: ApiClient,
-  endpoint: string,
-  method: string,
-  body?: unknown,
-  requiresAuth: boolean = false,
-  useETag: boolean = false,
-  requestTimeout?: number,
-  templatePath?: string,
-): Promise<SingleFetchResult> {
-  const { response, parsed, url } = await executeSingleFetch(
-    client,
-    endpoint,
-    method,
-    body,
-    requiresAuth,
-    useETag,
-    requestTimeout,
-    templatePath,
-  );
-
-  if (!response.ok) {
-    throw new EsiError(
-      response.status,
-      STATUS_MESSAGES[response.status] || response.statusText,
-      url,
-      parsed.requestId ?? undefined,
-    );
-  }
-
-  const data = await parseJsonBody(response, url);
-  return { data, parsed, url };
-}
+// --- Main request orchestration ---
 
 const executeRequest = async (
   client: ApiClient,
@@ -638,6 +54,9 @@ const executeRequest = async (
       body,
       requiresAuth,
       useETag,
+      resolveCache,
+      resolveRateLimiter,
+      resolveCircuitBreaker,
       requestTimeout,
       templatePath,
     );
@@ -658,6 +77,7 @@ const executeRequest = async (
       url,
       parsed,
       useETag,
+      resolveCache,
     );
     if (earlyResult) return finish(earlyResult);
 
@@ -668,6 +88,7 @@ const executeRequest = async (
         url,
         parsed,
         useETag,
+        resolveCache,
       );
       return finish(staleOrThrow);
     }
@@ -681,6 +102,7 @@ const executeRequest = async (
       parsed,
       data,
       useETag,
+      resolveCache,
       templatePath,
     );
 
@@ -695,6 +117,9 @@ const executeRequest = async (
         body,
         requiresAuth,
         false,
+        resolveCache,
+        resolveRateLimiter,
+        resolveCircuitBreaker,
         requestTimeout,
         templatePath,
       );
@@ -714,6 +139,7 @@ const executeRequest = async (
       url,
       useETag,
       pageFetch,
+      resolveCache,
       templatePath,
     );
     return finish(paginatedResult);
@@ -739,6 +165,9 @@ export const handleSinglePageRequest = async (
       body,
       requiresAuth,
       true,
+      resolveCache,
+      resolveRateLimiter,
+      resolveCircuitBreaker,
       requestTimeout,
       templatePath,
     ).then(({ data, parsed }) => ({
@@ -770,7 +199,13 @@ export const handleRequest = async (
 ): Promise<EsiHandlerResponse> => {
   const rawUrl = `${client.getLink()}/${endpoint}`;
   const startTime = Date.now();
-  const specHit = trySpecAwareCacheHit(client, rawUrl, method, templatePath);
+  const specHit = trySpecAwareCacheHit(
+    client,
+    rawUrl,
+    method,
+    templatePath,
+    resolveCache,
+  );
   if (specHit) {
     return applyResponseInterceptors(
       client,

--- a/src/core/requestPipeline/cachePolicy.ts
+++ b/src/core/requestPipeline/cachePolicy.ts
@@ -1,0 +1,118 @@
+import { ApiClient } from '../ApiClient';
+import { logDebug } from '../logger/loggerUtil';
+import { ICache } from '../cache/ICache';
+import { ParsedHeaders } from '../util/headersUtil';
+import { camelToSnake } from '../util/stringUtil';
+import { esiCacheTtls } from '../endpoints/esi-cache-ttls.generated';
+import { parseCacheControlTtl } from './headers';
+
+export interface EsiHandlerResponse {
+  headers: Record<string, string>;
+  body: unknown;
+  fromCache?: boolean;
+  stale?: boolean;
+  cacheHitType?: 'spec-ttl' | 'etag-304' | 'stale-on-error';
+  responseTimeMs?: number;
+  cursors?: import('../pagination/CursorPaginationHandler').CursorTokens;
+}
+
+/**
+ * Look up the spec-defined cache TTL for a given method + template path.
+ * Returns TTL in milliseconds, or undefined if not found.
+ */
+export function lookupSpecTtl(
+  method: string,
+  templatePath: string,
+): number | undefined {
+  const normalized = templatePath
+    .replace(/\/$/, '')
+    .replace(/\{(\w+)\}/g, (_, name: string) => `{${camelToSnake(name)}}`);
+  const key = `${method}:${normalized}`;
+  const seconds = esiCacheTtls[key];
+  return typeof seconds === 'number' ? seconds * 1000 : undefined;
+}
+
+/**
+ * Attempt a spec-aware cache hit (TTL-based, no network request).
+ */
+export function trySpecAwareCacheHit(
+  client: ApiClient,
+  url: string,
+  method: string,
+  templatePath: string | undefined,
+  resolveCache: (client: ApiClient) => ICache | null,
+): EsiHandlerResponse | null {
+  if (method !== 'GET' || !templatePath) return null;
+  const specTtlMs = lookupSpecTtl(method, templatePath);
+  if (!specTtlMs) return null;
+  const cache = resolveCache(client);
+  if (!cache) return null;
+  const entry = cache.get(url);
+  if (!entry) return null;
+  const age = Date.now() - entry.timestamp;
+  if (age < specTtlMs) {
+    logDebug(
+      `Spec-aware cache hit for ${url} (age=${Math.round(age / 1000)}s, ttl=${Math.round(specTtlMs / 1000)}s)`,
+    );
+    return {
+      headers: entry.headers,
+      body: entry.data,
+      fromCache: true,
+      cacheHitType: 'spec-ttl',
+    };
+  }
+  return null;
+}
+
+/**
+ * Attempt to return a stale cached response (used on server errors).
+ */
+export function tryStaleCacheResponse(
+  client: ApiClient,
+  url: string,
+  parsed: ParsedHeaders,
+  resolveCache: (client: ApiClient) => ICache | null,
+): EsiHandlerResponse | null {
+  const cache = resolveCache(client);
+  if (!cache) return null;
+  const cachedEntry = cache.get(url);
+  if (!cachedEntry) return null;
+  return {
+    headers: { ...cachedEntry.headers, ...parsed.raw },
+    body: cachedEntry.data,
+    fromCache: true,
+    stale: true,
+    cacheHitType: 'stale-on-error',
+  };
+}
+
+/**
+ * Cache a successful response, or invalidate cache for non-GET methods.
+ */
+export function cacheResponse(
+  client: ApiClient,
+  url: string,
+  method: string,
+  endpoint: string,
+  parsed: ParsedHeaders,
+  data: unknown,
+  useETag: boolean,
+  resolveCache: (client: ApiClient) => ICache | null,
+  templatePath?: string,
+): void {
+  const cache = resolveCache(client);
+  if (useETag && method === 'GET' && cache && parsed.etag) {
+    const headerTtl = parseCacheControlTtl(parsed.raw);
+    const specTtlMs = templatePath
+      ? lookupSpecTtl(method, templatePath)
+      : undefined;
+    const ttl = specTtlMs ?? headerTtl;
+    cache.set(url, parsed.etag, data, parsed.raw, ttl);
+    const ttlInfo = ttl ? ` (ttl=${ttl}ms)` : '';
+    logDebug(`Cached response for ${url} with ETag ${parsed.etag}${ttlInfo}`);
+  }
+
+  if (method !== 'GET' && cache) {
+    cache.deleteByPath(endpoint.split('?')[0]!);
+  }
+}

--- a/src/core/requestPipeline/dependencies.ts
+++ b/src/core/requestPipeline/dependencies.ts
@@ -1,0 +1,36 @@
+import { ApiClient } from '../ApiClient';
+import { buildError } from '../util/error';
+import { ICache } from '../cache/ICache';
+import { IRateLimiter } from '../rateLimiter/IRateLimiter';
+import { ICircuitBreaker } from '../circuitBreaker/ICircuitBreaker';
+import { IRetryStrategy } from '../IRetryStrategy';
+import { RetryStrategy } from '../RetryStrategy';
+
+export function resolveCache(client: ApiClient): ICache | null {
+  return client.getCache();
+}
+
+export function resolveRateLimiter(client: ApiClient): IRateLimiter {
+  const limiter = client.getRateLimiter();
+  if (!limiter) {
+    throw buildError(
+      'No rate limiter configured on ApiClient. ' +
+        'Set one via apiClient.setRateLimiter(new RateLimiter()).',
+      'CONFIGURATION_ERROR',
+    );
+  }
+  return limiter;
+}
+
+export function resolveCircuitBreaker(
+  client: ApiClient,
+): ICircuitBreaker | null {
+  return client.getCircuitBreaker();
+}
+
+export function resolveRetryStrategy(client: ApiClient): IRetryStrategy {
+  return (
+    client.getRetryStrategy() ??
+    new RetryStrategy(client.getRetryConfig() ?? undefined)
+  );
+}

--- a/src/core/requestPipeline/fetchExecution.ts
+++ b/src/core/requestPipeline/fetchExecution.ts
@@ -1,0 +1,186 @@
+import { ApiClient } from '../ApiClient';
+import { EsiError, TimeoutError } from '../util/error';
+import { logInfo, logWarn, logError } from '../logger/loggerUtil';
+import { parseHeaders, ParsedHeaders } from '../util/headersUtil';
+import { ICache } from '../cache/ICache';
+import { IRateLimiter } from '../rateLimiter/IRateLimiter';
+import { ICircuitBreaker } from '../circuitBreaker/ICircuitBreaker';
+import { buildError } from '../util/error';
+import { buildRequestHeaders } from './headers';
+import { applyRequestMiddleware } from './middlewareBridge';
+import { STATUS_MESSAGES } from './statusHandling';
+
+export interface RawFetchResult {
+  response: Response;
+  parsed: ParsedHeaders;
+  url: string;
+}
+
+export interface SingleFetchResult {
+  data: unknown;
+  parsed: ParsedHeaders;
+  url: string;
+}
+
+/**
+ * Execute a single HTTP fetch with rate limiting, circuit breaker, and timeout.
+ */
+export async function executeSingleFetch(
+  client: ApiClient,
+  endpoint: string,
+  method: string,
+  body: unknown,
+  requiresAuth: boolean,
+  useETag: boolean,
+  resolveCache: (client: ApiClient) => ICache | null,
+  resolveRateLimiter: (client: ApiClient) => IRateLimiter,
+  resolveCircuitBreaker: (client: ApiClient) => ICircuitBreaker | null,
+  requestTimeout?: number,
+  templatePath?: string,
+): Promise<RawFetchResult> {
+  const rawUrl = `${client.getLink()}/${endpoint}`;
+  const builtHeaders = buildRequestHeaders(
+    client,
+    rawUrl,
+    method,
+    requiresAuth,
+    useETag,
+    body,
+    resolveCache,
+  ) as Record<string, string>;
+
+  const req = await applyRequestMiddleware(
+    client,
+    rawUrl,
+    endpoint,
+    method,
+    builtHeaders,
+    body,
+  );
+
+  const options: RequestInit = {
+    method,
+    headers: req.headers,
+    body: req.body ? JSON.stringify(req.body) : undefined,
+  };
+
+  const url = req.url;
+  logInfo(`Hitting endpoint: ${url}`);
+
+  const cb = resolveCircuitBreaker(client);
+  if (cb) cb.checkCircuit(endpoint);
+
+  const rateLimiter = resolveRateLimiter(client);
+  await rateLimiter.checkRateLimit(templatePath, method, req.headers);
+
+  const timeoutMs = requestTimeout ?? client.getTimeout();
+  const controller = new AbortController();
+  const timer = globalThis.setTimeout(() => controller.abort(), timeoutMs);
+  options.signal = controller.signal;
+
+  let response: Response;
+  try {
+    response = await fetch(url, options);
+  } catch (err) {
+    clearTimeout(timer);
+    if (cb) {
+      // Status 0 = network/timeout failure — counts toward opening the circuit
+      cb.recordFailure(endpoint, 0);
+    }
+    if (err instanceof Error && err.name === 'AbortError') {
+      throw new TimeoutError(timeoutMs, url);
+    }
+    throw err;
+  }
+  clearTimeout(timer);
+
+  const parsed = parseHeaders(response.headers);
+
+  rateLimiter.updateFromResponse(
+    parsed.raw,
+    response.status,
+    templatePath,
+    method,
+    req.headers,
+  );
+
+  if (cb) {
+    if (
+      response.status >= 500 ||
+      response.status === 420 ||
+      response.status === 429
+    ) {
+      cb.recordFailure(endpoint, response.status);
+    } else {
+      cb.recordSuccess(endpoint);
+    }
+  }
+
+  if (parsed.warning) {
+    logWarn(
+      `ESI Warning ${parsed.warning.code} for ${url}: ${parsed.warning.message}`,
+    );
+  }
+
+  return { response, parsed, url };
+}
+
+/**
+ * Parse a JSON response body, throwing on parse failure.
+ */
+export async function parseJsonBody(
+  response: Response,
+  _url: string,
+): Promise<unknown> {
+  try {
+    return (await response.json()) as unknown;
+  } catch (jsonError) {
+    const msg =
+      jsonError instanceof Error ? jsonError.message : String(jsonError);
+    logError(`Failed to parse JSON response: ${msg}`);
+    throw buildError(`Invalid JSON response: ${msg}`, 'JSON_PARSE_ERROR');
+  }
+}
+
+/**
+ * Fetch a single page: execute the fetch, check for errors, parse JSON.
+ */
+export async function fetchOnePage(
+  client: ApiClient,
+  endpoint: string,
+  method: string,
+  body: unknown,
+  requiresAuth: boolean,
+  useETag: boolean,
+  resolveCache: (client: ApiClient) => ICache | null,
+  resolveRateLimiter: (client: ApiClient) => IRateLimiter,
+  resolveCircuitBreaker: (client: ApiClient) => ICircuitBreaker | null,
+  requestTimeout?: number,
+  templatePath?: string,
+): Promise<SingleFetchResult> {
+  const { response, parsed, url } = await executeSingleFetch(
+    client,
+    endpoint,
+    method,
+    body,
+    requiresAuth,
+    useETag,
+    resolveCache,
+    resolveRateLimiter,
+    resolveCircuitBreaker,
+    requestTimeout,
+    templatePath,
+  );
+
+  if (!response.ok) {
+    throw new EsiError(
+      response.status,
+      STATUS_MESSAGES[response.status] || response.statusText,
+      url,
+      parsed.requestId ?? undefined,
+    );
+  }
+
+  const data = await parseJsonBody(response, url);
+  return { data, parsed, url };
+}

--- a/src/core/requestPipeline/headers.ts
+++ b/src/core/requestPipeline/headers.ts
@@ -1,0 +1,68 @@
+import { ApiClient } from '../ApiClient';
+import { buildError } from '../util/error';
+import { logDebug } from '../logger/loggerUtil';
+import { ICache } from '../cache/ICache';
+import { USER_AGENT, COMPATIBILITY_DATE } from '../constants';
+
+/**
+ * Parse Cache-Control header to extract max-age TTL in milliseconds.
+ */
+export const parseCacheControlTtl = (
+  headers: Record<string, string>,
+): number | undefined => {
+  const cacheControl = headers['cache-control'] ?? headers['Cache-Control'];
+  if (!cacheControl) return undefined;
+  const match = /max-age=(\d+)/.exec(cacheControl);
+  return match ? parseInt(match[1]!, 10) * 1000 : undefined;
+};
+
+/**
+ * Build the request headers for an ESI API call.
+ */
+export function buildRequestHeaders(
+  client: ApiClient,
+  url: string,
+  method: string,
+  requiresAuth: boolean,
+  useETag: boolean,
+  body: unknown,
+  resolveCache: (client: ApiClient) => ICache | null,
+): HeadersInit {
+  const headers: HeadersInit = {
+    Accept: 'application/json',
+    'Accept-Encoding': 'gzip, deflate, br',
+    'User-Agent': USER_AGENT,
+    'X-Compatibility-Date': COMPATIBILITY_DATE,
+  };
+
+  const language = client.getLanguage();
+  if (language) {
+    headers['Accept-Language'] = language;
+  }
+
+  if (requiresAuth) {
+    const authHeader = client.getAuthorizationHeader();
+    if (!authHeader) {
+      throw buildError(
+        'Authorization header is required but not provided',
+        'NO_AUTH_TOKEN',
+      );
+    }
+    headers['Authorization'] = authHeader;
+  }
+
+  const cache = resolveCache(client);
+  if (useETag && method === 'GET' && cache) {
+    const cachedETag = cache.getETag(url);
+    if (cachedETag) {
+      headers['If-None-Match'] = cachedETag;
+      logDebug(`Adding If-None-Match header: ${cachedETag}`);
+    }
+  }
+
+  if (body) {
+    headers['Content-Type'] = 'application/json';
+  }
+
+  return headers;
+}

--- a/src/core/requestPipeline/index.ts
+++ b/src/core/requestPipeline/index.ts
@@ -1,0 +1,34 @@
+export { buildRequestHeaders, parseCacheControlTtl } from './headers';
+export {
+  lookupSpecTtl,
+  trySpecAwareCacheHit,
+  tryStaleCacheResponse,
+  cacheResponse,
+} from './cachePolicy';
+export type { EsiHandlerResponse } from './cachePolicy';
+export {
+  STATUS_MESSAGES,
+  handleEarlyStatus,
+  handleErrorResponse,
+  wrapError,
+} from './statusHandling';
+export {
+  handleCursorPagination,
+  handleOffsetPagination,
+} from './paginationOrchestration';
+export {
+  applyRequestMiddleware,
+  applyResponseInterceptors,
+} from './middlewareBridge';
+export {
+  executeSingleFetch,
+  fetchOnePage,
+  parseJsonBody,
+} from './fetchExecution';
+export type { RawFetchResult, SingleFetchResult } from './fetchExecution';
+export {
+  resolveCache,
+  resolveRateLimiter,
+  resolveCircuitBreaker,
+  resolveRetryStrategy,
+} from './dependencies';

--- a/src/core/requestPipeline/middlewareBridge.ts
+++ b/src/core/requestPipeline/middlewareBridge.ts
@@ -1,0 +1,66 @@
+import { ApiClient } from '../ApiClient';
+import { RequestContext, ResponseContext } from '../middleware/Middleware';
+import { EsiHandlerResponse } from './cachePolicy';
+
+/**
+ * Apply request interceptors from the middleware pipeline.
+ */
+export async function applyRequestMiddleware(
+  client: ApiClient,
+  url: string,
+  endpoint: string,
+  method: string,
+  headers: Record<string, string>,
+  body: unknown,
+): Promise<{ url: string; headers: Record<string, string>; body: unknown }> {
+  const middleware = client.getMiddleware();
+  if (!middleware.hasInterceptors()) {
+    return { url, headers, body };
+  }
+  const reqCtx: RequestContext = {
+    url,
+    endpoint,
+    method,
+    headers: { ...headers },
+    body,
+  };
+  const modified = await middleware.applyRequestInterceptors(reqCtx);
+  return {
+    url: modified.url,
+    headers: modified.headers,
+    body: modified.body,
+  };
+}
+
+/**
+ * Apply response interceptors from the middleware pipeline.
+ */
+export async function applyResponseInterceptors(
+  client: ApiClient,
+  result: EsiHandlerResponse,
+  url: string,
+  endpoint: string,
+  method: string,
+  startTime: number,
+): Promise<EsiHandlerResponse> {
+  const middleware = client.getMiddleware();
+  if (!middleware.hasInterceptors()) return result;
+
+  const responseCtx: ResponseContext = {
+    url,
+    endpoint,
+    method,
+    status: 200,
+    headers: result.headers,
+    body: result.body,
+    durationMs: Date.now() - startTime,
+    fromCache: result.fromCache ?? false,
+  };
+
+  const modified = await middleware.applyResponseInterceptors(responseCtx);
+  return {
+    ...result,
+    headers: modified.headers,
+    body: modified.body,
+  };
+}

--- a/src/core/requestPipeline/paginationOrchestration.ts
+++ b/src/core/requestPipeline/paginationOrchestration.ts
@@ -1,0 +1,108 @@
+import { ApiClient } from '../ApiClient';
+import { buildError, EsiError } from '../util/error';
+import { logInfo, logWarn } from '../logger/loggerUtil';
+import { ParsedHeaders } from '../util/headersUtil';
+import {
+  PaginationHandler,
+  PageFetcher,
+} from '../pagination/PaginationHandler';
+import { CursorTokens } from '../pagination/CursorPaginationHandler';
+import { CircuitOpenError } from '../circuitBreaker/CircuitBreaker';
+import { ICache } from '../cache/ICache';
+import { cacheResponse, EsiHandlerResponse } from './cachePolicy';
+
+/**
+ * Handle cursor-based pagination. Returns null if the response
+ * does not contain cursor pagination headers.
+ */
+export function handleCursorPagination(
+  parsed: ParsedHeaders,
+  data: unknown,
+): EsiHandlerResponse | null {
+  if (!parsed.hasCursorPagination) return null;
+
+  const cursors: CursorTokens = {
+    before: parsed.cursorBefore,
+    after: parsed.cursorAfter,
+  };
+
+  return { headers: parsed.raw, body: data, cursors };
+}
+
+/**
+ * Handle offset-based pagination. Fetches remaining pages if xPages > 1.
+ */
+export async function handleOffsetPagination(
+  client: ApiClient,
+  endpoint: string,
+  method: string,
+  requiresAuth: boolean,
+  parsed: ParsedHeaders,
+  data: unknown,
+  body: unknown,
+  url: string,
+  useETag: boolean,
+  pageFetch: PageFetcher,
+  resolveCache: (client: ApiClient) => ICache | null,
+  templatePath?: string,
+): Promise<EsiHandlerResponse> {
+  const totalPages = parsed.xPages;
+
+  if (totalPages <= 1) {
+    return { headers: parsed.raw, body: data };
+  }
+
+  logInfo(
+    `Found ${totalPages} pages, fetching additional pages with rate limiting...`,
+  );
+
+  try {
+    const firstPageData = Array.isArray(data) ? data : [data];
+    const allData = await PaginationHandler.fetchRemainingPages(
+      client,
+      endpoint,
+      method,
+      requiresAuth,
+      firstPageData,
+      totalPages,
+      body,
+      {
+        maxPages: Math.min(totalPages, 1000),
+        stopOnEmptyPage: true,
+        maxRetries: 3,
+      },
+      pageFetch,
+      templatePath,
+    );
+
+    cacheResponse(
+      client,
+      url,
+      method,
+      endpoint,
+      parsed,
+      allData,
+      useETag,
+      resolveCache,
+      templatePath,
+    );
+    return { headers: parsed.raw, body: allData };
+  } catch (paginationError: unknown) {
+    const msg =
+      paginationError instanceof Error
+        ? paginationError.message
+        : String(paginationError);
+    logWarn(`Pagination failed for ${url}: ${msg}`);
+    if (
+      paginationError instanceof EsiError ||
+      paginationError instanceof CircuitOpenError
+    ) {
+      throw paginationError;
+    }
+    throw buildError(
+      `Pagination incomplete for ${url}: ${msg}`,
+      'PAGINATION_INCOMPLETE',
+      url,
+    );
+  }
+}

--- a/src/core/requestPipeline/statusHandling.ts
+++ b/src/core/requestPipeline/statusHandling.ts
@@ -1,0 +1,124 @@
+import { ApiClient } from '../ApiClient';
+import { EsiError } from '../util/error';
+import { logInfo, logWarn } from '../logger/loggerUtil';
+import { ICache } from '../cache/ICache';
+import { ParsedHeaders } from '../util/headersUtil';
+import { CircuitOpenError } from '../circuitBreaker/CircuitBreaker';
+import { buildError } from '../util/error';
+import { logError } from '../logger/loggerUtil';
+import { tryStaleCacheResponse, EsiHandlerResponse } from './cachePolicy';
+
+export const STATUS_MESSAGES: Record<number, string> = {
+  201: 'Created',
+  204: 'No Content',
+  304: 'Not Modified',
+  400: 'Bad Request',
+  401: 'Unauthorized',
+  403: 'Forbidden',
+  404: 'Resource not found',
+  420: 'Error Limited',
+  422: 'Unprocessable Entity',
+  429: 'Too many requests',
+  500: 'Internal server error',
+  503: 'Service Unavailable',
+  504: 'Gateway Timeout',
+  520: 'Internal server error, did the request terminate too soon?',
+};
+
+/**
+ * Handle early-return HTTP statuses (201, 204, 304).
+ */
+export function handleEarlyStatus(
+  client: ApiClient,
+  status: number,
+  url: string,
+  parsed: ParsedHeaders,
+  useETag: boolean,
+  resolveCache: (client: ApiClient) => ICache | null,
+): EsiHandlerResponse | null {
+  if (status === 201) {
+    return { headers: parsed.raw, body: undefined };
+  }
+
+  if (status === 204) {
+    logInfo(`No Content for endpoint: ${url}`);
+    return { headers: parsed.raw, body: undefined };
+  }
+
+  if (status === 304) {
+    const cache = resolveCache(client);
+    if (useETag && cache) {
+      const cachedEntry = cache.get(url);
+      if (cachedEntry) {
+        logInfo(`Cache hit (304) for endpoint: ${url}`);
+        return {
+          headers: { ...cachedEntry.headers, ...parsed.raw },
+          body: cachedEntry.data,
+          fromCache: true,
+          cacheHitType: 'etag-304',
+        };
+      }
+    }
+    throw new EsiError(
+      304,
+      'Not Modified — no cached data available',
+      url,
+      parsed.requestId ?? undefined,
+    );
+  }
+
+  return null;
+}
+
+/**
+ * Handle error HTTP responses (4xx, 5xx). May serve stale cache on 5xx.
+ */
+export function handleErrorResponse(
+  client: ApiClient,
+  response: Response,
+  url: string,
+  parsed: ParsedHeaders,
+  useETag: boolean,
+  resolveCache: (client: ApiClient) => ICache | null,
+): EsiHandlerResponse | never {
+  const errorMessage = STATUS_MESSAGES[response.status] || response.statusText;
+
+  if (response.status >= 500 && useETag) {
+    const staleResult = tryStaleCacheResponse(
+      client,
+      url,
+      parsed,
+      resolveCache,
+    );
+    if (staleResult) {
+      logWarn(`${errorMessage} for ${url} — serving stale cache`);
+      return staleResult;
+    }
+  }
+
+  if (response.status === 420 || response.status === 429) {
+    logWarn(`Rate limited (${response.status}) on ${url}`);
+  }
+
+  throw new EsiError(
+    response.status,
+    errorMessage,
+    url,
+    parsed.requestId ?? undefined,
+  );
+}
+
+/**
+ * Wrap an unknown error into an EsiError or rethrow known errors.
+ */
+export function wrapError(error: unknown): never {
+  if (error instanceof EsiError || error instanceof CircuitOpenError) {
+    throw error;
+  }
+  if (error instanceof Error) {
+    logError(`Unexpected error: ${error.message}`);
+    throw buildError(error.message, 'ESIJS_ERROR');
+  }
+  logError(`Unexpected error: ${String(error)}`);
+  throw buildError(String(error), 'ESIJS_ERROR');
+}

--- a/tests/tdd/core/requestPipeline/cachePolicy.test.ts
+++ b/tests/tdd/core/requestPipeline/cachePolicy.test.ts
@@ -1,0 +1,292 @@
+import {
+  lookupSpecTtl,
+  trySpecAwareCacheHit,
+  tryStaleCacheResponse,
+  cacheResponse,
+} from '../../../../src/core/requestPipeline/cachePolicy';
+import { ApiClient } from '../../../../src/core/ApiClient';
+import { ICache } from '../../../../src/core/cache/ICache';
+import { ETagCacheManager } from '../../../../src/core/cache/ETagCacheManager';
+import { ParsedHeaders } from '../../../../src/core/util/headersUtil';
+
+const BASE_URL = 'https://esi.evetech.net';
+
+describe('requestPipeline/cachePolicy', () => {
+  describe('lookupSpecTtl', () => {
+    it('should return undefined for unknown endpoints', () => {
+      expect(lookupSpecTtl('GET', '/v999/nonexistent/')).toBeUndefined();
+    });
+
+    it('should normalize camelCase path parameters to snake_case', () => {
+      // The function should convert {characterId} to {character_id}
+      const result = lookupSpecTtl(
+        'GET',
+        '/v5/characters/{characterId}/skills/',
+      );
+      // Whether this returns a value depends on the generated cache TTLs,
+      // but the normalization itself should not throw
+      expect(result === undefined || typeof result === 'number').toBe(true);
+    });
+
+    it('should strip trailing slashes', () => {
+      const withSlash = lookupSpecTtl('GET', '/v1/status/');
+      const withoutSlash = lookupSpecTtl('GET', '/v1/status');
+      expect(withSlash).toBe(withoutSlash);
+    });
+
+    it('should return milliseconds (not seconds)', () => {
+      const result = lookupSpecTtl('GET', '/v1/status/');
+      if (result !== undefined) {
+        // ESI cache TTLs are at least 1 second = 1000ms
+        expect(result).toBeGreaterThanOrEqual(1000);
+      }
+    });
+  });
+
+  describe('trySpecAwareCacheHit', () => {
+    let client: ApiClient;
+    const resolveCache = (c: ApiClient) => c.getCache();
+
+    beforeEach(() => {
+      client = new ApiClient('test', BASE_URL);
+    });
+
+    it('should return null for non-GET methods', () => {
+      expect(
+        trySpecAwareCacheHit(
+          client,
+          `${BASE_URL}/v1/status/`,
+          'POST',
+          '/v1/status/',
+          resolveCache,
+        ),
+      ).toBeNull();
+    });
+
+    it('should return null when no templatePath is provided', () => {
+      expect(
+        trySpecAwareCacheHit(
+          client,
+          `${BASE_URL}/v1/status/`,
+          'GET',
+          undefined,
+          resolveCache,
+        ),
+      ).toBeNull();
+    });
+
+    it('should return null when no cache is configured', () => {
+      expect(
+        trySpecAwareCacheHit(
+          client,
+          `${BASE_URL}/v1/status/`,
+          'GET',
+          '/v1/status/',
+          resolveCache,
+        ),
+      ).toBeNull();
+    });
+
+    it('should return cached response when within TTL', () => {
+      const cache = new ETagCacheManager({
+        maxEntries: 100,
+        defaultTtl: 60000,
+      });
+      client.setCache(cache);
+
+      const url = `${BASE_URL}/v1/status/`;
+      cache.set(url, '"etag"', { players: 100 }, { 'content-type': 'json' });
+
+      const result = trySpecAwareCacheHit(
+        client,
+        url,
+        'GET',
+        '/v1/status/',
+        resolveCache,
+      );
+
+      // If there's a spec TTL for /v1/status, the hit should work
+      if (result) {
+        expect(result.fromCache).toBe(true);
+        expect(result.cacheHitType).toBe('spec-ttl');
+        expect(result.body).toEqual({ players: 100 });
+      }
+
+      cache.shutdown();
+    });
+  });
+
+  describe('tryStaleCacheResponse', () => {
+    let client: ApiClient;
+    const resolveCache = (c: ApiClient) => c.getCache();
+
+    beforeEach(() => {
+      client = new ApiClient('test', BASE_URL);
+    });
+
+    it('should return null when no cache is configured', () => {
+      const parsed = { raw: {}, xPages: 1 } as ParsedHeaders;
+      expect(
+        tryStaleCacheResponse(
+          client,
+          `${BASE_URL}/v1/status/`,
+          parsed,
+          resolveCache,
+        ),
+      ).toBeNull();
+    });
+
+    it('should return null when nothing is cached', () => {
+      const cache = new ETagCacheManager({
+        maxEntries: 100,
+        defaultTtl: 60000,
+      });
+      client.setCache(cache);
+
+      const parsed = { raw: {} } as ParsedHeaders;
+      expect(
+        tryStaleCacheResponse(
+          client,
+          `${BASE_URL}/v1/uncached/`,
+          parsed,
+          resolveCache,
+        ),
+      ).toBeNull();
+
+      cache.shutdown();
+    });
+
+    it('should return stale cached response when data exists', () => {
+      const cache = new ETagCacheManager({
+        maxEntries: 100,
+        defaultTtl: 60000,
+      });
+      client.setCache(cache);
+
+      const url = `${BASE_URL}/v1/status/`;
+      cache.set(
+        url,
+        '"etag"',
+        { players: 100 },
+        { 'content-type': 'application/json' },
+      );
+
+      const parsed = {
+        raw: { 'x-request-id': 'abc' },
+      } as unknown as ParsedHeaders;
+      const result = tryStaleCacheResponse(client, url, parsed, resolveCache);
+
+      expect(result).not.toBeNull();
+      expect(result!.fromCache).toBe(true);
+      expect(result!.stale).toBe(true);
+      expect(result!.cacheHitType).toBe('stale-on-error');
+      expect(result!.body).toEqual({ players: 100 });
+
+      cache.shutdown();
+    });
+  });
+
+  describe('cacheResponse', () => {
+    let client: ApiClient;
+    let cache: ETagCacheManager;
+    const resolveCache = (c: ApiClient) => c.getCache();
+
+    beforeEach(() => {
+      client = new ApiClient('test', BASE_URL);
+      cache = new ETagCacheManager({ maxEntries: 100, defaultTtl: 60000 });
+      client.setCache(cache);
+    });
+
+    afterEach(() => {
+      cache.shutdown();
+    });
+
+    it('should cache GET responses with ETag', () => {
+      const url = `${BASE_URL}/v1/status/`;
+      const parsed = {
+        raw: { 'content-type': 'application/json' },
+        etag: '"etag-123"',
+      } as unknown as ParsedHeaders;
+
+      cacheResponse(
+        client,
+        url,
+        'GET',
+        'v1/status/',
+        parsed,
+        { players: 100 },
+        true,
+        resolveCache,
+      );
+
+      const entry = cache.get(url);
+      expect(entry).not.toBeNull();
+      expect(entry!.data).toEqual({ players: 100 });
+    });
+
+    it('should not cache GET responses without ETag', () => {
+      const url = `${BASE_URL}/v1/status/`;
+      const parsed = {
+        raw: { 'content-type': 'application/json' },
+        etag: null,
+      } as unknown as ParsedHeaders;
+
+      cacheResponse(
+        client,
+        url,
+        'GET',
+        'v1/status/',
+        parsed,
+        { players: 100 },
+        true,
+        resolveCache,
+      );
+
+      const entry = cache.get(url);
+      expect(entry).toBeNull();
+    });
+
+    it('should not cache when useETag is false', () => {
+      const url = `${BASE_URL}/v1/status/`;
+      const parsed = {
+        raw: {},
+        etag: '"etag-123"',
+      } as unknown as ParsedHeaders;
+
+      cacheResponse(
+        client,
+        url,
+        'GET',
+        'v1/status/',
+        parsed,
+        { players: 100 },
+        false,
+        resolveCache,
+      );
+
+      const entry = cache.get(url);
+      expect(entry).toBeNull();
+    });
+
+    it('should invalidate cache for non-GET methods', () => {
+      const url = `${BASE_URL}/v1/characters/123/contacts/`;
+      cache.set(url, '"etag"', [{ contact_id: 1 }], { 'content-type': 'json' });
+
+      const parsed = { raw: {}, etag: null } as unknown as ParsedHeaders;
+      cacheResponse(
+        client,
+        url,
+        'POST',
+        'v1/characters/123/contacts/',
+        parsed,
+        { success: true },
+        true,
+        resolveCache,
+      );
+
+      // Non-GET should invalidate, not store
+      const entry = cache.get(url);
+      expect(entry).toBeNull();
+    });
+  });
+});

--- a/tests/tdd/core/requestPipeline/headers.test.ts
+++ b/tests/tdd/core/requestPipeline/headers.test.ts
@@ -1,0 +1,196 @@
+import {
+  buildRequestHeaders,
+  parseCacheControlTtl,
+} from '../../../../src/core/requestPipeline/headers';
+import { ApiClient } from '../../../../src/core/ApiClient';
+import { ICache } from '../../../../src/core/cache/ICache';
+
+const BASE_URL = 'https://esi.evetech.net';
+
+describe('requestPipeline/headers', () => {
+  describe('parseCacheControlTtl', () => {
+    it('should return undefined when no cache-control header exists', () => {
+      expect(parseCacheControlTtl({})).toBeUndefined();
+    });
+
+    it('should parse max-age from lowercase cache-control header', () => {
+      expect(parseCacheControlTtl({ 'cache-control': 'max-age=300' })).toBe(
+        300_000,
+      );
+    });
+
+    it('should parse max-age from mixed-case Cache-Control header', () => {
+      expect(parseCacheControlTtl({ 'Cache-Control': 'max-age=60' })).toBe(
+        60_000,
+      );
+    });
+
+    it('should return undefined when cache-control has no max-age', () => {
+      expect(
+        parseCacheControlTtl({ 'cache-control': 'no-cache, no-store' }),
+      ).toBeUndefined();
+    });
+
+    it('should parse max-age when mixed with other directives', () => {
+      expect(
+        parseCacheControlTtl({
+          'cache-control': 'public, max-age=120, must-revalidate',
+        }),
+      ).toBe(120_000);
+    });
+
+    it('should handle max-age=0', () => {
+      expect(parseCacheControlTtl({ 'cache-control': 'max-age=0' })).toBe(0);
+    });
+  });
+
+  describe('buildRequestHeaders', () => {
+    let client: ApiClient;
+    const nullCache = () => null;
+
+    beforeEach(() => {
+      client = new ApiClient('test', BASE_URL);
+    });
+
+    it('should include standard headers', () => {
+      const headers = buildRequestHeaders(
+        client,
+        `${BASE_URL}/v1/status/`,
+        'GET',
+        false,
+        false,
+        undefined,
+        nullCache,
+      ) as Record<string, string>;
+
+      expect(headers['Accept']).toBe('application/json');
+      expect(headers['Accept-Encoding']).toBe('gzip, deflate, br');
+      expect(headers['User-Agent']).toMatch(/esi\.ts/);
+      expect(headers['X-Compatibility-Date']).toBeDefined();
+    });
+
+    it('should include Accept-Language when language is set', () => {
+      client.setLanguage('de');
+      const headers = buildRequestHeaders(
+        client,
+        `${BASE_URL}/v1/status/`,
+        'GET',
+        false,
+        false,
+        undefined,
+        nullCache,
+      ) as Record<string, string>;
+
+      expect(headers['Accept-Language']).toBe('de');
+    });
+
+    it('should not include Accept-Language when language is not set', () => {
+      const headers = buildRequestHeaders(
+        client,
+        `${BASE_URL}/v1/status/`,
+        'GET',
+        false,
+        false,
+        undefined,
+        nullCache,
+      ) as Record<string, string>;
+
+      expect(headers['Accept-Language']).toBeUndefined();
+    });
+
+    it('should throw when requiresAuth is true and no token', () => {
+      expect(() =>
+        buildRequestHeaders(
+          client,
+          `${BASE_URL}/v1/characters/123/`,
+          'GET',
+          true,
+          false,
+          undefined,
+          nullCache,
+        ),
+      ).toThrow('Authorization header is required');
+    });
+
+    it('should include Authorization header when token is set', () => {
+      client.setAccessToken('my-token');
+      const headers = buildRequestHeaders(
+        client,
+        `${BASE_URL}/v1/characters/123/`,
+        'GET',
+        true,
+        false,
+        undefined,
+        nullCache,
+      ) as Record<string, string>;
+
+      expect(headers['Authorization']).toBe('Bearer my-token');
+    });
+
+    it('should include Content-Type when body is provided', () => {
+      const headers = buildRequestHeaders(
+        client,
+        `${BASE_URL}/v1/status/`,
+        'POST',
+        false,
+        false,
+        { foo: 'bar' },
+        nullCache,
+      ) as Record<string, string>;
+
+      expect(headers['Content-Type']).toBe('application/json');
+    });
+
+    it('should not include Content-Type when body is not provided', () => {
+      const headers = buildRequestHeaders(
+        client,
+        `${BASE_URL}/v1/status/`,
+        'GET',
+        false,
+        false,
+        undefined,
+        nullCache,
+      ) as Record<string, string>;
+
+      expect(headers['Content-Type']).toBeUndefined();
+    });
+
+    it('should include If-None-Match header when useETag is true and cache has an ETag', () => {
+      const mockCache: Partial<ICache> = {
+        getETag: jest.fn().mockReturnValue('"etag-abc"'),
+      };
+      const withCache = () => mockCache as ICache;
+
+      const headers = buildRequestHeaders(
+        client,
+        `${BASE_URL}/v1/status/`,
+        'GET',
+        false,
+        true,
+        undefined,
+        withCache,
+      ) as Record<string, string>;
+
+      expect(headers['If-None-Match']).toBe('"etag-abc"');
+    });
+
+    it('should not include If-None-Match for non-GET methods', () => {
+      const mockCache: Partial<ICache> = {
+        getETag: jest.fn().mockReturnValue('"etag-abc"'),
+      };
+      const withCache = () => mockCache as ICache;
+
+      const headers = buildRequestHeaders(
+        client,
+        `${BASE_URL}/v1/status/`,
+        'POST',
+        false,
+        true,
+        undefined,
+        withCache,
+      ) as Record<string, string>;
+
+      expect(headers['If-None-Match']).toBeUndefined();
+    });
+  });
+});

--- a/tests/tdd/core/requestPipeline/statusHandling.test.ts
+++ b/tests/tdd/core/requestPipeline/statusHandling.test.ts
@@ -1,0 +1,167 @@
+import {
+  STATUS_MESSAGES,
+  handleEarlyStatus,
+  wrapError,
+} from '../../../../src/core/requestPipeline/statusHandling';
+import { ApiClient } from '../../../../src/core/ApiClient';
+import { EsiError } from '../../../../src/core/util/error';
+import { ETagCacheManager } from '../../../../src/core/cache/ETagCacheManager';
+import { CircuitOpenError } from '../../../../src/core/circuitBreaker/CircuitBreaker';
+import { ParsedHeaders } from '../../../../src/core/util/headersUtil';
+
+const BASE_URL = 'https://esi.evetech.net';
+
+describe('requestPipeline/statusHandling', () => {
+  describe('STATUS_MESSAGES', () => {
+    it('should have messages for common HTTP statuses', () => {
+      expect(STATUS_MESSAGES[404]).toBe('Resource not found');
+      expect(STATUS_MESSAGES[429]).toBe('Too many requests');
+      expect(STATUS_MESSAGES[500]).toBe('Internal server error');
+      expect(STATUS_MESSAGES[503]).toBe('Service Unavailable');
+    });
+
+    it('should have messages for ESI-specific statuses', () => {
+      expect(STATUS_MESSAGES[420]).toBe('Error Limited');
+      expect(STATUS_MESSAGES[520]).toContain('terminate too soon');
+    });
+  });
+
+  describe('handleEarlyStatus', () => {
+    let client: ApiClient;
+    const resolveCache = (c: ApiClient) => c.getCache();
+
+    beforeEach(() => {
+      client = new ApiClient('test', BASE_URL);
+    });
+
+    it('should return response with undefined body for 201', () => {
+      const parsed = {
+        raw: { 'x-request-id': '123' },
+      } as unknown as ParsedHeaders;
+      const result = handleEarlyStatus(
+        client,
+        201,
+        `${BASE_URL}/v1/test/`,
+        parsed,
+        false,
+        resolveCache,
+      );
+
+      expect(result).not.toBeNull();
+      expect(result!.body).toBeUndefined();
+      expect(result!.headers).toEqual(parsed.raw);
+    });
+
+    it('should return response with undefined body for 204', () => {
+      const parsed = { raw: {} } as unknown as ParsedHeaders;
+      const result = handleEarlyStatus(
+        client,
+        204,
+        `${BASE_URL}/v1/test/`,
+        parsed,
+        false,
+        resolveCache,
+      );
+
+      expect(result).not.toBeNull();
+      expect(result!.body).toBeUndefined();
+    });
+
+    it('should return cached data on 304 with cache hit', () => {
+      const cache = new ETagCacheManager({
+        maxEntries: 100,
+        defaultTtl: 60000,
+      });
+      client.setCache(cache);
+
+      const url = `${BASE_URL}/v1/status/`;
+      cache.set(url, '"etag"', { players: 50 }, { 'content-type': 'json' });
+
+      const parsed = {
+        raw: { 'x-new': 'header' },
+      } as unknown as ParsedHeaders;
+      const result = handleEarlyStatus(
+        client,
+        304,
+        url,
+        parsed,
+        true,
+        resolveCache,
+      );
+
+      expect(result).not.toBeNull();
+      expect(result!.fromCache).toBe(true);
+      expect(result!.cacheHitType).toBe('etag-304');
+      expect(result!.body).toEqual({ players: 50 });
+
+      cache.shutdown();
+    });
+
+    it('should throw EsiError on 304 with no cached data', () => {
+      const parsed = {
+        raw: {},
+        requestId: 'req-1',
+      } as unknown as ParsedHeaders;
+
+      expect(() =>
+        handleEarlyStatus(
+          client,
+          304,
+          `${BASE_URL}/v1/test/`,
+          parsed,
+          true,
+          resolveCache,
+        ),
+      ).toThrow(EsiError);
+    });
+
+    it('should return null for non-early statuses like 200', () => {
+      const parsed = { raw: {} } as unknown as ParsedHeaders;
+      const result = handleEarlyStatus(
+        client,
+        200,
+        `${BASE_URL}/v1/test/`,
+        parsed,
+        false,
+        resolveCache,
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null for error statuses like 500', () => {
+      const parsed = { raw: {} } as unknown as ParsedHeaders;
+      const result = handleEarlyStatus(
+        client,
+        500,
+        `${BASE_URL}/v1/test/`,
+        parsed,
+        false,
+        resolveCache,
+      );
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('wrapError', () => {
+    it('should rethrow EsiError as-is', () => {
+      const esiErr = new EsiError(404, 'Not found', '/test');
+      expect(() => wrapError(esiErr)).toThrow(esiErr);
+    });
+
+    it('should rethrow CircuitOpenError as-is', () => {
+      const cbErr = new CircuitOpenError('test-endpoint', 5, 30000);
+      expect(() => wrapError(cbErr)).toThrow(cbErr);
+    });
+
+    it('should wrap generic Error into ESIJS_ERROR', () => {
+      const err = new Error('something broke');
+      expect(() => wrapError(err)).toThrow('something broke');
+    });
+
+    it('should wrap string errors', () => {
+      expect(() => wrapError('string error')).toThrow('string error');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Extracts `ApiRequestHandler.ts` (815 → 250 lines) into 7 composable modules under `src/core/requestPipeline/`:
  - `headers.ts` — `buildRequestHeaders`, `parseCacheControlTtl`
  - `cachePolicy.ts` — `lookupSpecTtl`, `trySpecAwareCacheHit`, `tryStaleCacheResponse`, `cacheResponse`
  - `statusHandling.ts` — `handleEarlyStatus`, `handleErrorResponse`, `wrapError`, `STATUS_MESSAGES`
  - `paginationOrchestration.ts` — `handleCursorPagination`, `handleOffsetPagination`
  - `middlewareBridge.ts` — `applyRequestMiddleware`, `applyResponseInterceptors`
  - `fetchExecution.ts` — `executeSingleFetch`, `fetchOnePage`, `parseJsonBody`
  - `dependencies.ts` — `resolveCache`, `resolveRateLimiter`, `resolveCircuitBreaker`, `resolveRetryStrategy`
- Dependency resolution functions passed as parameters for testability
- 42 new focused unit tests across 3 test files
- No public API surface changes

## Test plan
- [ ] All 91 original test suites pass unmodified (behavior-preserving refactor)
- [ ] 42 new unit tests for extracted modules (headers, cachePolicy, statusHandling)
- [ ] Typecheck passes
- [ ] API surface report unchanged

> **Note:** Merge this PR before #144 (CB keying/half-open) — both touch `ApiRequestHandler.ts`. #144 will need a rebase after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)