### PR TITLE
fix: circuit breaker keying, half-open probe races, and scheduled cleanup

### DIFF
--- a/etc/esi.ts.api.md
+++ b/etc/esi.ts.api.md
@@ -3444,6 +3444,10 @@ export class CircuitBreaker implements ICircuitBreaker {
     // (undocumented)
     cleanup(): number;
     // (undocumented)
+    destroy(): void;
+    // (undocumented)
+    getKeyStrategy(): 'resolved' | 'template';
+    // (undocumented)
     getState(endpoint: string): CircuitState;
     // (undocumented)
     getStats(): {
@@ -3466,10 +3470,12 @@ export class CircuitBreaker implements ICircuitBreaker {
 
 // @public (undocumented)
 export interface CircuitBreakerConfig {
+    cleanupIntervalMs?: number;
     // (undocumented)
     failureThreshold?: number;
     // (undocumented)
     halfOpenMaxAttempts?: number;
+    keyStrategy?: 'resolved' | 'template';
     // (undocumented)
     resetTimeoutMs?: number;
     // (undocumented)
@@ -9952,6 +9958,8 @@ export interface ICircuitBreaker {
     checkCircuit(endpoint: string): void;
     // (undocumented)
     cleanup(): number;
+    destroy?(): void;
+    getKeyStrategy?(): 'resolved' | 'template';
     // (undocumented)
     getState(endpoint: string): CircuitState;
     // (undocumented)

--- a/src/core/circuitBreaker/CircuitBreaker.ts
+++ b/src/core/circuitBreaker/CircuitBreaker.ts
@@ -8,6 +8,10 @@ export interface CircuitBreakerConfig {
   resetTimeoutMs?: number;
   halfOpenMaxAttempts?: number;
   staleThresholdMs?: number;
+  /** 'resolved' (default, current behavior) | 'template' (group by endpoint template path) */
+  keyStrategy?: 'resolved' | 'template';
+  /** Interval in ms for automatic cleanup of stale circuits. 0 or undefined disables. Recommended value: staleThresholdMs. */
+  cleanupIntervalMs?: number;
 }
 
 interface CircuitRecord {
@@ -23,12 +27,20 @@ export class CircuitBreaker implements ICircuitBreaker {
   private readonly resetTimeoutMs: number;
   private readonly halfOpenMaxAttempts: number;
   private readonly staleThresholdMs: number;
+  private readonly keyStrategy: 'resolved' | 'template';
+  private cleanupTimer: ReturnType<typeof setInterval> | null = null;
 
   constructor(config: CircuitBreakerConfig = {}) {
     this.failureThreshold = config.failureThreshold ?? 5;
     this.resetTimeoutMs = config.resetTimeoutMs ?? 30_000;
     this.halfOpenMaxAttempts = config.halfOpenMaxAttempts ?? 1;
     this.staleThresholdMs = config.staleThresholdMs ?? 3_600_000;
+    this.keyStrategy = config.keyStrategy ?? 'resolved';
+
+    const cleanupIntervalMs = config.cleanupIntervalMs;
+    if (cleanupIntervalMs !== undefined && cleanupIntervalMs > 0) {
+      this.startCleanupTimer(cleanupIntervalMs);
+    }
   }
 
   private getKey(endpoint: string): string {
@@ -188,8 +200,28 @@ export class CircuitBreaker implements ICircuitBreaker {
     return cleaned;
   }
 
-  shutdown(): void {
+  getKeyStrategy(): 'resolved' | 'template' {
+    return this.keyStrategy;
+  }
+
+  destroy(): void {
+    if (this.cleanupTimer) {
+      clearInterval(this.cleanupTimer);
+      this.cleanupTimer = null;
+    }
     this.circuits.clear();
+  }
+
+  shutdown(): void {
+    this.destroy();
+  }
+
+  private startCleanupTimer(intervalMs: number): void {
+    this.cleanupTimer = setInterval(() => {
+      this.cleanup();
+    }, intervalMs);
+    // Don't prevent process exit (important for test runners and CLI tools)
+    this.cleanupTimer.unref();
   }
 }
 

--- a/src/core/circuitBreaker/ICircuitBreaker.ts
+++ b/src/core/circuitBreaker/ICircuitBreaker.ts
@@ -13,4 +13,8 @@ export interface ICircuitBreaker {
   reset(endpoint?: string): void;
   cleanup(): number;
   shutdown(): void;
+  /** Release resources (timers). Optional for backward compatibility. */
+  destroy?(): void;
+  /** Returns the configured key strategy. Optional for backward compatibility. */
+  getKeyStrategy?(): 'resolved' | 'template';
 }

--- a/src/core/requestPipeline/fetchExecution.ts
+++ b/src/core/requestPipeline/fetchExecution.ts
@@ -68,61 +68,75 @@ export async function executeSingleFetch(
   logInfo(`Hitting endpoint: ${url}`);
 
   const cb = resolveCircuitBreaker(client);
-  if (cb) cb.checkCircuit(endpoint);
+  const cbKey =
+    cb && templatePath && cb.getKeyStrategy?.() === 'template'
+      ? templatePath
+      : endpoint;
 
-  const rateLimiter = resolveRateLimiter(client);
-  await rateLimiter.checkRateLimit(templatePath, method, req.headers);
+  if (cb) cb.checkCircuit(cbKey);
 
-  const timeoutMs = requestTimeout ?? client.getTimeout();
-  const controller = new AbortController();
-  const timer = globalThis.setTimeout(() => controller.abort(), timeoutMs);
-  options.signal = controller.signal;
+  let cbRecorded = false;
 
-  let response: Response;
   try {
-    response = await fetch(url, options);
-  } catch (err) {
+    const rateLimiter = resolveRateLimiter(client);
+    await rateLimiter.checkRateLimit(templatePath, method, req.headers);
+
+    const timeoutMs = requestTimeout ?? client.getTimeout();
+    const controller = new AbortController();
+    const timer = globalThis.setTimeout(() => controller.abort(), timeoutMs);
+    options.signal = controller.signal;
+
+    let response: Response;
+    try {
+      response = await fetch(url, options);
+    } catch (err) {
+      clearTimeout(timer);
+      if (cb) {
+        cb.recordFailure(cbKey, 0);
+        cbRecorded = true;
+      }
+      if (err instanceof Error && err.name === 'AbortError') {
+        throw new TimeoutError(timeoutMs, url);
+      }
+      throw err;
+    }
     clearTimeout(timer);
-    if (cb) {
-      // Status 0 = network/timeout failure — counts toward opening the circuit
-      cb.recordFailure(endpoint, 0);
-    }
-    if (err instanceof Error && err.name === 'AbortError') {
-      throw new TimeoutError(timeoutMs, url);
-    }
-    throw err;
-  }
-  clearTimeout(timer);
 
-  const parsed = parseHeaders(response.headers);
+    const parsed = parseHeaders(response.headers);
 
-  rateLimiter.updateFromResponse(
-    parsed.raw,
-    response.status,
-    templatePath,
-    method,
-    req.headers,
-  );
-
-  if (cb) {
-    if (
-      response.status >= 500 ||
-      response.status === 420 ||
-      response.status === 429
-    ) {
-      cb.recordFailure(endpoint, response.status);
-    } else {
-      cb.recordSuccess(endpoint);
-    }
-  }
-
-  if (parsed.warning) {
-    logWarn(
-      `ESI Warning ${parsed.warning.code} for ${url}: ${parsed.warning.message}`,
+    rateLimiter.updateFromResponse(
+      parsed.raw,
+      response.status,
+      templatePath,
+      method,
+      req.headers,
     );
-  }
 
-  return { response, parsed, url };
+    if (cb) {
+      if (
+        response.status >= 500 ||
+        response.status === 420 ||
+        response.status === 429
+      ) {
+        cb.recordFailure(cbKey, response.status);
+      } else {
+        cb.recordSuccess(cbKey);
+      }
+      cbRecorded = true;
+    }
+
+    if (parsed.warning) {
+      logWarn(
+        `ESI Warning ${parsed.warning.code} for ${url}: ${parsed.warning.message}`,
+      );
+    }
+
+    return { response, parsed, url };
+  } finally {
+    if (cb && !cbRecorded) {
+      cb.recordFailure(cbKey, 0);
+    }
+  }
 }
 
 /**

--- a/tests/tdd/core/circuitBreaker.test.ts
+++ b/tests/tdd/core/circuitBreaker.test.ts
@@ -1,6 +1,7 @@
 import {
   CircuitBreaker,
   CircuitOpenError,
+  CircuitBreakerConfig,
 } from '../../../src/core/circuitBreaker/CircuitBreaker';
 
 describe('CircuitBreaker', () => {
@@ -319,6 +320,164 @@ describe('CircuitBreaker', () => {
       cb.recordFailure('v1/universe/types/', 500);
 
       cb.reset();
+      expect(cb.getStats().totalCircuits).toBe(0);
+    });
+  });
+
+  describe('key strategy', () => {
+    it('should default to resolved key strategy', () => {
+      const cb = new CircuitBreaker();
+      expect(cb.getKeyStrategy()).toBe('resolved');
+    });
+
+    it('should accept template key strategy', () => {
+      const cb = new CircuitBreaker({ keyStrategy: 'template' });
+      cb.destroy();
+      expect(cb.getKeyStrategy()).toBe('template');
+    });
+
+    it('should isolate resolved paths by default (different characters)', () => {
+      const cb = new CircuitBreaker({
+        failureThreshold: 2,
+        cleanupIntervalMs: 0,
+      });
+
+      cb.recordFailure('characters/1/orders/', 500);
+      cb.recordFailure('characters/1/orders/', 500);
+
+      expect(cb.getState('characters/1/orders/')).toBe('open');
+      expect(cb.getState('characters/2/orders/')).toBe('closed');
+    });
+
+    it('should group under same circuit when template key is used directly', () => {
+      const cb = new CircuitBreaker({
+        failureThreshold: 2,
+        keyStrategy: 'template',
+        cleanupIntervalMs: 0,
+      });
+
+      // When keyStrategy is 'template', the caller (ApiRequestHandler)
+      // passes the template path. Here we simulate that by passing the
+      // template path directly to the CB methods.
+      const templateKey = 'characters/{character_id}/orders/';
+
+      cb.recordFailure(templateKey, 500);
+      cb.recordFailure(templateKey, 500);
+
+      expect(cb.getState(templateKey)).toBe('open');
+    });
+  });
+
+  describe('half-open probe slot release', () => {
+    it('should allow re-probing after failure releases slot', () => {
+      const cb = new CircuitBreaker({
+        failureThreshold: 2,
+        resetTimeoutMs: 0,
+        halfOpenMaxAttempts: 1,
+      });
+
+      cb.recordFailure('v1/status/', 500);
+      cb.recordFailure('v1/status/', 500);
+
+      // Transitions to half-open and allows probe
+      cb.checkCircuit('v1/status/');
+
+      // Simulate an early throw: recordFailure with status 0 releases the slot
+      cb.recordFailure('v1/status/', 0);
+
+      // After the probe failure, circuit should re-open.
+      // With resetTimeoutMs=0, getState sees it as half-open again.
+      // A new probe should be allowed (half-open attempts reset on re-open).
+      cb.checkCircuit('v1/status/');
+      // The probe is allowed, verifying slot is not permanently wasted
+      cb.recordSuccess('v1/status/');
+      expect(cb.getState('v1/status/')).toBe('closed');
+    });
+  });
+
+  describe('scheduled cleanup', () => {
+    it('should automatically clean stale circuits on timer', async () => {
+      const cb = new CircuitBreaker({
+        failureThreshold: 5,
+        staleThresholdMs: 1,
+        cleanupIntervalMs: 10,
+      });
+
+      cb.recordFailure('v1/a/', 500);
+      cb.recordSuccess('v1/a/');
+
+      expect(cb.getStats().totalCircuits).toBe(1);
+
+      // Wait for the cleanup timer to fire
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(cb.getStats().totalCircuits).toBe(0);
+
+      cb.destroy();
+    });
+
+    it('should not start cleanup timer when cleanupIntervalMs is 0', () => {
+      const cb = new CircuitBreaker({ cleanupIntervalMs: 0 });
+
+      // Should not throw or have issues
+      cb.recordFailure('v1/a/', 500);
+      cb.recordSuccess('v1/a/');
+
+      cb.destroy();
+    });
+  });
+
+  describe('destroy', () => {
+    it('should clear the cleanup timer and circuits', () => {
+      const cb = new CircuitBreaker({
+        failureThreshold: 2,
+        cleanupIntervalMs: 100,
+      });
+
+      cb.recordFailure('v1/status/', 500);
+      cb.recordFailure('v1/status/', 500);
+
+      expect(cb.getStats().totalCircuits).toBe(1);
+
+      cb.destroy();
+
+      expect(cb.getStats().totalCircuits).toBe(0);
+    });
+
+    it('should be safe to call destroy multiple times', () => {
+      const cb = new CircuitBreaker({ cleanupIntervalMs: 100 });
+
+      cb.destroy();
+      cb.destroy();
+      // No errors expected
+    });
+
+    it('should stop scheduled cleanup after destroy', async () => {
+      const cb = new CircuitBreaker({
+        failureThreshold: 5,
+        staleThresholdMs: 1,
+        cleanupIntervalMs: 10,
+      });
+
+      cb.destroy();
+
+      // Add a stale circuit after destroy
+      cb.recordFailure('v1/a/', 500);
+      cb.recordSuccess('v1/a/');
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // Timer was cleared, so automatic cleanup should not have run
+      expect(cb.getStats().totalCircuits).toBe(1);
+    });
+
+    it('shutdown should delegate to destroy', () => {
+      const cb = new CircuitBreaker({ cleanupIntervalMs: 100 });
+
+      cb.recordFailure('v1/status/', 500);
+
+      cb.shutdown();
+
       expect(cb.getStats().totalCircuits).toBe(0);
     });
   });


### PR DESCRIPTION
## Summary
- Adds configurable `keyStrategy` to `CircuitBreakerConfig` (`'resolved'` default | `'template'` for grouping by endpoint template path)
- Fixes half-open probe race: wraps CB-guarded section in `try/finally` so a wasted probe slot (e.g. rate limiter throws between `checkCircuit` and `recordSuccess`) is released via `recordFailure`
- Adds scheduled `cleanup()` via opt-in `cleanupIntervalMs` config (timer is `unref()`'d)
- Adds `destroy()` method to `CircuitBreaker` for clean resource release
- 159 lines of new tests covering key strategy, half-open slot release, scheduled cleanup, and destroy

## Test plan
- [ ] All existing test suites pass unmodified
- [ ] New tests verify: resolved vs template key isolation, half-open slot release, scheduled cleanup fires, destroy clears timer
- [ ] Typecheck passes
- [ ] API surface report updated

> **Note:** This PR conflicts with #143 (handler decomposition) — both touch `ApiRequestHandler.ts`. Merge #143 first, then rebase this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)