### PR TITLE
refactor: remove generatedSchemas from public API surface

### DIFF
--- a/etc/esi.ts.api.md
+++ b/etc/esi.ts.api.md
@@ -130,17 +130,6 @@ interface AllianceDetail {
 }
 
 // @public (undocumented)
-const AllianceDetailSchema: z.ZodObject<{
-    creator_corporation_id: z.ZodNumber;
-    creator_id: z.ZodNumber;
-    date_founded: z.ZodString;
-    executor_corporation_id: z.ZodOptional<z.ZodNumber>;
-    faction_id: z.ZodOptional<z.ZodNumber>;
-    name: z.ZodString;
-    ticker: z.ZodString;
-}, z.core.$loose>;
-
-// @public (undocumented)
 export type AllianceIcon = z.infer<typeof AllianceIconSchema>;
 
 // @public (undocumented)
@@ -182,19 +171,6 @@ interface AlliancesAllianceIdContactsGet {
 }
 
 // @public (undocumented)
-const AlliancesAllianceIdContactsGetSchema: z.ZodObject<{
-    contact_id: z.ZodNumber;
-    contact_type: z.ZodEnum<{
-        faction: "faction";
-        character: "character";
-        corporation: "corporation";
-        alliance: "alliance";
-    }>;
-    label_ids: z.ZodOptional<z.ZodArray<z.ZodNumber>>;
-    standing: z.ZodNumber;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface AlliancesAllianceIdContactsLabelsGet {
     // (undocumented)
     label_id: number;
@@ -203,24 +179,12 @@ interface AlliancesAllianceIdContactsLabelsGet {
 }
 
 // @public (undocumented)
-const AlliancesAllianceIdContactsLabelsGetSchema: z.ZodObject<{
-    label_id: z.ZodNumber;
-    label_name: z.ZodString;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface AlliancesAllianceIdIconsGet {
     // (undocumented)
     px128x128?: string;
     // (undocumented)
     px64x64?: string;
 }
-
-// @public (undocumented)
-const AlliancesAllianceIdIconsGetSchema: z.ZodObject<{
-    px128x128: z.ZodOptional<z.ZodString>;
-    px64x64: z.ZodOptional<z.ZodString>;
-}, z.core.$loose>;
 
 // @public (undocumented)
 export type Ancestry = z.infer<typeof AncestrySchema>;
@@ -832,14 +796,6 @@ interface CharactersAffiliationPost {
 }
 
 // @public (undocumented)
-const CharactersAffiliationPostSchema: z.ZodObject<{
-    alliance_id: z.ZodOptional<z.ZodNumber>;
-    character_id: z.ZodNumber;
-    corporation_id: z.ZodNumber;
-    faction_id: z.ZodOptional<z.ZodNumber>;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface CharactersCharacterIdAgentsResearchGet {
     // (undocumented)
     agent_id: number;
@@ -852,15 +808,6 @@ interface CharactersCharacterIdAgentsResearchGet {
     // (undocumented)
     started_at: string;
 }
-
-// @public (undocumented)
-const CharactersCharacterIdAgentsResearchGetSchema: z.ZodObject<{
-    agent_id: z.ZodNumber;
-    points_per_day: z.ZodNumber;
-    remainder_points: z.ZodNumber;
-    skill_type_id: z.ZodNumber;
-    started_at: z.ZodString;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface CharactersCharacterIdAssetsGet {
@@ -883,113 +830,6 @@ interface CharactersCharacterIdAssetsGet {
 }
 
 // @public (undocumented)
-const CharactersCharacterIdAssetsGetSchema: z.ZodObject<{
-    is_blueprint_copy: z.ZodOptional<z.ZodBoolean>;
-    is_singleton: z.ZodBoolean;
-    item_id: z.ZodNumber;
-    location_flag: z.ZodEnum<{
-        AssetSafety: "AssetSafety";
-        AutoFit: "AutoFit";
-        BoosterBay: "BoosterBay";
-        CapsuleerDeliveries: "CapsuleerDeliveries";
-        Cargo: "Cargo";
-        CorporationGoalDeliveries: "CorporationGoalDeliveries";
-        CorpseBay: "CorpseBay";
-        Deliveries: "Deliveries";
-        DroneBay: "DroneBay";
-        ExpeditionHold: "ExpeditionHold";
-        FighterBay: "FighterBay";
-        FighterTube0: "FighterTube0";
-        FighterTube1: "FighterTube1";
-        FighterTube2: "FighterTube2";
-        FighterTube3: "FighterTube3";
-        FighterTube4: "FighterTube4";
-        FleetHangar: "FleetHangar";
-        FrigateEscapeBay: "FrigateEscapeBay";
-        Hangar: "Hangar";
-        HangarAll: "HangarAll";
-        HiSlot0: "HiSlot0";
-        HiSlot1: "HiSlot1";
-        HiSlot2: "HiSlot2";
-        HiSlot3: "HiSlot3";
-        HiSlot4: "HiSlot4";
-        HiSlot5: "HiSlot5";
-        HiSlot6: "HiSlot6";
-        HiSlot7: "HiSlot7";
-        HiddenModifiers: "HiddenModifiers";
-        Implant: "Implant";
-        InfrastructureHangar: "InfrastructureHangar";
-        LoSlot0: "LoSlot0";
-        LoSlot1: "LoSlot1";
-        LoSlot2: "LoSlot2";
-        LoSlot3: "LoSlot3";
-        LoSlot4: "LoSlot4";
-        LoSlot5: "LoSlot5";
-        LoSlot6: "LoSlot6";
-        LoSlot7: "LoSlot7";
-        Locked: "Locked";
-        MedSlot0: "MedSlot0";
-        MedSlot1: "MedSlot1";
-        MedSlot2: "MedSlot2";
-        MedSlot3: "MedSlot3";
-        MedSlot4: "MedSlot4";
-        MedSlot5: "MedSlot5";
-        MedSlot6: "MedSlot6";
-        MedSlot7: "MedSlot7";
-        MobileDepotHold: "MobileDepotHold";
-        MoonMaterialBay: "MoonMaterialBay";
-        QuafeBay: "QuafeBay";
-        RigSlot0: "RigSlot0";
-        RigSlot1: "RigSlot1";
-        RigSlot2: "RigSlot2";
-        RigSlot3: "RigSlot3";
-        RigSlot4: "RigSlot4";
-        RigSlot5: "RigSlot5";
-        RigSlot6: "RigSlot6";
-        RigSlot7: "RigSlot7";
-        ShipHangar: "ShipHangar";
-        Skill: "Skill";
-        SpecializedAmmoHold: "SpecializedAmmoHold";
-        SpecializedAsteroidHold: "SpecializedAsteroidHold";
-        SpecializedCommandCenterHold: "SpecializedCommandCenterHold";
-        SpecializedFuelBay: "SpecializedFuelBay";
-        SpecializedGasHold: "SpecializedGasHold";
-        SpecializedIceHold: "SpecializedIceHold";
-        SpecializedIndustrialShipHold: "SpecializedIndustrialShipHold";
-        SpecializedLargeShipHold: "SpecializedLargeShipHold";
-        SpecializedMaterialBay: "SpecializedMaterialBay";
-        SpecializedMediumShipHold: "SpecializedMediumShipHold";
-        SpecializedMineralHold: "SpecializedMineralHold";
-        SpecializedOreHold: "SpecializedOreHold";
-        SpecializedPlanetaryCommoditiesHold: "SpecializedPlanetaryCommoditiesHold";
-        SpecializedSalvageHold: "SpecializedSalvageHold";
-        SpecializedShipHold: "SpecializedShipHold";
-        SpecializedSmallShipHold: "SpecializedSmallShipHold";
-        StructureDeedBay: "StructureDeedBay";
-        SubSystemBay: "SubSystemBay";
-        SubSystemSlot0: "SubSystemSlot0";
-        SubSystemSlot1: "SubSystemSlot1";
-        SubSystemSlot2: "SubSystemSlot2";
-        SubSystemSlot3: "SubSystemSlot3";
-        SubSystemSlot4: "SubSystemSlot4";
-        SubSystemSlot5: "SubSystemSlot5";
-        SubSystemSlot6: "SubSystemSlot6";
-        SubSystemSlot7: "SubSystemSlot7";
-        Unlocked: "Unlocked";
-        Wardrobe: "Wardrobe";
-    }>;
-    location_id: z.ZodNumber;
-    location_type: z.ZodEnum<{
-        other: "other";
-        solar_system: "solar_system";
-        station: "station";
-        item: "item";
-    }>;
-    quantity: z.ZodNumber;
-    type_id: z.ZodNumber;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface CharactersCharacterIdAssetsLocationsPost {
     // (undocumented)
     item_id: number;
@@ -1002,28 +842,12 @@ interface CharactersCharacterIdAssetsLocationsPost {
 }
 
 // @public (undocumented)
-const CharactersCharacterIdAssetsLocationsPostSchema: z.ZodObject<{
-    item_id: z.ZodNumber;
-    position: z.ZodObject<{
-        x: z.ZodNumber;
-        y: z.ZodNumber;
-        z: z.ZodNumber;
-    }, z.core.$loose>;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface CharactersCharacterIdAssetsNamesPost {
     // (undocumented)
     item_id: number;
     // (undocumented)
     name: string;
 }
-
-// @public (undocumented)
-const CharactersCharacterIdAssetsNamesPostSchema: z.ZodObject<{
-    item_id: z.ZodNumber;
-    name: z.ZodString;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface CharactersCharacterIdAttributesGet {
@@ -1046,18 +870,6 @@ interface CharactersCharacterIdAttributesGet {
 }
 
 // @public (undocumented)
-const CharactersCharacterIdAttributesGetSchema: z.ZodObject<{
-    accrued_remap_cooldown_date: z.ZodOptional<z.ZodString>;
-    bonus_remaps: z.ZodOptional<z.ZodNumber>;
-    charisma: z.ZodNumber;
-    intelligence: z.ZodNumber;
-    last_remap_date: z.ZodOptional<z.ZodString>;
-    memory: z.ZodNumber;
-    perception: z.ZodNumber;
-    willpower: z.ZodNumber;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface CharactersCharacterIdBlueprintsGet {
     // (undocumented)
     item_id: number;
@@ -1078,112 +890,12 @@ interface CharactersCharacterIdBlueprintsGet {
 }
 
 // @public (undocumented)
-const CharactersCharacterIdBlueprintsGetSchema: z.ZodObject<{
-    item_id: z.ZodNumber;
-    location_flag: z.ZodEnum<{
-        AssetSafety: "AssetSafety";
-        AutoFit: "AutoFit";
-        Cargo: "Cargo";
-        CorpseBay: "CorpseBay";
-        Deliveries: "Deliveries";
-        DroneBay: "DroneBay";
-        FighterBay: "FighterBay";
-        FighterTube0: "FighterTube0";
-        FighterTube1: "FighterTube1";
-        FighterTube2: "FighterTube2";
-        FighterTube3: "FighterTube3";
-        FighterTube4: "FighterTube4";
-        FleetHangar: "FleetHangar";
-        Hangar: "Hangar";
-        HangarAll: "HangarAll";
-        HiSlot0: "HiSlot0";
-        HiSlot1: "HiSlot1";
-        HiSlot2: "HiSlot2";
-        HiSlot3: "HiSlot3";
-        HiSlot4: "HiSlot4";
-        HiSlot5: "HiSlot5";
-        HiSlot6: "HiSlot6";
-        HiSlot7: "HiSlot7";
-        HiddenModifiers: "HiddenModifiers";
-        Implant: "Implant";
-        LoSlot0: "LoSlot0";
-        LoSlot1: "LoSlot1";
-        LoSlot2: "LoSlot2";
-        LoSlot3: "LoSlot3";
-        LoSlot4: "LoSlot4";
-        LoSlot5: "LoSlot5";
-        LoSlot6: "LoSlot6";
-        LoSlot7: "LoSlot7";
-        Locked: "Locked";
-        MedSlot0: "MedSlot0";
-        MedSlot1: "MedSlot1";
-        MedSlot2: "MedSlot2";
-        MedSlot3: "MedSlot3";
-        MedSlot4: "MedSlot4";
-        MedSlot5: "MedSlot5";
-        MedSlot6: "MedSlot6";
-        MedSlot7: "MedSlot7";
-        QuafeBay: "QuafeBay";
-        RigSlot0: "RigSlot0";
-        RigSlot1: "RigSlot1";
-        RigSlot2: "RigSlot2";
-        RigSlot3: "RigSlot3";
-        RigSlot4: "RigSlot4";
-        RigSlot5: "RigSlot5";
-        RigSlot6: "RigSlot6";
-        RigSlot7: "RigSlot7";
-        ShipHangar: "ShipHangar";
-        SpecializedAmmoHold: "SpecializedAmmoHold";
-        SpecializedCommandCenterHold: "SpecializedCommandCenterHold";
-        SpecializedFuelBay: "SpecializedFuelBay";
-        SpecializedGasHold: "SpecializedGasHold";
-        SpecializedIndustrialShipHold: "SpecializedIndustrialShipHold";
-        SpecializedLargeShipHold: "SpecializedLargeShipHold";
-        SpecializedMaterialBay: "SpecializedMaterialBay";
-        SpecializedMediumShipHold: "SpecializedMediumShipHold";
-        SpecializedMineralHold: "SpecializedMineralHold";
-        SpecializedOreHold: "SpecializedOreHold";
-        SpecializedPlanetaryCommoditiesHold: "SpecializedPlanetaryCommoditiesHold";
-        SpecializedSalvageHold: "SpecializedSalvageHold";
-        SpecializedShipHold: "SpecializedShipHold";
-        SpecializedSmallShipHold: "SpecializedSmallShipHold";
-        SubSystemSlot0: "SubSystemSlot0";
-        SubSystemSlot1: "SubSystemSlot1";
-        SubSystemSlot2: "SubSystemSlot2";
-        SubSystemSlot3: "SubSystemSlot3";
-        SubSystemSlot4: "SubSystemSlot4";
-        SubSystemSlot5: "SubSystemSlot5";
-        SubSystemSlot6: "SubSystemSlot6";
-        SubSystemSlot7: "SubSystemSlot7";
-        Unlocked: "Unlocked";
-        Module: "Module";
-    }>;
-    location_id: z.ZodNumber;
-    material_efficiency: z.ZodNumber;
-    quantity: z.ZodNumber;
-    runs: z.ZodNumber;
-    time_efficiency: z.ZodNumber;
-    type_id: z.ZodNumber;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface CharactersCharacterIdCalendarEventIdAttendeesGet {
     // (undocumented)
     character_id?: number;
     // (undocumented)
     event_response?: 'declined' | 'not_responded' | 'accepted' | 'tentative';
 }
-
-// @public (undocumented)
-const CharactersCharacterIdCalendarEventIdAttendeesGetSchema: z.ZodObject<{
-    character_id: z.ZodOptional<z.ZodNumber>;
-    event_response: z.ZodOptional<z.ZodEnum<{
-        declined: "declined";
-        not_responded: "not_responded";
-        accepted: "accepted";
-        tentative: "tentative";
-    }>>;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface CharactersCharacterIdCalendarEventIdGet {
@@ -1210,26 +922,6 @@ interface CharactersCharacterIdCalendarEventIdGet {
 }
 
 // @public (undocumented)
-const CharactersCharacterIdCalendarEventIdGetSchema: z.ZodObject<{
-    date: z.ZodString;
-    duration: z.ZodNumber;
-    event_id: z.ZodNumber;
-    importance: z.ZodNumber;
-    owner_id: z.ZodNumber;
-    owner_name: z.ZodString;
-    owner_type: z.ZodEnum<{
-        faction: "faction";
-        character: "character";
-        corporation: "corporation";
-        alliance: "alliance";
-        eve_server: "eve_server";
-    }>;
-    response: z.ZodString;
-    text: z.ZodString;
-    title: z.ZodString;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface CharactersCharacterIdCalendarGet {
     // (undocumented)
     event_date?: string;
@@ -1242,20 +934,6 @@ interface CharactersCharacterIdCalendarGet {
     // (undocumented)
     title?: string;
 }
-
-// @public (undocumented)
-const CharactersCharacterIdCalendarGetSchema: z.ZodObject<{
-    event_date: z.ZodOptional<z.ZodString>;
-    event_id: z.ZodOptional<z.ZodNumber>;
-    event_response: z.ZodOptional<z.ZodEnum<{
-        declined: "declined";
-        not_responded: "not_responded";
-        accepted: "accepted";
-        tentative: "tentative";
-    }>>;
-    importance: z.ZodOptional<z.ZodNumber>;
-    title: z.ZodOptional<z.ZodString>;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface CharactersCharacterIdClonesGet {
@@ -1279,29 +957,6 @@ interface CharactersCharacterIdClonesGet {
 }
 
 // @public (undocumented)
-const CharactersCharacterIdClonesGetSchema: z.ZodObject<{
-    home_location: z.ZodOptional<z.ZodObject<{
-        location_id: z.ZodOptional<z.ZodNumber>;
-        location_type: z.ZodOptional<z.ZodEnum<{
-            station: "station";
-            structure: "structure";
-        }>>;
-    }, z.core.$loose>>;
-    jump_clones: z.ZodArray<z.ZodObject<{
-        implants: z.ZodArray<z.ZodNumber>;
-        jump_clone_id: z.ZodNumber;
-        location_id: z.ZodNumber;
-        location_type: z.ZodEnum<{
-            station: "station";
-            structure: "structure";
-        }>;
-        name: z.ZodOptional<z.ZodString>;
-    }, z.core.$loose>>;
-    last_clone_jump_date: z.ZodOptional<z.ZodString>;
-    last_station_change_date: z.ZodOptional<z.ZodString>;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface CharactersCharacterIdContactsGet {
     // (undocumented)
     contact_id: number;
@@ -1318,33 +973,12 @@ interface CharactersCharacterIdContactsGet {
 }
 
 // @public (undocumented)
-const CharactersCharacterIdContactsGetSchema: z.ZodObject<{
-    contact_id: z.ZodNumber;
-    contact_type: z.ZodEnum<{
-        faction: "faction";
-        character: "character";
-        corporation: "corporation";
-        alliance: "alliance";
-    }>;
-    is_blocked: z.ZodOptional<z.ZodBoolean>;
-    is_watched: z.ZodOptional<z.ZodBoolean>;
-    label_ids: z.ZodOptional<z.ZodArray<z.ZodNumber>>;
-    standing: z.ZodNumber;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface CharactersCharacterIdContactsLabelsGet {
     // (undocumented)
     label_id: number;
     // (undocumented)
     label_name: string;
 }
-
-// @public (undocumented)
-const CharactersCharacterIdContactsLabelsGetSchema: z.ZodObject<{
-    label_id: z.ZodNumber;
-    label_name: z.ZodString;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface CharactersCharacterIdContractsContractIdBidsGet {
@@ -1357,14 +991,6 @@ interface CharactersCharacterIdContractsContractIdBidsGet {
     // (undocumented)
     date_bid: string;
 }
-
-// @public (undocumented)
-const CharactersCharacterIdContractsContractIdBidsGetSchema: z.ZodObject<{
-    amount: z.ZodNumber;
-    bid_id: z.ZodNumber;
-    bidder_id: z.ZodNumber;
-    date_bid: z.ZodString;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface CharactersCharacterIdContractsContractIdItemsGet {
@@ -1381,16 +1007,6 @@ interface CharactersCharacterIdContractsContractIdItemsGet {
     // (undocumented)
     type_id: number;
 }
-
-// @public (undocumented)
-const CharactersCharacterIdContractsContractIdItemsGetSchema: z.ZodObject<{
-    is_included: z.ZodBoolean;
-    is_singleton: z.ZodBoolean;
-    quantity: z.ZodNumber;
-    raw_quantity: z.ZodOptional<z.ZodNumber>;
-    record_id: z.ZodNumber;
-    type_id: z.ZodNumber;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface CharactersCharacterIdContractsGet {
@@ -1441,54 +1057,6 @@ interface CharactersCharacterIdContractsGet {
 }
 
 // @public (undocumented)
-const CharactersCharacterIdContractsGetSchema: z.ZodObject<{
-    acceptor_id: z.ZodNumber;
-    assignee_id: z.ZodNumber;
-    availability: z.ZodEnum<{
-        corporation: "corporation";
-        alliance: "alliance";
-        public: "public";
-        personal: "personal";
-    }>;
-    buyout: z.ZodOptional<z.ZodNumber>;
-    collateral: z.ZodOptional<z.ZodNumber>;
-    contract_id: z.ZodNumber;
-    date_accepted: z.ZodOptional<z.ZodString>;
-    date_completed: z.ZodOptional<z.ZodString>;
-    date_expired: z.ZodString;
-    date_issued: z.ZodString;
-    days_to_complete: z.ZodOptional<z.ZodNumber>;
-    end_location_id: z.ZodOptional<z.ZodNumber>;
-    for_corporation: z.ZodBoolean;
-    issuer_corporation_id: z.ZodNumber;
-    issuer_id: z.ZodNumber;
-    price: z.ZodOptional<z.ZodNumber>;
-    reward: z.ZodOptional<z.ZodNumber>;
-    start_location_id: z.ZodOptional<z.ZodNumber>;
-    status: z.ZodEnum<{
-        cancelled: "cancelled";
-        outstanding: "outstanding";
-        in_progress: "in_progress";
-        finished_issuer: "finished_issuer";
-        finished_contractor: "finished_contractor";
-        finished: "finished";
-        rejected: "rejected";
-        failed: "failed";
-        deleted: "deleted";
-        reversed: "reversed";
-    }>;
-    title: z.ZodOptional<z.ZodString>;
-    type: z.ZodEnum<{
-        unknown: "unknown";
-        item_exchange: "item_exchange";
-        auction: "auction";
-        courier: "courier";
-        loan: "loan";
-    }>;
-    volume: z.ZodOptional<z.ZodNumber>;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface CharactersCharacterIdCorporationhistoryGet {
     // (undocumented)
     corporation_id: number;
@@ -1501,14 +1069,6 @@ interface CharactersCharacterIdCorporationhistoryGet {
 }
 
 // @public (undocumented)
-const CharactersCharacterIdCorporationhistoryGetSchema: z.ZodObject<{
-    corporation_id: z.ZodNumber;
-    is_deleted: z.ZodOptional<z.ZodBoolean>;
-    record_id: z.ZodNumber;
-    start_date: z.ZodString;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface CharactersCharacterIdFatigueGet {
     // (undocumented)
     jump_fatigue_expire_date?: string;
@@ -1517,13 +1077,6 @@ interface CharactersCharacterIdFatigueGet {
     // (undocumented)
     last_update_date?: string;
 }
-
-// @public (undocumented)
-const CharactersCharacterIdFatigueGetSchema: z.ZodObject<{
-    jump_fatigue_expire_date: z.ZodOptional<z.ZodString>;
-    last_jump_date: z.ZodOptional<z.ZodString>;
-    last_update_date: z.ZodOptional<z.ZodString>;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface CharactersCharacterIdFittingsGet {
@@ -1544,63 +1097,6 @@ interface CharactersCharacterIdFittingsGet {
 }
 
 // @public (undocumented)
-const CharactersCharacterIdFittingsGetSchema: z.ZodObject<{
-    description: z.ZodString;
-    fitting_id: z.ZodNumber;
-    items: z.ZodArray<z.ZodObject<{
-        flag: z.ZodEnum<{
-            Cargo: "Cargo";
-            DroneBay: "DroneBay";
-            FighterBay: "FighterBay";
-            HiSlot0: "HiSlot0";
-            HiSlot1: "HiSlot1";
-            HiSlot2: "HiSlot2";
-            HiSlot3: "HiSlot3";
-            HiSlot4: "HiSlot4";
-            HiSlot5: "HiSlot5";
-            HiSlot6: "HiSlot6";
-            HiSlot7: "HiSlot7";
-            LoSlot0: "LoSlot0";
-            LoSlot1: "LoSlot1";
-            LoSlot2: "LoSlot2";
-            LoSlot3: "LoSlot3";
-            LoSlot4: "LoSlot4";
-            LoSlot5: "LoSlot5";
-            LoSlot6: "LoSlot6";
-            LoSlot7: "LoSlot7";
-            MedSlot0: "MedSlot0";
-            MedSlot1: "MedSlot1";
-            MedSlot2: "MedSlot2";
-            MedSlot3: "MedSlot3";
-            MedSlot4: "MedSlot4";
-            MedSlot5: "MedSlot5";
-            MedSlot6: "MedSlot6";
-            MedSlot7: "MedSlot7";
-            RigSlot0: "RigSlot0";
-            RigSlot1: "RigSlot1";
-            RigSlot2: "RigSlot2";
-            SubSystemSlot0: "SubSystemSlot0";
-            SubSystemSlot1: "SubSystemSlot1";
-            SubSystemSlot2: "SubSystemSlot2";
-            SubSystemSlot3: "SubSystemSlot3";
-            ServiceSlot0: "ServiceSlot0";
-            ServiceSlot1: "ServiceSlot1";
-            ServiceSlot2: "ServiceSlot2";
-            ServiceSlot3: "ServiceSlot3";
-            ServiceSlot4: "ServiceSlot4";
-            ServiceSlot5: "ServiceSlot5";
-            ServiceSlot6: "ServiceSlot6";
-            ServiceSlot7: "ServiceSlot7";
-            Invalid: "Invalid";
-        }>;
-        quantity: z.ZodNumber;
-        type_id: z.ZodNumber;
-    }, z.core.$loose>>;
-    name: z.ZodString;
-    ship_type_id: z.ZodNumber;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface CharactersCharacterIdFleetGet {
     // (undocumented)
     fleet_boss_id: number;
@@ -1613,20 +1109,6 @@ interface CharactersCharacterIdFleetGet {
     // (undocumented)
     wing_id: number;
 }
-
-// @public (undocumented)
-const CharactersCharacterIdFleetGetSchema: z.ZodObject<{
-    fleet_boss_id: z.ZodNumber;
-    fleet_id: z.ZodNumber;
-    role: z.ZodEnum<{
-        fleet_commander: "fleet_commander";
-        wing_commander: "wing_commander";
-        squad_commander: "squad_commander";
-        squad_member: "squad_member";
-    }>;
-    squad_id: z.ZodNumber;
-    wing_id: z.ZodNumber;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface CharactersCharacterIdFwStatsGet {
@@ -1651,24 +1133,6 @@ interface CharactersCharacterIdFwStatsGet {
         yesterday: number;
     };
 }
-
-// @public (undocumented)
-const CharactersCharacterIdFwStatsGetSchema: z.ZodObject<{
-    current_rank: z.ZodOptional<z.ZodNumber>;
-    enlisted_on: z.ZodOptional<z.ZodString>;
-    faction_id: z.ZodOptional<z.ZodNumber>;
-    highest_rank: z.ZodOptional<z.ZodNumber>;
-    kills: z.ZodObject<{
-        last_week: z.ZodNumber;
-        total: z.ZodNumber;
-        yesterday: z.ZodNumber;
-    }, z.core.$loose>;
-    victory_points: z.ZodObject<{
-        last_week: z.ZodNumber;
-        total: z.ZodNumber;
-        yesterday: z.ZodNumber;
-    }, z.core.$loose>;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface CharactersCharacterIdIndustryJobsGet {
@@ -1719,51 +1183,12 @@ interface CharactersCharacterIdIndustryJobsGet {
 }
 
 // @public (undocumented)
-const CharactersCharacterIdIndustryJobsGetSchema: z.ZodObject<{
-    activity_id: z.ZodNumber;
-    blueprint_id: z.ZodNumber;
-    blueprint_location_id: z.ZodNumber;
-    blueprint_type_id: z.ZodNumber;
-    completed_character_id: z.ZodOptional<z.ZodNumber>;
-    completed_date: z.ZodOptional<z.ZodString>;
-    cost: z.ZodOptional<z.ZodNumber>;
-    duration: z.ZodNumber;
-    end_date: z.ZodString;
-    facility_id: z.ZodNumber;
-    installer_id: z.ZodNumber;
-    job_id: z.ZodNumber;
-    licensed_runs: z.ZodOptional<z.ZodNumber>;
-    output_location_id: z.ZodNumber;
-    pause_date: z.ZodOptional<z.ZodString>;
-    probability: z.ZodOptional<z.ZodNumber>;
-    product_type_id: z.ZodOptional<z.ZodNumber>;
-    runs: z.ZodNumber;
-    start_date: z.ZodString;
-    station_id: z.ZodNumber;
-    status: z.ZodEnum<{
-        cancelled: "cancelled";
-        active: "active";
-        delivered: "delivered";
-        paused: "paused";
-        ready: "ready";
-        reverted: "reverted";
-    }>;
-    successful_runs: z.ZodOptional<z.ZodNumber>;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface CharactersCharacterIdKillmailsRecentGet {
     // (undocumented)
     killmail_hash: string;
     // (undocumented)
     killmail_id: number;
 }
-
-// @public (undocumented)
-const CharactersCharacterIdKillmailsRecentGetSchema: z.ZodObject<{
-    killmail_hash: z.ZodString;
-    killmail_id: z.ZodNumber;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface CharactersCharacterIdLocationGet {
@@ -1776,25 +1201,12 @@ interface CharactersCharacterIdLocationGet {
 }
 
 // @public (undocumented)
-const CharactersCharacterIdLocationGetSchema: z.ZodObject<{
-    solar_system_id: z.ZodNumber;
-    station_id: z.ZodOptional<z.ZodNumber>;
-    structure_id: z.ZodOptional<z.ZodNumber>;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface CharactersCharacterIdLoyaltyPointsGet {
     // (undocumented)
     corporation_id: number;
     // (undocumented)
     loyalty_points: number;
 }
-
-// @public (undocumented)
-const CharactersCharacterIdLoyaltyPointsGetSchema: z.ZodObject<{
-    corporation_id: z.ZodNumber;
-    loyalty_points: z.ZodNumber;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface CharactersCharacterIdMailGet {
@@ -1818,25 +1230,6 @@ interface CharactersCharacterIdMailGet {
 }
 
 // @public (undocumented)
-const CharactersCharacterIdMailGetSchema: z.ZodObject<{
-    from: z.ZodOptional<z.ZodNumber>;
-    is_read: z.ZodOptional<z.ZodBoolean>;
-    labels: z.ZodOptional<z.ZodArray<z.ZodNumber>>;
-    mail_id: z.ZodOptional<z.ZodNumber>;
-    recipients: z.ZodOptional<z.ZodArray<z.ZodObject<{
-        recipient_id: z.ZodNumber;
-        recipient_type: z.ZodEnum<{
-            character: "character";
-            corporation: "corporation";
-            alliance: "alliance";
-            mailing_list: "mailing_list";
-        }>;
-    }, z.core.$loose>>>;
-    subject: z.ZodOptional<z.ZodString>;
-    timestamp: z.ZodOptional<z.ZodString>;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface CharactersCharacterIdMailLabelsGet {
     // (undocumented)
     labels?: ({
@@ -1850,48 +1243,12 @@ interface CharactersCharacterIdMailLabelsGet {
 }
 
 // @public (undocumented)
-const CharactersCharacterIdMailLabelsGetSchema: z.ZodObject<{
-    labels: z.ZodOptional<z.ZodArray<z.ZodObject<{
-        color: z.ZodOptional<z.ZodEnum<{
-            "#0000fe": "#0000fe";
-            "#006634": "#006634";
-            "#0099ff": "#0099ff";
-            "#00ff33": "#00ff33";
-            "#01ffff": "#01ffff";
-            "#349800": "#349800";
-            "#660066": "#660066";
-            "#666666": "#666666";
-            "#999999": "#999999";
-            "#99ffff": "#99ffff";
-            "#9a0000": "#9a0000";
-            "#ccff9a": "#ccff9a";
-            "#e6e6e6": "#e6e6e6";
-            "#fe0000": "#fe0000";
-            "#ff6600": "#ff6600";
-            "#ffff01": "#ffff01";
-            "#ffffcd": "#ffffcd";
-            "#ffffff": "#ffffff";
-        }>>;
-        label_id: z.ZodOptional<z.ZodNumber>;
-        name: z.ZodOptional<z.ZodString>;
-        unread_count: z.ZodOptional<z.ZodNumber>;
-    }, z.core.$loose>>>;
-    total_unread_count: z.ZodOptional<z.ZodNumber>;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface CharactersCharacterIdMailListsGet {
     // (undocumented)
     mailing_list_id: number;
     // (undocumented)
     name: string;
 }
-
-// @public (undocumented)
-const CharactersCharacterIdMailListsGetSchema: z.ZodObject<{
-    mailing_list_id: z.ZodNumber;
-    name: z.ZodString;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface CharactersCharacterIdMailMailIdGet {
@@ -1913,25 +1270,6 @@ interface CharactersCharacterIdMailMailIdGet {
     // (undocumented)
     timestamp?: string;
 }
-
-// @public (undocumented)
-const CharactersCharacterIdMailMailIdGetSchema: z.ZodObject<{
-    body: z.ZodOptional<z.ZodString>;
-    from: z.ZodOptional<z.ZodNumber>;
-    labels: z.ZodOptional<z.ZodArray<z.ZodNumber>>;
-    read: z.ZodOptional<z.ZodBoolean>;
-    recipients: z.ZodOptional<z.ZodArray<z.ZodObject<{
-        recipient_id: z.ZodNumber;
-        recipient_type: z.ZodEnum<{
-            character: "character";
-            corporation: "corporation";
-            alliance: "alliance";
-            mailing_list: "mailing_list";
-        }>;
-    }, z.core.$loose>>>;
-    subject: z.ZodOptional<z.ZodString>;
-    timestamp: z.ZodOptional<z.ZodString>;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface CharactersCharacterIdMedalsGet {
@@ -1961,27 +1299,6 @@ interface CharactersCharacterIdMedalsGet {
 }
 
 // @public (undocumented)
-const CharactersCharacterIdMedalsGetSchema: z.ZodObject<{
-    corporation_id: z.ZodNumber;
-    date: z.ZodString;
-    description: z.ZodString;
-    graphics: z.ZodArray<z.ZodObject<{
-        color: z.ZodOptional<z.ZodNumber>;
-        graphic: z.ZodString;
-        layer: z.ZodNumber;
-        part: z.ZodNumber;
-    }, z.core.$loose>>;
-    issuer_id: z.ZodNumber;
-    medal_id: z.ZodNumber;
-    reason: z.ZodString;
-    status: z.ZodEnum<{
-        private: "private";
-        public: "public";
-    }>;
-    title: z.ZodString;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface CharactersCharacterIdMiningGet {
     // (undocumented)
     date: string;
@@ -1992,14 +1309,6 @@ interface CharactersCharacterIdMiningGet {
     // (undocumented)
     type_id: number;
 }
-
-// @public (undocumented)
-const CharactersCharacterIdMiningGetSchema: z.ZodObject<{
-    date: z.ZodString;
-    quantity: z.ZodNumber;
-    solar_system_id: z.ZodNumber;
-    type_id: z.ZodNumber;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface CharactersCharacterIdNotificationsContactsGet {
@@ -2014,15 +1323,6 @@ interface CharactersCharacterIdNotificationsContactsGet {
     // (undocumented)
     standing_level: number;
 }
-
-// @public (undocumented)
-const CharactersCharacterIdNotificationsContactsGetSchema: z.ZodObject<{
-    message: z.ZodString;
-    notification_id: z.ZodNumber;
-    send_date: z.ZodString;
-    sender_character_id: z.ZodNumber;
-    standing_level: z.ZodNumber;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface CharactersCharacterIdNotificationsGet {
@@ -2043,278 +1343,6 @@ interface CharactersCharacterIdNotificationsGet {
 }
 
 // @public (undocumented)
-const CharactersCharacterIdNotificationsGetSchema: z.ZodObject<{
-    is_read: z.ZodOptional<z.ZodBoolean>;
-    notification_id: z.ZodNumber;
-    sender_id: z.ZodNumber;
-    sender_type: z.ZodEnum<{
-        faction: "faction";
-        character: "character";
-        corporation: "corporation";
-        alliance: "alliance";
-        other: "other";
-    }>;
-    text: z.ZodOptional<z.ZodString>;
-    timestamp: z.ZodString;
-    type: z.ZodEnum<{
-        AcceptedAlly: "AcceptedAlly";
-        AcceptedSurrender: "AcceptedSurrender";
-        AgentRetiredTrigravian: "AgentRetiredTrigravian";
-        AllAnchoringMsg: "AllAnchoringMsg";
-        AllMaintenanceBillMsg: "AllMaintenanceBillMsg";
-        AllStrucInvulnerableMsg: "AllStrucInvulnerableMsg";
-        AllStructVulnerableMsg: "AllStructVulnerableMsg";
-        AllWarCorpJoinedAllianceMsg: "AllWarCorpJoinedAllianceMsg";
-        AllWarDeclaredMsg: "AllWarDeclaredMsg";
-        AllWarInvalidatedMsg: "AllWarInvalidatedMsg";
-        AllWarRetractedMsg: "AllWarRetractedMsg";
-        AllWarSurrenderMsg: "AllWarSurrenderMsg";
-        AllianceCapitalChanged: "AllianceCapitalChanged";
-        AllianceWarDeclaredV2: "AllianceWarDeclaredV2";
-        AllyContractCancelled: "AllyContractCancelled";
-        AllyJoinedWarAggressorMsg: "AllyJoinedWarAggressorMsg";
-        AllyJoinedWarAllyMsg: "AllyJoinedWarAllyMsg";
-        AllyJoinedWarDefenderMsg: "AllyJoinedWarDefenderMsg";
-        BattlePunishFriendlyFire: "BattlePunishFriendlyFire";
-        BillOutOfMoneyMsg: "BillOutOfMoneyMsg";
-        BillPaidCorpAllMsg: "BillPaidCorpAllMsg";
-        BountyClaimMsg: "BountyClaimMsg";
-        BountyESSShared: "BountyESSShared";
-        BountyESSTaken: "BountyESSTaken";
-        BountyPlacedAlliance: "BountyPlacedAlliance";
-        BountyPlacedChar: "BountyPlacedChar";
-        BountyPlacedCorp: "BountyPlacedCorp";
-        BountyYourBountyClaimed: "BountyYourBountyClaimed";
-        BuddyConnectContactAdd: "BuddyConnectContactAdd";
-        CharAppAcceptMsg: "CharAppAcceptMsg";
-        CharAppRejectMsg: "CharAppRejectMsg";
-        CharAppWithdrawMsg: "CharAppWithdrawMsg";
-        CharLeftCorpMsg: "CharLeftCorpMsg";
-        CharMedalMsg: "CharMedalMsg";
-        CharTerminationMsg: "CharTerminationMsg";
-        CloneActivationMsg: "CloneActivationMsg";
-        CloneActivationMsg2: "CloneActivationMsg2";
-        CloneMovedMsg: "CloneMovedMsg";
-        CloneRevokedMsg1: "CloneRevokedMsg1";
-        CloneRevokedMsg2: "CloneRevokedMsg2";
-        CombatOperationFinished: "CombatOperationFinished";
-        ContactAdd: "ContactAdd";
-        ContactEdit: "ContactEdit";
-        ContainerPasswordMsg: "ContainerPasswordMsg";
-        ContractRegionChangedToPochven: "ContractRegionChangedToPochven";
-        CorpAllBillMsg: "CorpAllBillMsg";
-        CorpAppAcceptMsg: "CorpAppAcceptMsg";
-        CorpAppInvitedMsg: "CorpAppInvitedMsg";
-        CorpAppNewMsg: "CorpAppNewMsg";
-        CorpAppRejectCustomMsg: "CorpAppRejectCustomMsg";
-        CorpAppRejectMsg: "CorpAppRejectMsg";
-        CorpBecameWarEligible: "CorpBecameWarEligible";
-        CorpDividendMsg: "CorpDividendMsg";
-        CorpFriendlyFireDisableTimerCompleted: "CorpFriendlyFireDisableTimerCompleted";
-        CorpFriendlyFireDisableTimerStarted: "CorpFriendlyFireDisableTimerStarted";
-        CorpFriendlyFireEnableTimerCompleted: "CorpFriendlyFireEnableTimerCompleted";
-        CorpFriendlyFireEnableTimerStarted: "CorpFriendlyFireEnableTimerStarted";
-        CorpKicked: "CorpKicked";
-        CorpLiquidationMsg: "CorpLiquidationMsg";
-        CorpNewCEOMsg: "CorpNewCEOMsg";
-        CorpNewsMsg: "CorpNewsMsg";
-        CorpNoLongerWarEligible: "CorpNoLongerWarEligible";
-        CorpOfficeExpirationMsg: "CorpOfficeExpirationMsg";
-        CorpStructLostMsg: "CorpStructLostMsg";
-        CorpTaxChangeMsg: "CorpTaxChangeMsg";
-        CorpVoteCEORevokedMsg: "CorpVoteCEORevokedMsg";
-        CorpVoteMsg: "CorpVoteMsg";
-        CorpWarDeclaredMsg: "CorpWarDeclaredMsg";
-        CorpWarDeclaredV2: "CorpWarDeclaredV2";
-        CorpWarFightingLegalMsg: "CorpWarFightingLegalMsg";
-        CorpWarInvalidatedMsg: "CorpWarInvalidatedMsg";
-        CorpWarRetractedMsg: "CorpWarRetractedMsg";
-        CorpWarSurrenderMsg: "CorpWarSurrenderMsg";
-        CorporationGoalClosed: "CorporationGoalClosed";
-        CorporationGoalCompleted: "CorporationGoalCompleted";
-        CorporationGoalCreated: "CorporationGoalCreated";
-        CorporationGoalExpired: "CorporationGoalExpired";
-        CorporationGoalLimitReached: "CorporationGoalLimitReached";
-        CorporationGoalNameChange: "CorporationGoalNameChange";
-        CorporationLeft: "CorporationLeft";
-        CustomsMsg: "CustomsMsg";
-        DailyItemRewardAutoClaimed: "DailyItemRewardAutoClaimed";
-        DeclareWar: "DeclareWar";
-        DistrictAttacked: "DistrictAttacked";
-        DustAppAcceptedMsg: "DustAppAcceptedMsg";
-        ESSMainBankLink: "ESSMainBankLink";
-        EntosisCaptureStarted: "EntosisCaptureStarted";
-        ExpertSystemExpired: "ExpertSystemExpired";
-        ExpertSystemExpiryImminent: "ExpertSystemExpiryImminent";
-        FWAllianceKickCeoIndividualStandingWarning: "FWAllianceKickCeoIndividualStandingWarning";
-        FWAllianceKickMsg: "FWAllianceKickMsg";
-        FWAllianceKickedCeoIndividualStanding: "FWAllianceKickedCeoIndividualStanding";
-        FWAllianceWarningMsg: "FWAllianceWarningMsg";
-        FWCharKickMsg: "FWCharKickMsg";
-        FWCharRankGainMsg: "FWCharRankGainMsg";
-        FWCharRankLossMsg: "FWCharRankLossMsg";
-        FWCharWarningMsg: "FWCharWarningMsg";
-        FWCharacterKickFromCorpIndividualStandingWarning: "FWCharacterKickFromCorpIndividualStandingWarning";
-        FWCharacterKickedFromCorpIndividualStanding: "FWCharacterKickedFromCorpIndividualStanding";
-        FWCorpJoinMsg: "FWCorpJoinMsg";
-        FWCorpKickMsg: "FWCorpKickMsg";
-        FWCorpLeaveMsg: "FWCorpLeaveMsg";
-        FWCorpWarningMsg: "FWCorpWarningMsg";
-        FWCorporationKickCeoIndividualStandingWarning: "FWCorporationKickCeoIndividualStandingWarning";
-        FWCorporationKickedCeoIndividualStanding: "FWCorporationKickedCeoIndividualStanding";
-        FacWarCorpJoinRequestMsg: "FacWarCorpJoinRequestMsg";
-        FacWarCorpJoinWithdrawMsg: "FacWarCorpJoinWithdrawMsg";
-        FacWarCorpLeaveRequestMsg: "FacWarCorpLeaveRequestMsg";
-        FacWarCorpLeaveWithdrawMsg: "FacWarCorpLeaveWithdrawMsg";
-        FacWarDirectEnlistmentRevoked: "FacWarDirectEnlistmentRevoked";
-        FacWarLPDisqualifiedEvent: "FacWarLPDisqualifiedEvent";
-        FacWarLPDisqualifiedKill: "FacWarLPDisqualifiedKill";
-        FacWarLPPayoutEvent: "FacWarLPPayoutEvent";
-        FacWarLPPayoutKill: "FacWarLPPayoutKill";
-        FreelanceProjectACLDeleted: "FreelanceProjectACLDeleted";
-        FreelanceProjectClosed: "FreelanceProjectClosed";
-        FreelanceProjectCompleted: "FreelanceProjectCompleted";
-        FreelanceProjectCreated: "FreelanceProjectCreated";
-        FreelanceProjectExpired: "FreelanceProjectExpired";
-        FreelanceProjectLimitReached: "FreelanceProjectLimitReached";
-        FreelanceProjectParticipantKicked: "FreelanceProjectParticipantKicked";
-        GameTimeAdded: "GameTimeAdded";
-        GameTimeReceived: "GameTimeReceived";
-        GameTimeSent: "GameTimeSent";
-        GiftReceived: "GiftReceived";
-        IHubDestroyedByBillFailure: "IHubDestroyedByBillFailure";
-        IncursionCompletedMsg: "IncursionCompletedMsg";
-        IndustryOperationFinished: "IndustryOperationFinished";
-        IndustryTeamAuctionLost: "IndustryTeamAuctionLost";
-        IndustryTeamAuctionWon: "IndustryTeamAuctionWon";
-        InfrastructureHubBillAboutToExpire: "InfrastructureHubBillAboutToExpire";
-        InsuranceExpirationMsg: "InsuranceExpirationMsg";
-        InsuranceFirstShipMsg: "InsuranceFirstShipMsg";
-        InsuranceInvalidatedMsg: "InsuranceInvalidatedMsg";
-        InsuranceIssuedMsg: "InsuranceIssuedMsg";
-        InsurancePayoutMsg: "InsurancePayoutMsg";
-        InvasionCompletedMsg: "InvasionCompletedMsg";
-        InvasionSystemLogin: "InvasionSystemLogin";
-        InvasionSystemStart: "InvasionSystemStart";
-        JumpCloneDeletedMsg1: "JumpCloneDeletedMsg1";
-        JumpCloneDeletedMsg2: "JumpCloneDeletedMsg2";
-        KillReportFinalBlow: "KillReportFinalBlow";
-        KillReportVictim: "KillReportVictim";
-        KillRightAvailable: "KillRightAvailable";
-        KillRightAvailableOpen: "KillRightAvailableOpen";
-        KillRightEarned: "KillRightEarned";
-        KillRightUnavailable: "KillRightUnavailable";
-        KillRightUnavailableOpen: "KillRightUnavailableOpen";
-        KillRightUsed: "KillRightUsed";
-        LPAutoRedeemed: "LPAutoRedeemed";
-        LocateCharMsg: "LocateCharMsg";
-        MadeWarMutual: "MadeWarMutual";
-        MercOfferRetractedMsg: "MercOfferRetractedMsg";
-        MercOfferedNegotiationMsg: "MercOfferedNegotiationMsg";
-        MercenaryDenAttacked: "MercenaryDenAttacked";
-        MercenaryDenNewMTO: "MercenaryDenNewMTO";
-        MercenaryDenReinforced: "MercenaryDenReinforced";
-        MissionCanceledTriglavian: "MissionCanceledTriglavian";
-        MissionOfferExpirationMsg: "MissionOfferExpirationMsg";
-        MissionTimeoutMsg: "MissionTimeoutMsg";
-        MoonminingAutomaticFracture: "MoonminingAutomaticFracture";
-        MoonminingExtractionCancelled: "MoonminingExtractionCancelled";
-        MoonminingExtractionFinished: "MoonminingExtractionFinished";
-        MoonminingExtractionStarted: "MoonminingExtractionStarted";
-        MoonminingLaserFired: "MoonminingLaserFired";
-        MutualWarExpired: "MutualWarExpired";
-        MutualWarInviteAccepted: "MutualWarInviteAccepted";
-        MutualWarInviteRejected: "MutualWarInviteRejected";
-        MutualWarInviteSent: "MutualWarInviteSent";
-        NPCStandingsGained: "NPCStandingsGained";
-        NPCStandingsLost: "NPCStandingsLost";
-        OfferToAllyRetracted: "OfferToAllyRetracted";
-        OfferedSurrender: "OfferedSurrender";
-        OfferedToAlly: "OfferedToAlly";
-        OfficeLeaseCanceledInsufficientStandings: "OfficeLeaseCanceledInsufficientStandings";
-        OldLscMessages: "OldLscMessages";
-        OperationFinished: "OperationFinished";
-        OrbitalAttacked: "OrbitalAttacked";
-        OrbitalReinforced: "OrbitalReinforced";
-        OwnershipTransferred: "OwnershipTransferred";
-        RaffleCreated: "RaffleCreated";
-        RaffleExpired: "RaffleExpired";
-        RaffleFinished: "RaffleFinished";
-        ReimbursementMsg: "ReimbursementMsg";
-        ResearchMissionAvailableMsg: "ResearchMissionAvailableMsg";
-        RetractsWar: "RetractsWar";
-        SPAutoRedeemed: "SPAutoRedeemed";
-        SeasonalChallengeCompleted: "SeasonalChallengeCompleted";
-        SkinSequencingCompleted: "SkinSequencingCompleted";
-        SkyhookDeployed: "SkyhookDeployed";
-        SkyhookDestroyed: "SkyhookDestroyed";
-        SkyhookLostShields: "SkyhookLostShields";
-        SkyhookOnline: "SkyhookOnline";
-        SkyhookUnderAttack: "SkyhookUnderAttack";
-        SovAllClaimAquiredMsg: "SovAllClaimAquiredMsg";
-        SovAllClaimLostMsg: "SovAllClaimLostMsg";
-        SovCommandNodeEventStarted: "SovCommandNodeEventStarted";
-        SovCorpBillLateMsg: "SovCorpBillLateMsg";
-        SovCorpClaimFailMsg: "SovCorpClaimFailMsg";
-        SovDisruptorMsg: "SovDisruptorMsg";
-        SovStationEnteredFreeport: "SovStationEnteredFreeport";
-        SovStructureDestroyed: "SovStructureDestroyed";
-        SovStructureReinforced: "SovStructureReinforced";
-        SovStructureSelfDestructCancel: "SovStructureSelfDestructCancel";
-        SovStructureSelfDestructFinished: "SovStructureSelfDestructFinished";
-        SovStructureSelfDestructRequested: "SovStructureSelfDestructRequested";
-        SovereigntyIHDamageMsg: "SovereigntyIHDamageMsg";
-        SovereigntySBUDamageMsg: "SovereigntySBUDamageMsg";
-        SovereigntyTCUDamageMsg: "SovereigntyTCUDamageMsg";
-        StationAggressionMsg1: "StationAggressionMsg1";
-        StationAggressionMsg2: "StationAggressionMsg2";
-        StationConquerMsg: "StationConquerMsg";
-        StationServiceDisabled: "StationServiceDisabled";
-        StationServiceEnabled: "StationServiceEnabled";
-        StationStateChangeMsg: "StationStateChangeMsg";
-        StoryLineMissionAvailableMsg: "StoryLineMissionAvailableMsg";
-        StructureAnchoring: "StructureAnchoring";
-        StructureCourierContractChanged: "StructureCourierContractChanged";
-        StructureDestroyed: "StructureDestroyed";
-        StructureFuelAlert: "StructureFuelAlert";
-        StructureImpendingAbandonmentAssetsAtRisk: "StructureImpendingAbandonmentAssetsAtRisk";
-        StructureItemsDelivered: "StructureItemsDelivered";
-        StructureItemsMovedToSafety: "StructureItemsMovedToSafety";
-        StructureLostArmor: "StructureLostArmor";
-        StructureLostShields: "StructureLostShields";
-        StructureLowReagentsAlert: "StructureLowReagentsAlert";
-        StructureNoReagentsAlert: "StructureNoReagentsAlert";
-        StructureOnline: "StructureOnline";
-        StructurePaintPurchased: "StructurePaintPurchased";
-        StructureServicesOffline: "StructureServicesOffline";
-        StructureUnanchoring: "StructureUnanchoring";
-        StructureUnderAttack: "StructureUnderAttack";
-        StructureWentHighPower: "StructureWentHighPower";
-        StructureWentLowPower: "StructureWentLowPower";
-        StructuresJobsCancelled: "StructuresJobsCancelled";
-        StructuresJobsPaused: "StructuresJobsPaused";
-        StructuresReinforcementChanged: "StructuresReinforcementChanged";
-        TowerAlertMsg: "TowerAlertMsg";
-        TowerResourceAlertMsg: "TowerResourceAlertMsg";
-        TransactionReversalMsg: "TransactionReversalMsg";
-        TutorialMsg: "TutorialMsg";
-        "WarAdopted ": "WarAdopted ";
-        WarAllyInherited: "WarAllyInherited";
-        WarAllyOfferDeclinedMsg: "WarAllyOfferDeclinedMsg";
-        WarConcordInvalidates: "WarConcordInvalidates";
-        WarDeclared: "WarDeclared";
-        WarEndedHqSecurityDrop: "WarEndedHqSecurityDrop";
-        WarHQRemovedFromSpace: "WarHQRemovedFromSpace";
-        WarInherited: "WarInherited";
-        WarInvalid: "WarInvalid";
-        WarRetracted: "WarRetracted";
-        WarRetractedByConcord: "WarRetractedByConcord";
-        WarSurrenderDeclinedMsg: "WarSurrenderDeclinedMsg";
-        WarSurrenderOfferMsg: "WarSurrenderOfferMsg";
-    }>;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface CharactersCharacterIdOnlineGet {
     // (undocumented)
     last_login?: string;
@@ -2325,14 +1353,6 @@ interface CharactersCharacterIdOnlineGet {
     // (undocumented)
     online: boolean;
 }
-
-// @public (undocumented)
-const CharactersCharacterIdOnlineGetSchema: z.ZodObject<{
-    last_login: z.ZodOptional<z.ZodString>;
-    last_logout: z.ZodOptional<z.ZodString>;
-    logins: z.ZodOptional<z.ZodNumber>;
-    online: z.ZodBoolean;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface CharactersCharacterIdOrdersGet {
@@ -2365,37 +1385,6 @@ interface CharactersCharacterIdOrdersGet {
     // (undocumented)
     volume_total: number;
 }
-
-// @public (undocumented)
-const CharactersCharacterIdOrdersGetSchema: z.ZodObject<{
-    duration: z.ZodNumber;
-    escrow: z.ZodOptional<z.ZodNumber>;
-    is_buy_order: z.ZodOptional<z.ZodBoolean>;
-    is_corporation: z.ZodBoolean;
-    issued: z.ZodString;
-    location_id: z.ZodNumber;
-    min_volume: z.ZodOptional<z.ZodNumber>;
-    order_id: z.ZodNumber;
-    price: z.ZodNumber;
-    range: z.ZodEnum<{
-        1: "1";
-        2: "2";
-        3: "3";
-        4: "4";
-        region: "region";
-        5: "5";
-        station: "station";
-        10: "10";
-        20: "20";
-        30: "30";
-        40: "40";
-        solarsystem: "solarsystem";
-    }>;
-    region_id: z.ZodNumber;
-    type_id: z.ZodNumber;
-    volume_remain: z.ZodNumber;
-    volume_total: z.ZodNumber;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface CharactersCharacterIdOrdersHistoryGet {
@@ -2432,41 +1421,6 @@ interface CharactersCharacterIdOrdersHistoryGet {
 }
 
 // @public (undocumented)
-const CharactersCharacterIdOrdersHistoryGetSchema: z.ZodObject<{
-    duration: z.ZodNumber;
-    escrow: z.ZodOptional<z.ZodNumber>;
-    is_buy_order: z.ZodOptional<z.ZodBoolean>;
-    is_corporation: z.ZodBoolean;
-    issued: z.ZodString;
-    location_id: z.ZodNumber;
-    min_volume: z.ZodOptional<z.ZodNumber>;
-    order_id: z.ZodNumber;
-    price: z.ZodNumber;
-    range: z.ZodEnum<{
-        1: "1";
-        2: "2";
-        3: "3";
-        4: "4";
-        region: "region";
-        5: "5";
-        station: "station";
-        10: "10";
-        20: "20";
-        30: "30";
-        40: "40";
-        solarsystem: "solarsystem";
-    }>;
-    region_id: z.ZodNumber;
-    state: z.ZodEnum<{
-        cancelled: "cancelled";
-        expired: "expired";
-    }>;
-    type_id: z.ZodNumber;
-    volume_remain: z.ZodNumber;
-    volume_total: z.ZodNumber;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface CharactersCharacterIdPlanetsGet {
     // (undocumented)
     last_update: string;
@@ -2483,26 +1437,6 @@ interface CharactersCharacterIdPlanetsGet {
     // (undocumented)
     upgrade_level: number;
 }
-
-// @public (undocumented)
-const CharactersCharacterIdPlanetsGetSchema: z.ZodObject<{
-    last_update: z.ZodString;
-    num_pins: z.ZodNumber;
-    owner_id: z.ZodNumber;
-    planet_id: z.ZodNumber;
-    planet_type: z.ZodEnum<{
-        temperate: "temperate";
-        barren: "barren";
-        oceanic: "oceanic";
-        ice: "ice";
-        gas: "gas";
-        lava: "lava";
-        storm: "storm";
-        plasma: "plasma";
-    }>;
-    solar_system_id: z.ZodNumber;
-    upgrade_level: z.ZodNumber;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface CharactersCharacterIdPlanetsPlanetIdGet {
@@ -2553,51 +1487,6 @@ interface CharactersCharacterIdPlanetsPlanetIdGet {
 }
 
 // @public (undocumented)
-const CharactersCharacterIdPlanetsPlanetIdGetSchema: z.ZodObject<{
-    links: z.ZodArray<z.ZodObject<{
-        destination_pin_id: z.ZodNumber;
-        link_level: z.ZodNumber;
-        source_pin_id: z.ZodNumber;
-    }, z.core.$loose>>;
-    pins: z.ZodArray<z.ZodObject<{
-        contents: z.ZodOptional<z.ZodArray<z.ZodObject<{
-            amount: z.ZodNumber;
-            type_id: z.ZodNumber;
-        }, z.core.$loose>>>;
-        expiry_time: z.ZodOptional<z.ZodString>;
-        extractor_details: z.ZodOptional<z.ZodObject<{
-            cycle_time: z.ZodOptional<z.ZodNumber>;
-            head_radius: z.ZodOptional<z.ZodNumber>;
-            heads: z.ZodArray<z.ZodObject<{
-                head_id: z.ZodNumber;
-                latitude: z.ZodNumber;
-                longitude: z.ZodNumber;
-            }, z.core.$loose>>;
-            product_type_id: z.ZodOptional<z.ZodNumber>;
-            qty_per_cycle: z.ZodOptional<z.ZodNumber>;
-        }, z.core.$loose>>;
-        factory_details: z.ZodOptional<z.ZodObject<{
-            schematic_id: z.ZodNumber;
-        }, z.core.$loose>>;
-        install_time: z.ZodOptional<z.ZodString>;
-        last_cycle_start: z.ZodOptional<z.ZodString>;
-        latitude: z.ZodNumber;
-        longitude: z.ZodNumber;
-        pin_id: z.ZodNumber;
-        schematic_id: z.ZodOptional<z.ZodNumber>;
-        type_id: z.ZodNumber;
-    }, z.core.$loose>>;
-    routes: z.ZodArray<z.ZodObject<{
-        content_type_id: z.ZodNumber;
-        destination_pin_id: z.ZodNumber;
-        quantity: z.ZodNumber;
-        route_id: z.ZodNumber;
-        source_pin_id: z.ZodNumber;
-        waypoints: z.ZodOptional<z.ZodArray<z.ZodNumber>>;
-    }, z.core.$loose>>;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface CharactersCharacterIdPortraitGet {
     // (undocumented)
     px128x128?: string;
@@ -2610,14 +1499,6 @@ interface CharactersCharacterIdPortraitGet {
 }
 
 // @public (undocumented)
-const CharactersCharacterIdPortraitGetSchema: z.ZodObject<{
-    px128x128: z.ZodOptional<z.ZodString>;
-    px256x256: z.ZodOptional<z.ZodString>;
-    px512x512: z.ZodOptional<z.ZodString>;
-    px64x64: z.ZodOptional<z.ZodString>;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface CharactersCharacterIdRolesGet {
     // (undocumented)
     roles?: 'Account_Take_1' | 'Account_Take_2' | 'Account_Take_3' | 'Account_Take_4' | 'Account_Take_5' | 'Account_Take_6' | 'Account_Take_7' | 'Accountant' | 'Auditor' | 'Brand_Manager' | 'Communications_Officer' | 'Config_Equipment' | 'Config_Starbase_Equipment' | 'Container_Take_1' | 'Container_Take_2' | 'Container_Take_3' | 'Container_Take_4' | 'Container_Take_5' | 'Container_Take_6' | 'Container_Take_7' | 'Contract_Manager' | 'Deliveries_Container_Take' | 'Deliveries_Query' | 'Deliveries_Take' | 'Diplomat' | 'Director' | 'Factory_Manager' | 'Fitting_Manager' | 'Hangar_Query_1' | 'Hangar_Query_2' | 'Hangar_Query_3' | 'Hangar_Query_4' | 'Hangar_Query_5' | 'Hangar_Query_6' | 'Hangar_Query_7' | 'Hangar_Take_1' | 'Hangar_Take_2' | 'Hangar_Take_3' | 'Hangar_Take_4' | 'Hangar_Take_5' | 'Hangar_Take_6' | 'Hangar_Take_7' | 'Junior_Accountant' | 'Personnel_Manager' | 'Project_Manager' | 'Rent_Factory_Facility' | 'Rent_Office' | 'Rent_Research_Facility' | 'Security_Officer' | 'Skill_Plan_Manager' | 'Starbase_Defense_Operator' | 'Starbase_Fuel_Technician' | 'Station_Manager' | 'Trader'[];
@@ -2628,234 +1509,6 @@ interface CharactersCharacterIdRolesGet {
     // (undocumented)
     roles_at_other?: 'Account_Take_1' | 'Account_Take_2' | 'Account_Take_3' | 'Account_Take_4' | 'Account_Take_5' | 'Account_Take_6' | 'Account_Take_7' | 'Accountant' | 'Auditor' | 'Brand_Manager' | 'Communications_Officer' | 'Config_Equipment' | 'Config_Starbase_Equipment' | 'Container_Take_1' | 'Container_Take_2' | 'Container_Take_3' | 'Container_Take_4' | 'Container_Take_5' | 'Container_Take_6' | 'Container_Take_7' | 'Contract_Manager' | 'Deliveries_Container_Take' | 'Deliveries_Query' | 'Deliveries_Take' | 'Diplomat' | 'Director' | 'Factory_Manager' | 'Fitting_Manager' | 'Hangar_Query_1' | 'Hangar_Query_2' | 'Hangar_Query_3' | 'Hangar_Query_4' | 'Hangar_Query_5' | 'Hangar_Query_6' | 'Hangar_Query_7' | 'Hangar_Take_1' | 'Hangar_Take_2' | 'Hangar_Take_3' | 'Hangar_Take_4' | 'Hangar_Take_5' | 'Hangar_Take_6' | 'Hangar_Take_7' | 'Junior_Accountant' | 'Personnel_Manager' | 'Project_Manager' | 'Rent_Factory_Facility' | 'Rent_Office' | 'Rent_Research_Facility' | 'Security_Officer' | 'Skill_Plan_Manager' | 'Starbase_Defense_Operator' | 'Starbase_Fuel_Technician' | 'Station_Manager' | 'Trader'[];
 }
-
-// @public (undocumented)
-const CharactersCharacterIdRolesGetSchema: z.ZodObject<{
-    roles: z.ZodOptional<z.ZodArray<z.ZodEnum<{
-        Account_Take_1: "Account_Take_1";
-        Account_Take_2: "Account_Take_2";
-        Account_Take_3: "Account_Take_3";
-        Account_Take_4: "Account_Take_4";
-        Account_Take_5: "Account_Take_5";
-        Account_Take_6: "Account_Take_6";
-        Account_Take_7: "Account_Take_7";
-        Accountant: "Accountant";
-        Auditor: "Auditor";
-        Brand_Manager: "Brand_Manager";
-        Communications_Officer: "Communications_Officer";
-        Config_Equipment: "Config_Equipment";
-        Config_Starbase_Equipment: "Config_Starbase_Equipment";
-        Container_Take_1: "Container_Take_1";
-        Container_Take_2: "Container_Take_2";
-        Container_Take_3: "Container_Take_3";
-        Container_Take_4: "Container_Take_4";
-        Container_Take_5: "Container_Take_5";
-        Container_Take_6: "Container_Take_6";
-        Container_Take_7: "Container_Take_7";
-        Contract_Manager: "Contract_Manager";
-        Deliveries_Container_Take: "Deliveries_Container_Take";
-        Deliveries_Query: "Deliveries_Query";
-        Deliveries_Take: "Deliveries_Take";
-        Diplomat: "Diplomat";
-        Director: "Director";
-        Factory_Manager: "Factory_Manager";
-        Fitting_Manager: "Fitting_Manager";
-        Hangar_Query_1: "Hangar_Query_1";
-        Hangar_Query_2: "Hangar_Query_2";
-        Hangar_Query_3: "Hangar_Query_3";
-        Hangar_Query_4: "Hangar_Query_4";
-        Hangar_Query_5: "Hangar_Query_5";
-        Hangar_Query_6: "Hangar_Query_6";
-        Hangar_Query_7: "Hangar_Query_7";
-        Hangar_Take_1: "Hangar_Take_1";
-        Hangar_Take_2: "Hangar_Take_2";
-        Hangar_Take_3: "Hangar_Take_3";
-        Hangar_Take_4: "Hangar_Take_4";
-        Hangar_Take_5: "Hangar_Take_5";
-        Hangar_Take_6: "Hangar_Take_6";
-        Hangar_Take_7: "Hangar_Take_7";
-        Junior_Accountant: "Junior_Accountant";
-        Personnel_Manager: "Personnel_Manager";
-        Project_Manager: "Project_Manager";
-        Rent_Factory_Facility: "Rent_Factory_Facility";
-        Rent_Office: "Rent_Office";
-        Rent_Research_Facility: "Rent_Research_Facility";
-        Security_Officer: "Security_Officer";
-        Skill_Plan_Manager: "Skill_Plan_Manager";
-        Starbase_Defense_Operator: "Starbase_Defense_Operator";
-        Starbase_Fuel_Technician: "Starbase_Fuel_Technician";
-        Station_Manager: "Station_Manager";
-        Trader: "Trader";
-    }>>>;
-    roles_at_base: z.ZodOptional<z.ZodArray<z.ZodEnum<{
-        Account_Take_1: "Account_Take_1";
-        Account_Take_2: "Account_Take_2";
-        Account_Take_3: "Account_Take_3";
-        Account_Take_4: "Account_Take_4";
-        Account_Take_5: "Account_Take_5";
-        Account_Take_6: "Account_Take_6";
-        Account_Take_7: "Account_Take_7";
-        Accountant: "Accountant";
-        Auditor: "Auditor";
-        Brand_Manager: "Brand_Manager";
-        Communications_Officer: "Communications_Officer";
-        Config_Equipment: "Config_Equipment";
-        Config_Starbase_Equipment: "Config_Starbase_Equipment";
-        Container_Take_1: "Container_Take_1";
-        Container_Take_2: "Container_Take_2";
-        Container_Take_3: "Container_Take_3";
-        Container_Take_4: "Container_Take_4";
-        Container_Take_5: "Container_Take_5";
-        Container_Take_6: "Container_Take_6";
-        Container_Take_7: "Container_Take_7";
-        Contract_Manager: "Contract_Manager";
-        Deliveries_Container_Take: "Deliveries_Container_Take";
-        Deliveries_Query: "Deliveries_Query";
-        Deliveries_Take: "Deliveries_Take";
-        Diplomat: "Diplomat";
-        Director: "Director";
-        Factory_Manager: "Factory_Manager";
-        Fitting_Manager: "Fitting_Manager";
-        Hangar_Query_1: "Hangar_Query_1";
-        Hangar_Query_2: "Hangar_Query_2";
-        Hangar_Query_3: "Hangar_Query_3";
-        Hangar_Query_4: "Hangar_Query_4";
-        Hangar_Query_5: "Hangar_Query_5";
-        Hangar_Query_6: "Hangar_Query_6";
-        Hangar_Query_7: "Hangar_Query_7";
-        Hangar_Take_1: "Hangar_Take_1";
-        Hangar_Take_2: "Hangar_Take_2";
-        Hangar_Take_3: "Hangar_Take_3";
-        Hangar_Take_4: "Hangar_Take_4";
-        Hangar_Take_5: "Hangar_Take_5";
-        Hangar_Take_6: "Hangar_Take_6";
-        Hangar_Take_7: "Hangar_Take_7";
-        Junior_Accountant: "Junior_Accountant";
-        Personnel_Manager: "Personnel_Manager";
-        Project_Manager: "Project_Manager";
-        Rent_Factory_Facility: "Rent_Factory_Facility";
-        Rent_Office: "Rent_Office";
-        Rent_Research_Facility: "Rent_Research_Facility";
-        Security_Officer: "Security_Officer";
-        Skill_Plan_Manager: "Skill_Plan_Manager";
-        Starbase_Defense_Operator: "Starbase_Defense_Operator";
-        Starbase_Fuel_Technician: "Starbase_Fuel_Technician";
-        Station_Manager: "Station_Manager";
-        Trader: "Trader";
-    }>>>;
-    roles_at_hq: z.ZodOptional<z.ZodArray<z.ZodEnum<{
-        Account_Take_1: "Account_Take_1";
-        Account_Take_2: "Account_Take_2";
-        Account_Take_3: "Account_Take_3";
-        Account_Take_4: "Account_Take_4";
-        Account_Take_5: "Account_Take_5";
-        Account_Take_6: "Account_Take_6";
-        Account_Take_7: "Account_Take_7";
-        Accountant: "Accountant";
-        Auditor: "Auditor";
-        Brand_Manager: "Brand_Manager";
-        Communications_Officer: "Communications_Officer";
-        Config_Equipment: "Config_Equipment";
-        Config_Starbase_Equipment: "Config_Starbase_Equipment";
-        Container_Take_1: "Container_Take_1";
-        Container_Take_2: "Container_Take_2";
-        Container_Take_3: "Container_Take_3";
-        Container_Take_4: "Container_Take_4";
-        Container_Take_5: "Container_Take_5";
-        Container_Take_6: "Container_Take_6";
-        Container_Take_7: "Container_Take_7";
-        Contract_Manager: "Contract_Manager";
-        Deliveries_Container_Take: "Deliveries_Container_Take";
-        Deliveries_Query: "Deliveries_Query";
-        Deliveries_Take: "Deliveries_Take";
-        Diplomat: "Diplomat";
-        Director: "Director";
-        Factory_Manager: "Factory_Manager";
-        Fitting_Manager: "Fitting_Manager";
-        Hangar_Query_1: "Hangar_Query_1";
-        Hangar_Query_2: "Hangar_Query_2";
-        Hangar_Query_3: "Hangar_Query_3";
-        Hangar_Query_4: "Hangar_Query_4";
-        Hangar_Query_5: "Hangar_Query_5";
-        Hangar_Query_6: "Hangar_Query_6";
-        Hangar_Query_7: "Hangar_Query_7";
-        Hangar_Take_1: "Hangar_Take_1";
-        Hangar_Take_2: "Hangar_Take_2";
-        Hangar_Take_3: "Hangar_Take_3";
-        Hangar_Take_4: "Hangar_Take_4";
-        Hangar_Take_5: "Hangar_Take_5";
-        Hangar_Take_6: "Hangar_Take_6";
-        Hangar_Take_7: "Hangar_Take_7";
-        Junior_Accountant: "Junior_Accountant";
-        Personnel_Manager: "Personnel_Manager";
-        Project_Manager: "Project_Manager";
-        Rent_Factory_Facility: "Rent_Factory_Facility";
-        Rent_Office: "Rent_Office";
-        Rent_Research_Facility: "Rent_Research_Facility";
-        Security_Officer: "Security_Officer";
-        Skill_Plan_Manager: "Skill_Plan_Manager";
-        Starbase_Defense_Operator: "Starbase_Defense_Operator";
-        Starbase_Fuel_Technician: "Starbase_Fuel_Technician";
-        Station_Manager: "Station_Manager";
-        Trader: "Trader";
-    }>>>;
-    roles_at_other: z.ZodOptional<z.ZodArray<z.ZodEnum<{
-        Account_Take_1: "Account_Take_1";
-        Account_Take_2: "Account_Take_2";
-        Account_Take_3: "Account_Take_3";
-        Account_Take_4: "Account_Take_4";
-        Account_Take_5: "Account_Take_5";
-        Account_Take_6: "Account_Take_6";
-        Account_Take_7: "Account_Take_7";
-        Accountant: "Accountant";
-        Auditor: "Auditor";
-        Brand_Manager: "Brand_Manager";
-        Communications_Officer: "Communications_Officer";
-        Config_Equipment: "Config_Equipment";
-        Config_Starbase_Equipment: "Config_Starbase_Equipment";
-        Container_Take_1: "Container_Take_1";
-        Container_Take_2: "Container_Take_2";
-        Container_Take_3: "Container_Take_3";
-        Container_Take_4: "Container_Take_4";
-        Container_Take_5: "Container_Take_5";
-        Container_Take_6: "Container_Take_6";
-        Container_Take_7: "Container_Take_7";
-        Contract_Manager: "Contract_Manager";
-        Deliveries_Container_Take: "Deliveries_Container_Take";
-        Deliveries_Query: "Deliveries_Query";
-        Deliveries_Take: "Deliveries_Take";
-        Diplomat: "Diplomat";
-        Director: "Director";
-        Factory_Manager: "Factory_Manager";
-        Fitting_Manager: "Fitting_Manager";
-        Hangar_Query_1: "Hangar_Query_1";
-        Hangar_Query_2: "Hangar_Query_2";
-        Hangar_Query_3: "Hangar_Query_3";
-        Hangar_Query_4: "Hangar_Query_4";
-        Hangar_Query_5: "Hangar_Query_5";
-        Hangar_Query_6: "Hangar_Query_6";
-        Hangar_Query_7: "Hangar_Query_7";
-        Hangar_Take_1: "Hangar_Take_1";
-        Hangar_Take_2: "Hangar_Take_2";
-        Hangar_Take_3: "Hangar_Take_3";
-        Hangar_Take_4: "Hangar_Take_4";
-        Hangar_Take_5: "Hangar_Take_5";
-        Hangar_Take_6: "Hangar_Take_6";
-        Hangar_Take_7: "Hangar_Take_7";
-        Junior_Accountant: "Junior_Accountant";
-        Personnel_Manager: "Personnel_Manager";
-        Project_Manager: "Project_Manager";
-        Rent_Factory_Facility: "Rent_Factory_Facility";
-        Rent_Office: "Rent_Office";
-        Rent_Research_Facility: "Rent_Research_Facility";
-        Security_Officer: "Security_Officer";
-        Skill_Plan_Manager: "Skill_Plan_Manager";
-        Starbase_Defense_Operator: "Starbase_Defense_Operator";
-        Starbase_Fuel_Technician: "Starbase_Fuel_Technician";
-        Station_Manager: "Station_Manager";
-        Trader: "Trader";
-    }>>>;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface CharactersCharacterIdSearchGet {
@@ -2884,21 +1537,6 @@ interface CharactersCharacterIdSearchGet {
 }
 
 // @public (undocumented)
-const CharactersCharacterIdSearchGetSchema: z.ZodObject<{
-    agent: z.ZodOptional<z.ZodArray<z.ZodNumber>>;
-    alliance: z.ZodOptional<z.ZodArray<z.ZodNumber>>;
-    character: z.ZodOptional<z.ZodArray<z.ZodNumber>>;
-    constellation: z.ZodOptional<z.ZodArray<z.ZodNumber>>;
-    corporation: z.ZodOptional<z.ZodArray<z.ZodNumber>>;
-    faction: z.ZodOptional<z.ZodArray<z.ZodNumber>>;
-    inventory_type: z.ZodOptional<z.ZodArray<z.ZodNumber>>;
-    region: z.ZodOptional<z.ZodArray<z.ZodNumber>>;
-    solar_system: z.ZodOptional<z.ZodArray<z.ZodNumber>>;
-    station: z.ZodOptional<z.ZodArray<z.ZodNumber>>;
-    structure: z.ZodOptional<z.ZodArray<z.ZodNumber>>;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface CharactersCharacterIdShipGet {
     // (undocumented)
     ship_item_id: number;
@@ -2907,13 +1545,6 @@ interface CharactersCharacterIdShipGet {
     // (undocumented)
     ship_type_id: number;
 }
-
-// @public (undocumented)
-const CharactersCharacterIdShipGetSchema: z.ZodObject<{
-    ship_item_id: z.ZodNumber;
-    ship_name: z.ZodString;
-    ship_type_id: z.ZodNumber;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface CharactersCharacterIdStandingsGet {
@@ -2926,29 +1557,12 @@ interface CharactersCharacterIdStandingsGet {
 }
 
 // @public (undocumented)
-const CharactersCharacterIdStandingsGetSchema: z.ZodObject<{
-    from_id: z.ZodNumber;
-    from_type: z.ZodEnum<{
-        agent: "agent";
-        npc_corp: "npc_corp";
-        faction: "faction";
-    }>;
-    standing: z.ZodNumber;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface CharactersCharacterIdTitlesGet {
     // (undocumented)
     name?: string;
     // (undocumented)
     title_id?: number;
 }
-
-// @public (undocumented)
-const CharactersCharacterIdTitlesGetSchema: z.ZodObject<{
-    name: z.ZodOptional<z.ZodString>;
-    title_id: z.ZodOptional<z.ZodNumber>;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface CharactersCharacterIdWalletJournalGet {
@@ -2981,199 +1595,6 @@ interface CharactersCharacterIdWalletJournalGet {
 }
 
 // @public (undocumented)
-const CharactersCharacterIdWalletJournalGetSchema: z.ZodObject<{
-    amount: z.ZodOptional<z.ZodNumber>;
-    balance: z.ZodOptional<z.ZodNumber>;
-    context_id: z.ZodOptional<z.ZodNumber>;
-    context_id_type: z.ZodOptional<z.ZodEnum<{
-        alliance_id: "alliance_id";
-        character_id: "character_id";
-        corporation_id: "corporation_id";
-        type_id: "type_id";
-        system_id: "system_id";
-        structure_id: "structure_id";
-        planet_id: "planet_id";
-        station_id: "station_id";
-        contract_id: "contract_id";
-        market_transaction_id: "market_transaction_id";
-        eve_system: "eve_system";
-        industry_job_id: "industry_job_id";
-    }>>;
-    date: z.ZodString;
-    description: z.ZodString;
-    first_party_id: z.ZodOptional<z.ZodNumber>;
-    id: z.ZodNumber;
-    reason: z.ZodOptional<z.ZodString>;
-    ref_type: z.ZodEnum<{
-        shares: "shares";
-        copying: "copying";
-        manufacturing: "manufacturing";
-        reaction: "reaction";
-        researching_technology: "researching_technology";
-        reverse_engineering: "reverse_engineering";
-        insurance: "insurance";
-        acceleration_gate_fee: "acceleration_gate_fee";
-        achievement_category_milestone_reward: "achievement_category_milestone_reward";
-        achievement_milestone_reward: "achievement_milestone_reward";
-        advertisement_listing_fee: "advertisement_listing_fee";
-        agent_donation: "agent_donation";
-        agent_location_services: "agent_location_services";
-        agent_miscellaneous: "agent_miscellaneous";
-        agent_mission_collateral_paid: "agent_mission_collateral_paid";
-        agent_mission_collateral_refunded: "agent_mission_collateral_refunded";
-        agent_mission_reward: "agent_mission_reward";
-        agent_mission_reward_corporation_tax: "agent_mission_reward_corporation_tax";
-        agent_mission_security_tax: "agent_mission_security_tax";
-        agent_mission_time_bonus_reward: "agent_mission_time_bonus_reward";
-        agent_mission_time_bonus_reward_corporation_tax: "agent_mission_time_bonus_reward_corporation_tax";
-        agent_security_services: "agent_security_services";
-        agent_services_rendered: "agent_services_rendered";
-        agents_preward: "agents_preward";
-        air_career_program_reward: "air_career_program_reward";
-        alliance_maintainance_fee: "alliance_maintainance_fee";
-        alliance_registration_fee: "alliance_registration_fee";
-        allignment_based_gate_toll: "allignment_based_gate_toll";
-        asset_safety_recovery_tax: "asset_safety_recovery_tax";
-        bounty: "bounty";
-        bounty_prize: "bounty_prize";
-        bounty_prize_corporation_tax: "bounty_prize_corporation_tax";
-        bounty_prizes: "bounty_prizes";
-        bounty_reimbursement: "bounty_reimbursement";
-        bounty_surcharge: "bounty_surcharge";
-        brokers_fee: "brokers_fee";
-        campaign_objective_isk_reward: "campaign_objective_isk_reward";
-        clone_activation: "clone_activation";
-        clone_transfer: "clone_transfer";
-        contraband_fine: "contraband_fine";
-        contract_auction_bid: "contract_auction_bid";
-        contract_auction_bid_corp: "contract_auction_bid_corp";
-        contract_auction_bid_refund: "contract_auction_bid_refund";
-        contract_auction_sold: "contract_auction_sold";
-        contract_brokers_fee: "contract_brokers_fee";
-        contract_brokers_fee_corp: "contract_brokers_fee_corp";
-        contract_collateral: "contract_collateral";
-        contract_collateral_deposited_corp: "contract_collateral_deposited_corp";
-        contract_collateral_payout: "contract_collateral_payout";
-        contract_collateral_refund: "contract_collateral_refund";
-        contract_deposit: "contract_deposit";
-        contract_deposit_corp: "contract_deposit_corp";
-        contract_deposit_refund: "contract_deposit_refund";
-        contract_deposit_sales_tax: "contract_deposit_sales_tax";
-        contract_price: "contract_price";
-        contract_price_payment_corp: "contract_price_payment_corp";
-        contract_reversal: "contract_reversal";
-        contract_reward: "contract_reward";
-        contract_reward_deposited: "contract_reward_deposited";
-        contract_reward_deposited_corp: "contract_reward_deposited_corp";
-        contract_reward_refund: "contract_reward_refund";
-        contract_sales_tax: "contract_sales_tax";
-        corporate_reward_payout: "corporate_reward_payout";
-        corporate_reward_tax: "corporate_reward_tax";
-        corporation_account_withdrawal: "corporation_account_withdrawal";
-        corporation_bulk_payment: "corporation_bulk_payment";
-        corporation_dividend_payment: "corporation_dividend_payment";
-        corporation_liquidation: "corporation_liquidation";
-        corporation_logo_change_cost: "corporation_logo_change_cost";
-        corporation_payment: "corporation_payment";
-        corporation_registration_fee: "corporation_registration_fee";
-        cosmetic_market_component_item_purchase: "cosmetic_market_component_item_purchase";
-        cosmetic_market_skin_purchase: "cosmetic_market_skin_purchase";
-        cosmetic_market_skin_sale: "cosmetic_market_skin_sale";
-        cosmetic_market_skin_sale_broker_fee: "cosmetic_market_skin_sale_broker_fee";
-        cosmetic_market_skin_sale_tax: "cosmetic_market_skin_sale_tax";
-        cosmetic_market_skin_transaction: "cosmetic_market_skin_transaction";
-        courier_mission_escrow: "courier_mission_escrow";
-        cspa: "cspa";
-        cspaofflinerefund: "cspaofflinerefund";
-        daily_challenge_reward: "daily_challenge_reward";
-        daily_goal_payouts: "daily_goal_payouts";
-        daily_goal_payouts_tax: "daily_goal_payouts_tax";
-        datacore_fee: "datacore_fee";
-        dna_modification_fee: "dna_modification_fee";
-        docking_fee: "docking_fee";
-        duel_wager_escrow: "duel_wager_escrow";
-        duel_wager_payment: "duel_wager_payment";
-        duel_wager_refund: "duel_wager_refund";
-        ess_escrow_transfer: "ess_escrow_transfer";
-        external_trade_delivery: "external_trade_delivery";
-        external_trade_freeze: "external_trade_freeze";
-        external_trade_thaw: "external_trade_thaw";
-        factory_slot_rental_fee: "factory_slot_rental_fee";
-        flux_payout: "flux_payout";
-        flux_tax: "flux_tax";
-        flux_ticket_repayment: "flux_ticket_repayment";
-        flux_ticket_sale: "flux_ticket_sale";
-        freelance_jobs_broadcasting_fee: "freelance_jobs_broadcasting_fee";
-        freelance_jobs_duration_fee: "freelance_jobs_duration_fee";
-        freelance_jobs_escrow_refund: "freelance_jobs_escrow_refund";
-        freelance_jobs_reward: "freelance_jobs_reward";
-        freelance_jobs_reward_corporation_tax: "freelance_jobs_reward_corporation_tax";
-        freelance_jobs_reward_escrow: "freelance_jobs_reward_escrow";
-        gm_cash_transfer: "gm_cash_transfer";
-        gm_plex_fee_refund: "gm_plex_fee_refund";
-        industry_job_tax: "industry_job_tax";
-        industry_security_tax: "industry_security_tax";
-        infrastructure_hub_maintenance: "infrastructure_hub_maintenance";
-        inheritance: "inheritance";
-        insurgency_corruption_contribution_reward: "insurgency_corruption_contribution_reward";
-        insurgency_suppression_contribution_reward: "insurgency_suppression_contribution_reward";
-        item_trader_payment: "item_trader_payment";
-        jump_clone_activation_fee: "jump_clone_activation_fee";
-        jump_clone_installation_fee: "jump_clone_installation_fee";
-        kill_right_fee: "kill_right_fee";
-        lp_store: "lp_store";
-        market_escrow: "market_escrow";
-        market_fine_paid: "market_fine_paid";
-        market_provider_tax: "market_provider_tax";
-        market_security_tax: "market_security_tax";
-        market_transaction: "market_transaction";
-        medal_creation: "medal_creation";
-        medal_issued: "medal_issued";
-        milestone_reward_payment: "milestone_reward_payment";
-        mission_completion: "mission_completion";
-        mission_cost: "mission_cost";
-        mission_expiration: "mission_expiration";
-        mission_reward: "mission_reward";
-        npc_bounty_security_tax: "npc_bounty_security_tax";
-        office_rental_fee: "office_rental_fee";
-        operation_bonus: "operation_bonus";
-        opportunity_reward: "opportunity_reward";
-        planetary_construction: "planetary_construction";
-        planetary_export_tax: "planetary_export_tax";
-        planetary_import_tax: "planetary_import_tax";
-        player_donation: "player_donation";
-        player_trading: "player_trading";
-        project_discovery_reward: "project_discovery_reward";
-        project_discovery_tax: "project_discovery_tax";
-        project_payouts: "project_payouts";
-        redeemed_isk_token: "redeemed_isk_token";
-        release_of_impounded_property: "release_of_impounded_property";
-        repair_bill: "repair_bill";
-        reprocessing_tax: "reprocessing_tax";
-        researching_material_productivity: "researching_material_productivity";
-        researching_time_productivity: "researching_time_productivity";
-        resource_wars_reward: "resource_wars_reward";
-        season_challenge_reward: "season_challenge_reward";
-        security_processing_fee: "security_processing_fee";
-        skill_purchase: "skill_purchase";
-        skyhook_claim_fee: "skyhook_claim_fee";
-        sovereignity_bill: "sovereignity_bill";
-        store_purchase: "store_purchase";
-        store_purchase_refund: "store_purchase_refund";
-        structure_gate_jump: "structure_gate_jump";
-        transaction_tax: "transaction_tax";
-        under_construction: "under_construction";
-        upkeep_adjustment_fee: "upkeep_adjustment_fee";
-        war_ally_contract: "war_ally_contract";
-        war_fee: "war_fee";
-        war_fee_surrender: "war_fee_surrender";
-    }>;
-    second_party_id: z.ZodOptional<z.ZodNumber>;
-    tax: z.ZodOptional<z.ZodNumber>;
-    tax_receiver_id: z.ZodOptional<z.ZodNumber>;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface CharactersCharacterIdWalletTransactionsGet {
     // (undocumented)
     client_id: number;
@@ -3196,20 +1617,6 @@ interface CharactersCharacterIdWalletTransactionsGet {
     // (undocumented)
     unit_price: number;
 }
-
-// @public (undocumented)
-const CharactersCharacterIdWalletTransactionsGetSchema: z.ZodObject<{
-    client_id: z.ZodNumber;
-    date: z.ZodString;
-    is_buy: z.ZodBoolean;
-    is_personal: z.ZodBoolean;
-    journal_ref_id: z.ZodNumber;
-    location_id: z.ZodNumber;
-    quantity: z.ZodNumber;
-    transaction_id: z.ZodNumber;
-    type_id: z.ZodNumber;
-    unit_price: z.ZodNumber;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface CharactersDetail {
@@ -3238,24 +1645,6 @@ interface CharactersDetail {
 }
 
 // @public (undocumented)
-const CharactersDetailSchema: z.ZodObject<{
-    alliance_id: z.ZodOptional<z.ZodNumber>;
-    birthday: z.ZodString;
-    bloodline_id: z.ZodNumber;
-    corporation_id: z.ZodNumber;
-    description: z.ZodOptional<z.ZodString>;
-    faction_id: z.ZodOptional<z.ZodNumber>;
-    gender: z.ZodEnum<{
-        male: "male";
-        female: "female";
-    }>;
-    name: z.ZodString;
-    race_id: z.ZodNumber;
-    security_status: z.ZodOptional<z.ZodNumber>;
-    title: z.ZodOptional<z.ZodString>;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface CharactersFreelanceJobsListing {
     // (undocumented)
     freelance_jobs: ({
@@ -3275,31 +1664,6 @@ interface CharactersFreelanceJobsListing {
 }
 
 // @public (undocumented)
-const CharactersFreelanceJobsListingSchema: z.ZodObject<{
-    freelance_jobs: z.ZodArray<z.ZodObject<{
-        id: z.ZodString;
-        last_modified: z.ZodString;
-        name: z.ZodString;
-        progress: z.ZodObject<{
-            current: z.ZodNumber;
-            desired: z.ZodNumber;
-        }, z.core.$loose>;
-        reward: z.ZodOptional<z.ZodObject<{
-            initial: z.ZodNumber;
-            remaining: z.ZodNumber;
-        }, z.core.$loose>>;
-        state: z.ZodEnum<{
-            Unspecified: "Unspecified";
-            Active: "Active";
-            Closed: "Closed";
-            Completed: "Completed";
-            Expired: "Expired";
-            Deleted: "Deleted";
-        }>;
-    }, z.core.$loose>>;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface CharactersFreelanceJobsParticipation {
     // (undocumented)
     contributed: number;
@@ -3308,18 +1672,6 @@ interface CharactersFreelanceJobsParticipation {
     // (undocumented)
     state: 'Unspecified' | 'Committed' | 'Kicked' | 'Resigned';
 }
-
-// @public (undocumented)
-const CharactersFreelanceJobsParticipationSchema: z.ZodObject<{
-    contributed: z.ZodNumber;
-    last_modified: z.ZodString;
-    state: z.ZodEnum<{
-        Unspecified: "Unspecified";
-        Committed: "Committed";
-        Kicked: "Kicked";
-        Resigned: "Resigned";
-    }>;
-}, z.core.$loose>;
 
 // @public (undocumented)
 export type CharacterShip = z.infer<typeof CharacterShipSchema>;
@@ -3389,18 +1741,6 @@ interface CharactersSkillqueueSkill {
 }
 
 // @public (undocumented)
-const CharactersSkillqueueSkillSchema: z.ZodObject<{
-    finish_date: z.ZodOptional<z.ZodString>;
-    finished_level: z.ZodNumber;
-    level_end_sp: z.ZodOptional<z.ZodNumber>;
-    level_start_sp: z.ZodOptional<z.ZodNumber>;
-    queue_position: z.ZodNumber;
-    skill_id: z.ZodNumber;
-    start_date: z.ZodOptional<z.ZodString>;
-    training_start_sp: z.ZodOptional<z.ZodNumber>;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface CharactersSkills {
     // (undocumented)
     skills: ({
@@ -3414,18 +1754,6 @@ interface CharactersSkills {
     // (undocumented)
     unallocated_sp?: number;
 }
-
-// @public (undocumented)
-const CharactersSkillsSchema: z.ZodObject<{
-    skills: z.ZodArray<z.ZodObject<{
-        active_skill_level: z.ZodNumber;
-        skill_id: z.ZodNumber;
-        skillpoints_in_skill: z.ZodNumber;
-        trained_skill_level: z.ZodNumber;
-    }, z.core.$loose>>;
-    total_sp: z.ZodNumber;
-    unallocated_sp: z.ZodOptional<z.ZodNumber>;
-}, z.core.$loose>;
 
 // @public (undocumented)
 export type CharacterTitle = z.infer<typeof CharacterTitleSchema>;
@@ -3803,13 +2131,6 @@ interface ContractsPublicBidsContractIdGet {
 }
 
 // @public (undocumented)
-const ContractsPublicBidsContractIdGetSchema: z.ZodObject<{
-    amount: z.ZodNumber;
-    bid_id: z.ZodNumber;
-    date_bid: z.ZodString;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface ContractsPublicItemsContractIdGet {
     // (undocumented)
     is_blueprint_copy?: boolean;
@@ -3830,19 +2151,6 @@ interface ContractsPublicItemsContractIdGet {
     // (undocumented)
     type_id: number;
 }
-
-// @public (undocumented)
-const ContractsPublicItemsContractIdGetSchema: z.ZodObject<{
-    is_blueprint_copy: z.ZodOptional<z.ZodBoolean>;
-    is_included: z.ZodBoolean;
-    item_id: z.ZodOptional<z.ZodNumber>;
-    material_efficiency: z.ZodOptional<z.ZodNumber>;
-    quantity: z.ZodNumber;
-    record_id: z.ZodNumber;
-    runs: z.ZodOptional<z.ZodNumber>;
-    time_efficiency: z.ZodOptional<z.ZodNumber>;
-    type_id: z.ZodNumber;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface ContractsPublicRegionIdGet {
@@ -3881,32 +2189,6 @@ interface ContractsPublicRegionIdGet {
 }
 
 // @public (undocumented)
-const ContractsPublicRegionIdGetSchema: z.ZodObject<{
-    buyout: z.ZodOptional<z.ZodNumber>;
-    collateral: z.ZodOptional<z.ZodNumber>;
-    contract_id: z.ZodNumber;
-    date_expired: z.ZodString;
-    date_issued: z.ZodString;
-    days_to_complete: z.ZodOptional<z.ZodNumber>;
-    end_location_id: z.ZodOptional<z.ZodNumber>;
-    for_corporation: z.ZodOptional<z.ZodBoolean>;
-    issuer_corporation_id: z.ZodNumber;
-    issuer_id: z.ZodNumber;
-    price: z.ZodOptional<z.ZodNumber>;
-    reward: z.ZodOptional<z.ZodNumber>;
-    start_location_id: z.ZodOptional<z.ZodNumber>;
-    title: z.ZodOptional<z.ZodString>;
-    type: z.ZodEnum<{
-        unknown: "unknown";
-        item_exchange: "item_exchange";
-        auction: "auction";
-        courier: "courier";
-        loan: "loan";
-    }>;
-    volume: z.ZodOptional<z.ZodNumber>;
-}, z.core.$loose>;
-
-// @public (undocumented)
 export type CorporationAllianceHistory = z.infer<typeof CorporationAllianceHistorySchema>;
 
 // @public (undocumented)
@@ -3935,15 +2217,6 @@ interface CorporationCorporationIdMiningExtractionsGet {
 }
 
 // @public (undocumented)
-const CorporationCorporationIdMiningExtractionsGetSchema: z.ZodObject<{
-    chunk_arrival_time: z.ZodString;
-    extraction_start_time: z.ZodString;
-    moon_id: z.ZodNumber;
-    natural_decay_time: z.ZodString;
-    structure_id: z.ZodNumber;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface CorporationCorporationIdMiningObserversGet {
     // (undocumented)
     last_updated: string;
@@ -3952,15 +2225,6 @@ interface CorporationCorporationIdMiningObserversGet {
     // (undocumented)
     observer_type: 'structure';
 }
-
-// @public (undocumented)
-const CorporationCorporationIdMiningObserversGetSchema: z.ZodObject<{
-    last_updated: z.ZodString;
-    observer_id: z.ZodNumber;
-    observer_type: z.ZodEnum<{
-        structure: "structure";
-    }>;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface CorporationCorporationIdMiningObserversObserverIdGet {
@@ -3975,15 +2239,6 @@ interface CorporationCorporationIdMiningObserversObserverIdGet {
     // (undocumented)
     type_id: number;
 }
-
-// @public (undocumented)
-const CorporationCorporationIdMiningObserversObserverIdGetSchema: z.ZodObject<{
-    character_id: z.ZodNumber;
-    last_updated: z.ZodString;
-    quantity: z.ZodNumber;
-    recorded_corporation_id: z.ZodNumber;
-    type_id: z.ZodNumber;
-}, z.core.$loose>;
 
 // @public (undocumented)
 export type CorporationDivisions = z.infer<typeof CorporationDivisionsSchema>;
@@ -4255,14 +2510,6 @@ interface CorporationsCorporationIdAlliancehistoryGet {
 }
 
 // @public (undocumented)
-const CorporationsCorporationIdAlliancehistoryGetSchema: z.ZodObject<{
-    alliance_id: z.ZodOptional<z.ZodNumber>;
-    is_deleted: z.ZodOptional<z.ZodBoolean>;
-    record_id: z.ZodNumber;
-    start_date: z.ZodString;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface CorporationsCorporationIdAssetsGet {
     // (undocumented)
     is_blueprint_copy?: boolean;
@@ -4283,149 +2530,6 @@ interface CorporationsCorporationIdAssetsGet {
 }
 
 // @public (undocumented)
-const CorporationsCorporationIdAssetsGetSchema: z.ZodObject<{
-    is_blueprint_copy: z.ZodOptional<z.ZodBoolean>;
-    is_singleton: z.ZodBoolean;
-    item_id: z.ZodNumber;
-    location_flag: z.ZodEnum<{
-        AssetSafety: "AssetSafety";
-        AutoFit: "AutoFit";
-        BoosterBay: "BoosterBay";
-        CapsuleerDeliveries: "CapsuleerDeliveries";
-        Cargo: "Cargo";
-        CorporationGoalDeliveries: "CorporationGoalDeliveries";
-        Deliveries: "Deliveries";
-        DroneBay: "DroneBay";
-        ExpeditionHold: "ExpeditionHold";
-        FighterBay: "FighterBay";
-        FighterTube0: "FighterTube0";
-        FighterTube1: "FighterTube1";
-        FighterTube2: "FighterTube2";
-        FighterTube3: "FighterTube3";
-        FighterTube4: "FighterTube4";
-        FleetHangar: "FleetHangar";
-        FrigateEscapeBay: "FrigateEscapeBay";
-        Hangar: "Hangar";
-        HangarAll: "HangarAll";
-        HiSlot0: "HiSlot0";
-        HiSlot1: "HiSlot1";
-        HiSlot2: "HiSlot2";
-        HiSlot3: "HiSlot3";
-        HiSlot4: "HiSlot4";
-        HiSlot5: "HiSlot5";
-        HiSlot6: "HiSlot6";
-        HiSlot7: "HiSlot7";
-        HiddenModifiers: "HiddenModifiers";
-        Implant: "Implant";
-        InfrastructureHangar: "InfrastructureHangar";
-        LoSlot0: "LoSlot0";
-        LoSlot1: "LoSlot1";
-        LoSlot2: "LoSlot2";
-        LoSlot3: "LoSlot3";
-        LoSlot4: "LoSlot4";
-        LoSlot5: "LoSlot5";
-        LoSlot6: "LoSlot6";
-        LoSlot7: "LoSlot7";
-        Locked: "Locked";
-        MedSlot0: "MedSlot0";
-        MedSlot1: "MedSlot1";
-        MedSlot2: "MedSlot2";
-        MedSlot3: "MedSlot3";
-        MedSlot4: "MedSlot4";
-        MedSlot5: "MedSlot5";
-        MedSlot6: "MedSlot6";
-        MedSlot7: "MedSlot7";
-        MobileDepotHold: "MobileDepotHold";
-        MoonMaterialBay: "MoonMaterialBay";
-        QuafeBay: "QuafeBay";
-        RigSlot0: "RigSlot0";
-        RigSlot1: "RigSlot1";
-        RigSlot2: "RigSlot2";
-        RigSlot3: "RigSlot3";
-        RigSlot4: "RigSlot4";
-        RigSlot5: "RigSlot5";
-        RigSlot6: "RigSlot6";
-        RigSlot7: "RigSlot7";
-        ShipHangar: "ShipHangar";
-        Skill: "Skill";
-        SpecializedAmmoHold: "SpecializedAmmoHold";
-        SpecializedAsteroidHold: "SpecializedAsteroidHold";
-        SpecializedCommandCenterHold: "SpecializedCommandCenterHold";
-        SpecializedFuelBay: "SpecializedFuelBay";
-        SpecializedGasHold: "SpecializedGasHold";
-        SpecializedIceHold: "SpecializedIceHold";
-        SpecializedIndustrialShipHold: "SpecializedIndustrialShipHold";
-        SpecializedLargeShipHold: "SpecializedLargeShipHold";
-        SpecializedMaterialBay: "SpecializedMaterialBay";
-        SpecializedMediumShipHold: "SpecializedMediumShipHold";
-        SpecializedMineralHold: "SpecializedMineralHold";
-        SpecializedOreHold: "SpecializedOreHold";
-        SpecializedPlanetaryCommoditiesHold: "SpecializedPlanetaryCommoditiesHold";
-        SpecializedSalvageHold: "SpecializedSalvageHold";
-        SpecializedShipHold: "SpecializedShipHold";
-        SpecializedSmallShipHold: "SpecializedSmallShipHold";
-        SubSystemBay: "SubSystemBay";
-        SubSystemSlot0: "SubSystemSlot0";
-        SubSystemSlot1: "SubSystemSlot1";
-        SubSystemSlot2: "SubSystemSlot2";
-        SubSystemSlot3: "SubSystemSlot3";
-        SubSystemSlot4: "SubSystemSlot4";
-        SubSystemSlot5: "SubSystemSlot5";
-        SubSystemSlot6: "SubSystemSlot6";
-        SubSystemSlot7: "SubSystemSlot7";
-        Unlocked: "Unlocked";
-        Wardrobe: "Wardrobe";
-        Bonus: "Bonus";
-        Booster: "Booster";
-        Capsule: "Capsule";
-        CorpDeliveries: "CorpDeliveries";
-        CorpSAG1: "CorpSAG1";
-        CorpSAG2: "CorpSAG2";
-        CorpSAG3: "CorpSAG3";
-        CorpSAG4: "CorpSAG4";
-        CorpSAG5: "CorpSAG5";
-        CorpSAG6: "CorpSAG6";
-        CorpSAG7: "CorpSAG7";
-        CrateLoot: "CrateLoot";
-        DustBattle: "DustBattle";
-        DustDatabank: "DustDatabank";
-        Impounded: "Impounded";
-        JunkyardReprocessed: "JunkyardReprocessed";
-        JunkyardTrashed: "JunkyardTrashed";
-        OfficeFolder: "OfficeFolder";
-        Pilot: "Pilot";
-        PlanetSurface: "PlanetSurface";
-        QuantumCoreRoom: "QuantumCoreRoom";
-        Reward: "Reward";
-        SecondaryStorage: "SecondaryStorage";
-        ServiceSlot0: "ServiceSlot0";
-        ServiceSlot1: "ServiceSlot1";
-        ServiceSlot2: "ServiceSlot2";
-        ServiceSlot3: "ServiceSlot3";
-        ServiceSlot4: "ServiceSlot4";
-        ServiceSlot5: "ServiceSlot5";
-        ServiceSlot6: "ServiceSlot6";
-        ServiceSlot7: "ServiceSlot7";
-        ShipOffline: "ShipOffline";
-        SkillInTraining: "SkillInTraining";
-        StructureActive: "StructureActive";
-        StructureFuel: "StructureFuel";
-        StructureInactive: "StructureInactive";
-        StructureOffline: "StructureOffline";
-        Wallet: "Wallet";
-    }>;
-    location_id: z.ZodNumber;
-    location_type: z.ZodEnum<{
-        other: "other";
-        solar_system: "solar_system";
-        station: "station";
-        item: "item";
-    }>;
-    quantity: z.ZodNumber;
-    type_id: z.ZodNumber;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface CorporationsCorporationIdAssetsLocationsPost {
     // (undocumented)
     item_id: number;
@@ -4438,28 +2542,12 @@ interface CorporationsCorporationIdAssetsLocationsPost {
 }
 
 // @public (undocumented)
-const CorporationsCorporationIdAssetsLocationsPostSchema: z.ZodObject<{
-    item_id: z.ZodNumber;
-    position: z.ZodObject<{
-        x: z.ZodNumber;
-        y: z.ZodNumber;
-        z: z.ZodNumber;
-    }, z.core.$loose>;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface CorporationsCorporationIdAssetsNamesPost {
     // (undocumented)
     item_id: number;
     // (undocumented)
     name: string;
 }
-
-// @public (undocumented)
-const CorporationsCorporationIdAssetsNamesPostSchema: z.ZodObject<{
-    item_id: z.ZodNumber;
-    name: z.ZodString;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface CorporationsCorporationIdBlueprintsGet {
@@ -4482,144 +2570,6 @@ interface CorporationsCorporationIdBlueprintsGet {
 }
 
 // @public (undocumented)
-const CorporationsCorporationIdBlueprintsGetSchema: z.ZodObject<{
-    item_id: z.ZodNumber;
-    location_flag: z.ZodEnum<{
-        AssetSafety: "AssetSafety";
-        AutoFit: "AutoFit";
-        BoosterBay: "BoosterBay";
-        CapsuleerDeliveries: "CapsuleerDeliveries";
-        Cargo: "Cargo";
-        CorporationGoalDeliveries: "CorporationGoalDeliveries";
-        Deliveries: "Deliveries";
-        DroneBay: "DroneBay";
-        ExpeditionHold: "ExpeditionHold";
-        FighterBay: "FighterBay";
-        FighterTube0: "FighterTube0";
-        FighterTube1: "FighterTube1";
-        FighterTube2: "FighterTube2";
-        FighterTube3: "FighterTube3";
-        FighterTube4: "FighterTube4";
-        FleetHangar: "FleetHangar";
-        FrigateEscapeBay: "FrigateEscapeBay";
-        Hangar: "Hangar";
-        HangarAll: "HangarAll";
-        HiSlot0: "HiSlot0";
-        HiSlot1: "HiSlot1";
-        HiSlot2: "HiSlot2";
-        HiSlot3: "HiSlot3";
-        HiSlot4: "HiSlot4";
-        HiSlot5: "HiSlot5";
-        HiSlot6: "HiSlot6";
-        HiSlot7: "HiSlot7";
-        HiddenModifiers: "HiddenModifiers";
-        Implant: "Implant";
-        InfrastructureHangar: "InfrastructureHangar";
-        LoSlot0: "LoSlot0";
-        LoSlot1: "LoSlot1";
-        LoSlot2: "LoSlot2";
-        LoSlot3: "LoSlot3";
-        LoSlot4: "LoSlot4";
-        LoSlot5: "LoSlot5";
-        LoSlot6: "LoSlot6";
-        LoSlot7: "LoSlot7";
-        Locked: "Locked";
-        MedSlot0: "MedSlot0";
-        MedSlot1: "MedSlot1";
-        MedSlot2: "MedSlot2";
-        MedSlot3: "MedSlot3";
-        MedSlot4: "MedSlot4";
-        MedSlot5: "MedSlot5";
-        MedSlot6: "MedSlot6";
-        MedSlot7: "MedSlot7";
-        MobileDepotHold: "MobileDepotHold";
-        MoonMaterialBay: "MoonMaterialBay";
-        QuafeBay: "QuafeBay";
-        RigSlot0: "RigSlot0";
-        RigSlot1: "RigSlot1";
-        RigSlot2: "RigSlot2";
-        RigSlot3: "RigSlot3";
-        RigSlot4: "RigSlot4";
-        RigSlot5: "RigSlot5";
-        RigSlot6: "RigSlot6";
-        RigSlot7: "RigSlot7";
-        ShipHangar: "ShipHangar";
-        Skill: "Skill";
-        SpecializedAmmoHold: "SpecializedAmmoHold";
-        SpecializedAsteroidHold: "SpecializedAsteroidHold";
-        SpecializedCommandCenterHold: "SpecializedCommandCenterHold";
-        SpecializedFuelBay: "SpecializedFuelBay";
-        SpecializedGasHold: "SpecializedGasHold";
-        SpecializedIceHold: "SpecializedIceHold";
-        SpecializedIndustrialShipHold: "SpecializedIndustrialShipHold";
-        SpecializedLargeShipHold: "SpecializedLargeShipHold";
-        SpecializedMaterialBay: "SpecializedMaterialBay";
-        SpecializedMediumShipHold: "SpecializedMediumShipHold";
-        SpecializedMineralHold: "SpecializedMineralHold";
-        SpecializedOreHold: "SpecializedOreHold";
-        SpecializedPlanetaryCommoditiesHold: "SpecializedPlanetaryCommoditiesHold";
-        SpecializedSalvageHold: "SpecializedSalvageHold";
-        SpecializedShipHold: "SpecializedShipHold";
-        SpecializedSmallShipHold: "SpecializedSmallShipHold";
-        SubSystemBay: "SubSystemBay";
-        SubSystemSlot0: "SubSystemSlot0";
-        SubSystemSlot1: "SubSystemSlot1";
-        SubSystemSlot2: "SubSystemSlot2";
-        SubSystemSlot3: "SubSystemSlot3";
-        SubSystemSlot4: "SubSystemSlot4";
-        SubSystemSlot5: "SubSystemSlot5";
-        SubSystemSlot6: "SubSystemSlot6";
-        SubSystemSlot7: "SubSystemSlot7";
-        Unlocked: "Unlocked";
-        Wardrobe: "Wardrobe";
-        Bonus: "Bonus";
-        Booster: "Booster";
-        Capsule: "Capsule";
-        CorpDeliveries: "CorpDeliveries";
-        CorpSAG1: "CorpSAG1";
-        CorpSAG2: "CorpSAG2";
-        CorpSAG3: "CorpSAG3";
-        CorpSAG4: "CorpSAG4";
-        CorpSAG5: "CorpSAG5";
-        CorpSAG6: "CorpSAG6";
-        CorpSAG7: "CorpSAG7";
-        CrateLoot: "CrateLoot";
-        DustBattle: "DustBattle";
-        DustDatabank: "DustDatabank";
-        Impounded: "Impounded";
-        JunkyardReprocessed: "JunkyardReprocessed";
-        JunkyardTrashed: "JunkyardTrashed";
-        OfficeFolder: "OfficeFolder";
-        Pilot: "Pilot";
-        PlanetSurface: "PlanetSurface";
-        QuantumCoreRoom: "QuantumCoreRoom";
-        Reward: "Reward";
-        SecondaryStorage: "SecondaryStorage";
-        ServiceSlot0: "ServiceSlot0";
-        ServiceSlot1: "ServiceSlot1";
-        ServiceSlot2: "ServiceSlot2";
-        ServiceSlot3: "ServiceSlot3";
-        ServiceSlot4: "ServiceSlot4";
-        ServiceSlot5: "ServiceSlot5";
-        ServiceSlot6: "ServiceSlot6";
-        ServiceSlot7: "ServiceSlot7";
-        ShipOffline: "ShipOffline";
-        SkillInTraining: "SkillInTraining";
-        StructureActive: "StructureActive";
-        StructureFuel: "StructureFuel";
-        StructureInactive: "StructureInactive";
-        StructureOffline: "StructureOffline";
-        Wallet: "Wallet";
-    }>;
-    location_id: z.ZodNumber;
-    material_efficiency: z.ZodNumber;
-    quantity: z.ZodNumber;
-    runs: z.ZodNumber;
-    time_efficiency: z.ZodNumber;
-    type_id: z.ZodNumber;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface CorporationsCorporationIdContactsGet {
     // (undocumented)
     contact_id: number;
@@ -4634,32 +2584,12 @@ interface CorporationsCorporationIdContactsGet {
 }
 
 // @public (undocumented)
-const CorporationsCorporationIdContactsGetSchema: z.ZodObject<{
-    contact_id: z.ZodNumber;
-    contact_type: z.ZodEnum<{
-        faction: "faction";
-        character: "character";
-        corporation: "corporation";
-        alliance: "alliance";
-    }>;
-    is_watched: z.ZodOptional<z.ZodBoolean>;
-    label_ids: z.ZodOptional<z.ZodArray<z.ZodNumber>>;
-    standing: z.ZodNumber;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface CorporationsCorporationIdContactsLabelsGet {
     // (undocumented)
     label_id: number;
     // (undocumented)
     label_name: string;
 }
-
-// @public (undocumented)
-const CorporationsCorporationIdContactsLabelsGetSchema: z.ZodObject<{
-    label_id: z.ZodNumber;
-    label_name: z.ZodString;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface CorporationsCorporationIdContainersLogsGet {
@@ -4690,162 +2620,6 @@ interface CorporationsCorporationIdContainersLogsGet {
 }
 
 // @public (undocumented)
-const CorporationsCorporationIdContainersLogsGetSchema: z.ZodObject<{
-    action: z.ZodEnum<{
-        add: "add";
-        assemble: "assemble";
-        configure: "configure";
-        enter_password: "enter_password";
-        lock: "lock";
-        move: "move";
-        repackage: "repackage";
-        set_name: "set_name";
-        set_password: "set_password";
-        unlock: "unlock";
-    }>;
-    character_id: z.ZodNumber;
-    container_id: z.ZodNumber;
-    container_type_id: z.ZodNumber;
-    location_flag: z.ZodEnum<{
-        AssetSafety: "AssetSafety";
-        AutoFit: "AutoFit";
-        BoosterBay: "BoosterBay";
-        CapsuleerDeliveries: "CapsuleerDeliveries";
-        Cargo: "Cargo";
-        CorporationGoalDeliveries: "CorporationGoalDeliveries";
-        Deliveries: "Deliveries";
-        DroneBay: "DroneBay";
-        ExpeditionHold: "ExpeditionHold";
-        FighterBay: "FighterBay";
-        FighterTube0: "FighterTube0";
-        FighterTube1: "FighterTube1";
-        FighterTube2: "FighterTube2";
-        FighterTube3: "FighterTube3";
-        FighterTube4: "FighterTube4";
-        FleetHangar: "FleetHangar";
-        FrigateEscapeBay: "FrigateEscapeBay";
-        Hangar: "Hangar";
-        HangarAll: "HangarAll";
-        HiSlot0: "HiSlot0";
-        HiSlot1: "HiSlot1";
-        HiSlot2: "HiSlot2";
-        HiSlot3: "HiSlot3";
-        HiSlot4: "HiSlot4";
-        HiSlot5: "HiSlot5";
-        HiSlot6: "HiSlot6";
-        HiSlot7: "HiSlot7";
-        HiddenModifiers: "HiddenModifiers";
-        Implant: "Implant";
-        InfrastructureHangar: "InfrastructureHangar";
-        LoSlot0: "LoSlot0";
-        LoSlot1: "LoSlot1";
-        LoSlot2: "LoSlot2";
-        LoSlot3: "LoSlot3";
-        LoSlot4: "LoSlot4";
-        LoSlot5: "LoSlot5";
-        LoSlot6: "LoSlot6";
-        LoSlot7: "LoSlot7";
-        Locked: "Locked";
-        MedSlot0: "MedSlot0";
-        MedSlot1: "MedSlot1";
-        MedSlot2: "MedSlot2";
-        MedSlot3: "MedSlot3";
-        MedSlot4: "MedSlot4";
-        MedSlot5: "MedSlot5";
-        MedSlot6: "MedSlot6";
-        MedSlot7: "MedSlot7";
-        MobileDepotHold: "MobileDepotHold";
-        MoonMaterialBay: "MoonMaterialBay";
-        QuafeBay: "QuafeBay";
-        RigSlot0: "RigSlot0";
-        RigSlot1: "RigSlot1";
-        RigSlot2: "RigSlot2";
-        RigSlot3: "RigSlot3";
-        RigSlot4: "RigSlot4";
-        RigSlot5: "RigSlot5";
-        RigSlot6: "RigSlot6";
-        RigSlot7: "RigSlot7";
-        ShipHangar: "ShipHangar";
-        Skill: "Skill";
-        SpecializedAmmoHold: "SpecializedAmmoHold";
-        SpecializedAsteroidHold: "SpecializedAsteroidHold";
-        SpecializedCommandCenterHold: "SpecializedCommandCenterHold";
-        SpecializedFuelBay: "SpecializedFuelBay";
-        SpecializedGasHold: "SpecializedGasHold";
-        SpecializedIceHold: "SpecializedIceHold";
-        SpecializedIndustrialShipHold: "SpecializedIndustrialShipHold";
-        SpecializedLargeShipHold: "SpecializedLargeShipHold";
-        SpecializedMaterialBay: "SpecializedMaterialBay";
-        SpecializedMediumShipHold: "SpecializedMediumShipHold";
-        SpecializedMineralHold: "SpecializedMineralHold";
-        SpecializedOreHold: "SpecializedOreHold";
-        SpecializedPlanetaryCommoditiesHold: "SpecializedPlanetaryCommoditiesHold";
-        SpecializedSalvageHold: "SpecializedSalvageHold";
-        SpecializedShipHold: "SpecializedShipHold";
-        SpecializedSmallShipHold: "SpecializedSmallShipHold";
-        SubSystemBay: "SubSystemBay";
-        SubSystemSlot0: "SubSystemSlot0";
-        SubSystemSlot1: "SubSystemSlot1";
-        SubSystemSlot2: "SubSystemSlot2";
-        SubSystemSlot3: "SubSystemSlot3";
-        SubSystemSlot4: "SubSystemSlot4";
-        SubSystemSlot5: "SubSystemSlot5";
-        SubSystemSlot6: "SubSystemSlot6";
-        SubSystemSlot7: "SubSystemSlot7";
-        Unlocked: "Unlocked";
-        Wardrobe: "Wardrobe";
-        Bonus: "Bonus";
-        Booster: "Booster";
-        Capsule: "Capsule";
-        CorpDeliveries: "CorpDeliveries";
-        CorpSAG1: "CorpSAG1";
-        CorpSAG2: "CorpSAG2";
-        CorpSAG3: "CorpSAG3";
-        CorpSAG4: "CorpSAG4";
-        CorpSAG5: "CorpSAG5";
-        CorpSAG6: "CorpSAG6";
-        CorpSAG7: "CorpSAG7";
-        CrateLoot: "CrateLoot";
-        DustBattle: "DustBattle";
-        DustDatabank: "DustDatabank";
-        Impounded: "Impounded";
-        JunkyardReprocessed: "JunkyardReprocessed";
-        JunkyardTrashed: "JunkyardTrashed";
-        OfficeFolder: "OfficeFolder";
-        Pilot: "Pilot";
-        PlanetSurface: "PlanetSurface";
-        QuantumCoreRoom: "QuantumCoreRoom";
-        Reward: "Reward";
-        SecondaryStorage: "SecondaryStorage";
-        ServiceSlot0: "ServiceSlot0";
-        ServiceSlot1: "ServiceSlot1";
-        ServiceSlot2: "ServiceSlot2";
-        ServiceSlot3: "ServiceSlot3";
-        ServiceSlot4: "ServiceSlot4";
-        ServiceSlot5: "ServiceSlot5";
-        ServiceSlot6: "ServiceSlot6";
-        ServiceSlot7: "ServiceSlot7";
-        ShipOffline: "ShipOffline";
-        SkillInTraining: "SkillInTraining";
-        StructureActive: "StructureActive";
-        StructureFuel: "StructureFuel";
-        StructureInactive: "StructureInactive";
-        StructureOffline: "StructureOffline";
-        Wallet: "Wallet";
-    }>;
-    location_id: z.ZodNumber;
-    logged_at: z.ZodString;
-    new_config_bitmask: z.ZodOptional<z.ZodNumber>;
-    old_config_bitmask: z.ZodOptional<z.ZodNumber>;
-    password_type: z.ZodOptional<z.ZodEnum<{
-        config: "config";
-        general: "general";
-    }>>;
-    quantity: z.ZodOptional<z.ZodNumber>;
-    type_id: z.ZodOptional<z.ZodNumber>;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface CorporationsCorporationIdContractsContractIdBidsGet {
     // (undocumented)
     amount: number;
@@ -4856,14 +2630,6 @@ interface CorporationsCorporationIdContractsContractIdBidsGet {
     // (undocumented)
     date_bid: string;
 }
-
-// @public (undocumented)
-const CorporationsCorporationIdContractsContractIdBidsGetSchema: z.ZodObject<{
-    amount: z.ZodNumber;
-    bid_id: z.ZodNumber;
-    bidder_id: z.ZodNumber;
-    date_bid: z.ZodString;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface CorporationsCorporationIdContractsContractIdItemsGet {
@@ -4880,16 +2646,6 @@ interface CorporationsCorporationIdContractsContractIdItemsGet {
     // (undocumented)
     type_id: number;
 }
-
-// @public (undocumented)
-const CorporationsCorporationIdContractsContractIdItemsGetSchema: z.ZodObject<{
-    is_included: z.ZodBoolean;
-    is_singleton: z.ZodBoolean;
-    quantity: z.ZodNumber;
-    raw_quantity: z.ZodOptional<z.ZodNumber>;
-    record_id: z.ZodNumber;
-    type_id: z.ZodNumber;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface CorporationsCorporationIdContractsGet {
@@ -4940,54 +2696,6 @@ interface CorporationsCorporationIdContractsGet {
 }
 
 // @public (undocumented)
-const CorporationsCorporationIdContractsGetSchema: z.ZodObject<{
-    acceptor_id: z.ZodNumber;
-    assignee_id: z.ZodNumber;
-    availability: z.ZodEnum<{
-        corporation: "corporation";
-        alliance: "alliance";
-        public: "public";
-        personal: "personal";
-    }>;
-    buyout: z.ZodOptional<z.ZodNumber>;
-    collateral: z.ZodOptional<z.ZodNumber>;
-    contract_id: z.ZodNumber;
-    date_accepted: z.ZodOptional<z.ZodString>;
-    date_completed: z.ZodOptional<z.ZodString>;
-    date_expired: z.ZodString;
-    date_issued: z.ZodString;
-    days_to_complete: z.ZodOptional<z.ZodNumber>;
-    end_location_id: z.ZodOptional<z.ZodNumber>;
-    for_corporation: z.ZodBoolean;
-    issuer_corporation_id: z.ZodNumber;
-    issuer_id: z.ZodNumber;
-    price: z.ZodOptional<z.ZodNumber>;
-    reward: z.ZodOptional<z.ZodNumber>;
-    start_location_id: z.ZodOptional<z.ZodNumber>;
-    status: z.ZodEnum<{
-        cancelled: "cancelled";
-        outstanding: "outstanding";
-        in_progress: "in_progress";
-        finished_issuer: "finished_issuer";
-        finished_contractor: "finished_contractor";
-        finished: "finished";
-        rejected: "rejected";
-        failed: "failed";
-        deleted: "deleted";
-        reversed: "reversed";
-    }>;
-    title: z.ZodOptional<z.ZodString>;
-    type: z.ZodEnum<{
-        unknown: "unknown";
-        item_exchange: "item_exchange";
-        auction: "auction";
-        courier: "courier";
-        loan: "loan";
-    }>;
-    volume: z.ZodOptional<z.ZodNumber>;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface CorporationsCorporationIdCustomsOfficesGet {
     // (undocumented)
     alliance_tax_rate?: number;
@@ -5022,31 +2730,6 @@ interface CorporationsCorporationIdCustomsOfficesGet {
 }
 
 // @public (undocumented)
-const CorporationsCorporationIdCustomsOfficesGetSchema: z.ZodObject<{
-    alliance_tax_rate: z.ZodOptional<z.ZodNumber>;
-    allow_access_with_standings: z.ZodBoolean;
-    allow_alliance_access: z.ZodBoolean;
-    bad_standing_tax_rate: z.ZodOptional<z.ZodNumber>;
-    corporation_tax_rate: z.ZodOptional<z.ZodNumber>;
-    excellent_standing_tax_rate: z.ZodOptional<z.ZodNumber>;
-    good_standing_tax_rate: z.ZodOptional<z.ZodNumber>;
-    neutral_standing_tax_rate: z.ZodOptional<z.ZodNumber>;
-    office_id: z.ZodNumber;
-    reinforce_exit_end: z.ZodNumber;
-    reinforce_exit_start: z.ZodNumber;
-    standing_level: z.ZodOptional<z.ZodEnum<{
-        bad: "bad";
-        excellent: "excellent";
-        good: "good";
-        neutral: "neutral";
-        terrible: "terrible";
-    }>>;
-    system_id: z.ZodNumber;
-    terrible_standing_tax_rate: z.ZodOptional<z.ZodNumber>;
-    type_id: z.ZodOptional<z.ZodNumber>;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface CorporationsCorporationIdDivisionsGet {
     // (undocumented)
     hangar?: ({
@@ -5061,18 +2744,6 @@ interface CorporationsCorporationIdDivisionsGet {
 }
 
 // @public (undocumented)
-const CorporationsCorporationIdDivisionsGetSchema: z.ZodObject<{
-    hangar: z.ZodOptional<z.ZodArray<z.ZodObject<{
-        division: z.ZodOptional<z.ZodNumber>;
-        name: z.ZodOptional<z.ZodString>;
-    }, z.core.$loose>>>;
-    wallet: z.ZodOptional<z.ZodArray<z.ZodObject<{
-        division: z.ZodOptional<z.ZodNumber>;
-        name: z.ZodOptional<z.ZodString>;
-    }, z.core.$loose>>>;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface CorporationsCorporationIdFacilitiesGet {
     // (undocumented)
     facility_id: number;
@@ -5081,13 +2752,6 @@ interface CorporationsCorporationIdFacilitiesGet {
     // (undocumented)
     type_id: number;
 }
-
-// @public (undocumented)
-const CorporationsCorporationIdFacilitiesGetSchema: z.ZodObject<{
-    facility_id: z.ZodNumber;
-    system_id: z.ZodNumber;
-    type_id: z.ZodNumber;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface CorporationsCorporationIdFwStatsGet {
@@ -5112,23 +2776,6 @@ interface CorporationsCorporationIdFwStatsGet {
 }
 
 // @public (undocumented)
-const CorporationsCorporationIdFwStatsGetSchema: z.ZodObject<{
-    enlisted_on: z.ZodOptional<z.ZodString>;
-    faction_id: z.ZodOptional<z.ZodNumber>;
-    kills: z.ZodObject<{
-        last_week: z.ZodNumber;
-        total: z.ZodNumber;
-        yesterday: z.ZodNumber;
-    }, z.core.$loose>;
-    pilots: z.ZodOptional<z.ZodNumber>;
-    victory_points: z.ZodObject<{
-        last_week: z.ZodNumber;
-        total: z.ZodNumber;
-        yesterday: z.ZodNumber;
-    }, z.core.$loose>;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface CorporationsCorporationIdIconsGet {
     // (undocumented)
     px128x128?: string;
@@ -5137,13 +2784,6 @@ interface CorporationsCorporationIdIconsGet {
     // (undocumented)
     px64x64?: string;
 }
-
-// @public (undocumented)
-const CorporationsCorporationIdIconsGetSchema: z.ZodObject<{
-    px128x128: z.ZodOptional<z.ZodString>;
-    px256x256: z.ZodOptional<z.ZodString>;
-    px64x64: z.ZodOptional<z.ZodString>;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface CorporationsCorporationIdIndustryJobsGet {
@@ -5194,51 +2834,12 @@ interface CorporationsCorporationIdIndustryJobsGet {
 }
 
 // @public (undocumented)
-const CorporationsCorporationIdIndustryJobsGetSchema: z.ZodObject<{
-    activity_id: z.ZodNumber;
-    blueprint_id: z.ZodNumber;
-    blueprint_location_id: z.ZodNumber;
-    blueprint_type_id: z.ZodNumber;
-    completed_character_id: z.ZodOptional<z.ZodNumber>;
-    completed_date: z.ZodOptional<z.ZodString>;
-    cost: z.ZodOptional<z.ZodNumber>;
-    duration: z.ZodNumber;
-    end_date: z.ZodString;
-    facility_id: z.ZodNumber;
-    installer_id: z.ZodNumber;
-    job_id: z.ZodNumber;
-    licensed_runs: z.ZodOptional<z.ZodNumber>;
-    location_id: z.ZodNumber;
-    output_location_id: z.ZodNumber;
-    pause_date: z.ZodOptional<z.ZodString>;
-    probability: z.ZodOptional<z.ZodNumber>;
-    product_type_id: z.ZodOptional<z.ZodNumber>;
-    runs: z.ZodNumber;
-    start_date: z.ZodString;
-    status: z.ZodEnum<{
-        cancelled: "cancelled";
-        active: "active";
-        delivered: "delivered";
-        paused: "paused";
-        ready: "ready";
-        reverted: "reverted";
-    }>;
-    successful_runs: z.ZodOptional<z.ZodNumber>;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface CorporationsCorporationIdKillmailsRecentGet {
     // (undocumented)
     killmail_hash: string;
     // (undocumented)
     killmail_id: number;
 }
-
-// @public (undocumented)
-const CorporationsCorporationIdKillmailsRecentGetSchema: z.ZodObject<{
-    killmail_hash: z.ZodString;
-    killmail_id: z.ZodNumber;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface CorporationsCorporationIdMedalsGet {
@@ -5253,15 +2854,6 @@ interface CorporationsCorporationIdMedalsGet {
     // (undocumented)
     title: string;
 }
-
-// @public (undocumented)
-const CorporationsCorporationIdMedalsGetSchema: z.ZodObject<{
-    created_at: z.ZodString;
-    creator_id: z.ZodNumber;
-    description: z.ZodString;
-    medal_id: z.ZodNumber;
-    title: z.ZodString;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface CorporationsCorporationIdMedalsIssuedGet {
@@ -5280,31 +2872,12 @@ interface CorporationsCorporationIdMedalsIssuedGet {
 }
 
 // @public (undocumented)
-const CorporationsCorporationIdMedalsIssuedGetSchema: z.ZodObject<{
-    character_id: z.ZodNumber;
-    issued_at: z.ZodString;
-    issuer_id: z.ZodNumber;
-    medal_id: z.ZodNumber;
-    reason: z.ZodString;
-    status: z.ZodEnum<{
-        private: "private";
-        public: "public";
-    }>;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface CorporationsCorporationIdMembersTitlesGet {
     // (undocumented)
     character_id: number;
     // (undocumented)
     titles: number[];
 }
-
-// @public (undocumented)
-const CorporationsCorporationIdMembersTitlesGetSchema: z.ZodObject<{
-    character_id: z.ZodNumber;
-    titles: z.ZodArray<z.ZodNumber>;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface CorporationsCorporationIdMembertrackingGet {
@@ -5323,17 +2896,6 @@ interface CorporationsCorporationIdMembertrackingGet {
     // (undocumented)
     start_date?: string;
 }
-
-// @public (undocumented)
-const CorporationsCorporationIdMembertrackingGetSchema: z.ZodObject<{
-    base_id: z.ZodOptional<z.ZodNumber>;
-    character_id: z.ZodNumber;
-    location_id: z.ZodOptional<z.ZodNumber>;
-    logoff_date: z.ZodOptional<z.ZodString>;
-    logon_date: z.ZodOptional<z.ZodString>;
-    ship_type_id: z.ZodOptional<z.ZodNumber>;
-    start_date: z.ZodOptional<z.ZodString>;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface CorporationsCorporationIdOrdersGet {
@@ -5368,38 +2930,6 @@ interface CorporationsCorporationIdOrdersGet {
     // (undocumented)
     wallet_division: number;
 }
-
-// @public (undocumented)
-const CorporationsCorporationIdOrdersGetSchema: z.ZodObject<{
-    duration: z.ZodNumber;
-    escrow: z.ZodOptional<z.ZodNumber>;
-    is_buy_order: z.ZodOptional<z.ZodBoolean>;
-    issued: z.ZodString;
-    issued_by: z.ZodNumber;
-    location_id: z.ZodNumber;
-    min_volume: z.ZodOptional<z.ZodNumber>;
-    order_id: z.ZodNumber;
-    price: z.ZodNumber;
-    range: z.ZodEnum<{
-        1: "1";
-        2: "2";
-        3: "3";
-        4: "4";
-        region: "region";
-        5: "5";
-        station: "station";
-        10: "10";
-        20: "20";
-        30: "30";
-        40: "40";
-        solarsystem: "solarsystem";
-    }>;
-    region_id: z.ZodNumber;
-    type_id: z.ZodNumber;
-    volume_remain: z.ZodNumber;
-    volume_total: z.ZodNumber;
-    wallet_division: z.ZodNumber;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface CorporationsCorporationIdOrdersHistoryGet {
@@ -5438,42 +2968,6 @@ interface CorporationsCorporationIdOrdersHistoryGet {
 }
 
 // @public (undocumented)
-const CorporationsCorporationIdOrdersHistoryGetSchema: z.ZodObject<{
-    duration: z.ZodNumber;
-    escrow: z.ZodOptional<z.ZodNumber>;
-    is_buy_order: z.ZodOptional<z.ZodBoolean>;
-    issued: z.ZodString;
-    issued_by: z.ZodOptional<z.ZodNumber>;
-    location_id: z.ZodNumber;
-    min_volume: z.ZodOptional<z.ZodNumber>;
-    order_id: z.ZodNumber;
-    price: z.ZodNumber;
-    range: z.ZodEnum<{
-        1: "1";
-        2: "2";
-        3: "3";
-        4: "4";
-        region: "region";
-        5: "5";
-        station: "station";
-        10: "10";
-        20: "20";
-        30: "30";
-        40: "40";
-        solarsystem: "solarsystem";
-    }>;
-    region_id: z.ZodNumber;
-    state: z.ZodEnum<{
-        cancelled: "cancelled";
-        expired: "expired";
-    }>;
-    type_id: z.ZodNumber;
-    volume_remain: z.ZodNumber;
-    volume_total: z.ZodNumber;
-    wallet_division: z.ZodNumber;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface CorporationsCorporationIdRolesGet {
     // (undocumented)
     character_id: number;
@@ -5496,459 +2990,6 @@ interface CorporationsCorporationIdRolesGet {
 }
 
 // @public (undocumented)
-const CorporationsCorporationIdRolesGetSchema: z.ZodObject<{
-    character_id: z.ZodNumber;
-    grantable_roles: z.ZodOptional<z.ZodArray<z.ZodEnum<{
-        Account_Take_1: "Account_Take_1";
-        Account_Take_2: "Account_Take_2";
-        Account_Take_3: "Account_Take_3";
-        Account_Take_4: "Account_Take_4";
-        Account_Take_5: "Account_Take_5";
-        Account_Take_6: "Account_Take_6";
-        Account_Take_7: "Account_Take_7";
-        Accountant: "Accountant";
-        Auditor: "Auditor";
-        Brand_Manager: "Brand_Manager";
-        Communications_Officer: "Communications_Officer";
-        Config_Equipment: "Config_Equipment";
-        Config_Starbase_Equipment: "Config_Starbase_Equipment";
-        Container_Take_1: "Container_Take_1";
-        Container_Take_2: "Container_Take_2";
-        Container_Take_3: "Container_Take_3";
-        Container_Take_4: "Container_Take_4";
-        Container_Take_5: "Container_Take_5";
-        Container_Take_6: "Container_Take_6";
-        Container_Take_7: "Container_Take_7";
-        Contract_Manager: "Contract_Manager";
-        Deliveries_Container_Take: "Deliveries_Container_Take";
-        Deliveries_Query: "Deliveries_Query";
-        Deliveries_Take: "Deliveries_Take";
-        Diplomat: "Diplomat";
-        Director: "Director";
-        Factory_Manager: "Factory_Manager";
-        Fitting_Manager: "Fitting_Manager";
-        Hangar_Query_1: "Hangar_Query_1";
-        Hangar_Query_2: "Hangar_Query_2";
-        Hangar_Query_3: "Hangar_Query_3";
-        Hangar_Query_4: "Hangar_Query_4";
-        Hangar_Query_5: "Hangar_Query_5";
-        Hangar_Query_6: "Hangar_Query_6";
-        Hangar_Query_7: "Hangar_Query_7";
-        Hangar_Take_1: "Hangar_Take_1";
-        Hangar_Take_2: "Hangar_Take_2";
-        Hangar_Take_3: "Hangar_Take_3";
-        Hangar_Take_4: "Hangar_Take_4";
-        Hangar_Take_5: "Hangar_Take_5";
-        Hangar_Take_6: "Hangar_Take_6";
-        Hangar_Take_7: "Hangar_Take_7";
-        Junior_Accountant: "Junior_Accountant";
-        Personnel_Manager: "Personnel_Manager";
-        Project_Manager: "Project_Manager";
-        Rent_Factory_Facility: "Rent_Factory_Facility";
-        Rent_Office: "Rent_Office";
-        Rent_Research_Facility: "Rent_Research_Facility";
-        Security_Officer: "Security_Officer";
-        Skill_Plan_Manager: "Skill_Plan_Manager";
-        Starbase_Defense_Operator: "Starbase_Defense_Operator";
-        Starbase_Fuel_Technician: "Starbase_Fuel_Technician";
-        Station_Manager: "Station_Manager";
-        Trader: "Trader";
-    }>>>;
-    grantable_roles_at_base: z.ZodOptional<z.ZodArray<z.ZodEnum<{
-        Account_Take_1: "Account_Take_1";
-        Account_Take_2: "Account_Take_2";
-        Account_Take_3: "Account_Take_3";
-        Account_Take_4: "Account_Take_4";
-        Account_Take_5: "Account_Take_5";
-        Account_Take_6: "Account_Take_6";
-        Account_Take_7: "Account_Take_7";
-        Accountant: "Accountant";
-        Auditor: "Auditor";
-        Brand_Manager: "Brand_Manager";
-        Communications_Officer: "Communications_Officer";
-        Config_Equipment: "Config_Equipment";
-        Config_Starbase_Equipment: "Config_Starbase_Equipment";
-        Container_Take_1: "Container_Take_1";
-        Container_Take_2: "Container_Take_2";
-        Container_Take_3: "Container_Take_3";
-        Container_Take_4: "Container_Take_4";
-        Container_Take_5: "Container_Take_5";
-        Container_Take_6: "Container_Take_6";
-        Container_Take_7: "Container_Take_7";
-        Contract_Manager: "Contract_Manager";
-        Deliveries_Container_Take: "Deliveries_Container_Take";
-        Deliveries_Query: "Deliveries_Query";
-        Deliveries_Take: "Deliveries_Take";
-        Diplomat: "Diplomat";
-        Director: "Director";
-        Factory_Manager: "Factory_Manager";
-        Fitting_Manager: "Fitting_Manager";
-        Hangar_Query_1: "Hangar_Query_1";
-        Hangar_Query_2: "Hangar_Query_2";
-        Hangar_Query_3: "Hangar_Query_3";
-        Hangar_Query_4: "Hangar_Query_4";
-        Hangar_Query_5: "Hangar_Query_5";
-        Hangar_Query_6: "Hangar_Query_6";
-        Hangar_Query_7: "Hangar_Query_7";
-        Hangar_Take_1: "Hangar_Take_1";
-        Hangar_Take_2: "Hangar_Take_2";
-        Hangar_Take_3: "Hangar_Take_3";
-        Hangar_Take_4: "Hangar_Take_4";
-        Hangar_Take_5: "Hangar_Take_5";
-        Hangar_Take_6: "Hangar_Take_6";
-        Hangar_Take_7: "Hangar_Take_7";
-        Junior_Accountant: "Junior_Accountant";
-        Personnel_Manager: "Personnel_Manager";
-        Project_Manager: "Project_Manager";
-        Rent_Factory_Facility: "Rent_Factory_Facility";
-        Rent_Office: "Rent_Office";
-        Rent_Research_Facility: "Rent_Research_Facility";
-        Security_Officer: "Security_Officer";
-        Skill_Plan_Manager: "Skill_Plan_Manager";
-        Starbase_Defense_Operator: "Starbase_Defense_Operator";
-        Starbase_Fuel_Technician: "Starbase_Fuel_Technician";
-        Station_Manager: "Station_Manager";
-        Trader: "Trader";
-    }>>>;
-    grantable_roles_at_hq: z.ZodOptional<z.ZodArray<z.ZodEnum<{
-        Account_Take_1: "Account_Take_1";
-        Account_Take_2: "Account_Take_2";
-        Account_Take_3: "Account_Take_3";
-        Account_Take_4: "Account_Take_4";
-        Account_Take_5: "Account_Take_5";
-        Account_Take_6: "Account_Take_6";
-        Account_Take_7: "Account_Take_7";
-        Accountant: "Accountant";
-        Auditor: "Auditor";
-        Brand_Manager: "Brand_Manager";
-        Communications_Officer: "Communications_Officer";
-        Config_Equipment: "Config_Equipment";
-        Config_Starbase_Equipment: "Config_Starbase_Equipment";
-        Container_Take_1: "Container_Take_1";
-        Container_Take_2: "Container_Take_2";
-        Container_Take_3: "Container_Take_3";
-        Container_Take_4: "Container_Take_4";
-        Container_Take_5: "Container_Take_5";
-        Container_Take_6: "Container_Take_6";
-        Container_Take_7: "Container_Take_7";
-        Contract_Manager: "Contract_Manager";
-        Deliveries_Container_Take: "Deliveries_Container_Take";
-        Deliveries_Query: "Deliveries_Query";
-        Deliveries_Take: "Deliveries_Take";
-        Diplomat: "Diplomat";
-        Director: "Director";
-        Factory_Manager: "Factory_Manager";
-        Fitting_Manager: "Fitting_Manager";
-        Hangar_Query_1: "Hangar_Query_1";
-        Hangar_Query_2: "Hangar_Query_2";
-        Hangar_Query_3: "Hangar_Query_3";
-        Hangar_Query_4: "Hangar_Query_4";
-        Hangar_Query_5: "Hangar_Query_5";
-        Hangar_Query_6: "Hangar_Query_6";
-        Hangar_Query_7: "Hangar_Query_7";
-        Hangar_Take_1: "Hangar_Take_1";
-        Hangar_Take_2: "Hangar_Take_2";
-        Hangar_Take_3: "Hangar_Take_3";
-        Hangar_Take_4: "Hangar_Take_4";
-        Hangar_Take_5: "Hangar_Take_5";
-        Hangar_Take_6: "Hangar_Take_6";
-        Hangar_Take_7: "Hangar_Take_7";
-        Junior_Accountant: "Junior_Accountant";
-        Personnel_Manager: "Personnel_Manager";
-        Project_Manager: "Project_Manager";
-        Rent_Factory_Facility: "Rent_Factory_Facility";
-        Rent_Office: "Rent_Office";
-        Rent_Research_Facility: "Rent_Research_Facility";
-        Security_Officer: "Security_Officer";
-        Skill_Plan_Manager: "Skill_Plan_Manager";
-        Starbase_Defense_Operator: "Starbase_Defense_Operator";
-        Starbase_Fuel_Technician: "Starbase_Fuel_Technician";
-        Station_Manager: "Station_Manager";
-        Trader: "Trader";
-    }>>>;
-    grantable_roles_at_other: z.ZodOptional<z.ZodArray<z.ZodEnum<{
-        Account_Take_1: "Account_Take_1";
-        Account_Take_2: "Account_Take_2";
-        Account_Take_3: "Account_Take_3";
-        Account_Take_4: "Account_Take_4";
-        Account_Take_5: "Account_Take_5";
-        Account_Take_6: "Account_Take_6";
-        Account_Take_7: "Account_Take_7";
-        Accountant: "Accountant";
-        Auditor: "Auditor";
-        Brand_Manager: "Brand_Manager";
-        Communications_Officer: "Communications_Officer";
-        Config_Equipment: "Config_Equipment";
-        Config_Starbase_Equipment: "Config_Starbase_Equipment";
-        Container_Take_1: "Container_Take_1";
-        Container_Take_2: "Container_Take_2";
-        Container_Take_3: "Container_Take_3";
-        Container_Take_4: "Container_Take_4";
-        Container_Take_5: "Container_Take_5";
-        Container_Take_6: "Container_Take_6";
-        Container_Take_7: "Container_Take_7";
-        Contract_Manager: "Contract_Manager";
-        Deliveries_Container_Take: "Deliveries_Container_Take";
-        Deliveries_Query: "Deliveries_Query";
-        Deliveries_Take: "Deliveries_Take";
-        Diplomat: "Diplomat";
-        Director: "Director";
-        Factory_Manager: "Factory_Manager";
-        Fitting_Manager: "Fitting_Manager";
-        Hangar_Query_1: "Hangar_Query_1";
-        Hangar_Query_2: "Hangar_Query_2";
-        Hangar_Query_3: "Hangar_Query_3";
-        Hangar_Query_4: "Hangar_Query_4";
-        Hangar_Query_5: "Hangar_Query_5";
-        Hangar_Query_6: "Hangar_Query_6";
-        Hangar_Query_7: "Hangar_Query_7";
-        Hangar_Take_1: "Hangar_Take_1";
-        Hangar_Take_2: "Hangar_Take_2";
-        Hangar_Take_3: "Hangar_Take_3";
-        Hangar_Take_4: "Hangar_Take_4";
-        Hangar_Take_5: "Hangar_Take_5";
-        Hangar_Take_6: "Hangar_Take_6";
-        Hangar_Take_7: "Hangar_Take_7";
-        Junior_Accountant: "Junior_Accountant";
-        Personnel_Manager: "Personnel_Manager";
-        Project_Manager: "Project_Manager";
-        Rent_Factory_Facility: "Rent_Factory_Facility";
-        Rent_Office: "Rent_Office";
-        Rent_Research_Facility: "Rent_Research_Facility";
-        Security_Officer: "Security_Officer";
-        Skill_Plan_Manager: "Skill_Plan_Manager";
-        Starbase_Defense_Operator: "Starbase_Defense_Operator";
-        Starbase_Fuel_Technician: "Starbase_Fuel_Technician";
-        Station_Manager: "Station_Manager";
-        Trader: "Trader";
-    }>>>;
-    roles: z.ZodOptional<z.ZodArray<z.ZodEnum<{
-        Account_Take_1: "Account_Take_1";
-        Account_Take_2: "Account_Take_2";
-        Account_Take_3: "Account_Take_3";
-        Account_Take_4: "Account_Take_4";
-        Account_Take_5: "Account_Take_5";
-        Account_Take_6: "Account_Take_6";
-        Account_Take_7: "Account_Take_7";
-        Accountant: "Accountant";
-        Auditor: "Auditor";
-        Brand_Manager: "Brand_Manager";
-        Communications_Officer: "Communications_Officer";
-        Config_Equipment: "Config_Equipment";
-        Config_Starbase_Equipment: "Config_Starbase_Equipment";
-        Container_Take_1: "Container_Take_1";
-        Container_Take_2: "Container_Take_2";
-        Container_Take_3: "Container_Take_3";
-        Container_Take_4: "Container_Take_4";
-        Container_Take_5: "Container_Take_5";
-        Container_Take_6: "Container_Take_6";
-        Container_Take_7: "Container_Take_7";
-        Contract_Manager: "Contract_Manager";
-        Deliveries_Container_Take: "Deliveries_Container_Take";
-        Deliveries_Query: "Deliveries_Query";
-        Deliveries_Take: "Deliveries_Take";
-        Diplomat: "Diplomat";
-        Director: "Director";
-        Factory_Manager: "Factory_Manager";
-        Fitting_Manager: "Fitting_Manager";
-        Hangar_Query_1: "Hangar_Query_1";
-        Hangar_Query_2: "Hangar_Query_2";
-        Hangar_Query_3: "Hangar_Query_3";
-        Hangar_Query_4: "Hangar_Query_4";
-        Hangar_Query_5: "Hangar_Query_5";
-        Hangar_Query_6: "Hangar_Query_6";
-        Hangar_Query_7: "Hangar_Query_7";
-        Hangar_Take_1: "Hangar_Take_1";
-        Hangar_Take_2: "Hangar_Take_2";
-        Hangar_Take_3: "Hangar_Take_3";
-        Hangar_Take_4: "Hangar_Take_4";
-        Hangar_Take_5: "Hangar_Take_5";
-        Hangar_Take_6: "Hangar_Take_6";
-        Hangar_Take_7: "Hangar_Take_7";
-        Junior_Accountant: "Junior_Accountant";
-        Personnel_Manager: "Personnel_Manager";
-        Project_Manager: "Project_Manager";
-        Rent_Factory_Facility: "Rent_Factory_Facility";
-        Rent_Office: "Rent_Office";
-        Rent_Research_Facility: "Rent_Research_Facility";
-        Security_Officer: "Security_Officer";
-        Skill_Plan_Manager: "Skill_Plan_Manager";
-        Starbase_Defense_Operator: "Starbase_Defense_Operator";
-        Starbase_Fuel_Technician: "Starbase_Fuel_Technician";
-        Station_Manager: "Station_Manager";
-        Trader: "Trader";
-    }>>>;
-    roles_at_base: z.ZodOptional<z.ZodArray<z.ZodEnum<{
-        Account_Take_1: "Account_Take_1";
-        Account_Take_2: "Account_Take_2";
-        Account_Take_3: "Account_Take_3";
-        Account_Take_4: "Account_Take_4";
-        Account_Take_5: "Account_Take_5";
-        Account_Take_6: "Account_Take_6";
-        Account_Take_7: "Account_Take_7";
-        Accountant: "Accountant";
-        Auditor: "Auditor";
-        Brand_Manager: "Brand_Manager";
-        Communications_Officer: "Communications_Officer";
-        Config_Equipment: "Config_Equipment";
-        Config_Starbase_Equipment: "Config_Starbase_Equipment";
-        Container_Take_1: "Container_Take_1";
-        Container_Take_2: "Container_Take_2";
-        Container_Take_3: "Container_Take_3";
-        Container_Take_4: "Container_Take_4";
-        Container_Take_5: "Container_Take_5";
-        Container_Take_6: "Container_Take_6";
-        Container_Take_7: "Container_Take_7";
-        Contract_Manager: "Contract_Manager";
-        Deliveries_Container_Take: "Deliveries_Container_Take";
-        Deliveries_Query: "Deliveries_Query";
-        Deliveries_Take: "Deliveries_Take";
-        Diplomat: "Diplomat";
-        Director: "Director";
-        Factory_Manager: "Factory_Manager";
-        Fitting_Manager: "Fitting_Manager";
-        Hangar_Query_1: "Hangar_Query_1";
-        Hangar_Query_2: "Hangar_Query_2";
-        Hangar_Query_3: "Hangar_Query_3";
-        Hangar_Query_4: "Hangar_Query_4";
-        Hangar_Query_5: "Hangar_Query_5";
-        Hangar_Query_6: "Hangar_Query_6";
-        Hangar_Query_7: "Hangar_Query_7";
-        Hangar_Take_1: "Hangar_Take_1";
-        Hangar_Take_2: "Hangar_Take_2";
-        Hangar_Take_3: "Hangar_Take_3";
-        Hangar_Take_4: "Hangar_Take_4";
-        Hangar_Take_5: "Hangar_Take_5";
-        Hangar_Take_6: "Hangar_Take_6";
-        Hangar_Take_7: "Hangar_Take_7";
-        Junior_Accountant: "Junior_Accountant";
-        Personnel_Manager: "Personnel_Manager";
-        Project_Manager: "Project_Manager";
-        Rent_Factory_Facility: "Rent_Factory_Facility";
-        Rent_Office: "Rent_Office";
-        Rent_Research_Facility: "Rent_Research_Facility";
-        Security_Officer: "Security_Officer";
-        Skill_Plan_Manager: "Skill_Plan_Manager";
-        Starbase_Defense_Operator: "Starbase_Defense_Operator";
-        Starbase_Fuel_Technician: "Starbase_Fuel_Technician";
-        Station_Manager: "Station_Manager";
-        Trader: "Trader";
-    }>>>;
-    roles_at_hq: z.ZodOptional<z.ZodArray<z.ZodEnum<{
-        Account_Take_1: "Account_Take_1";
-        Account_Take_2: "Account_Take_2";
-        Account_Take_3: "Account_Take_3";
-        Account_Take_4: "Account_Take_4";
-        Account_Take_5: "Account_Take_5";
-        Account_Take_6: "Account_Take_6";
-        Account_Take_7: "Account_Take_7";
-        Accountant: "Accountant";
-        Auditor: "Auditor";
-        Brand_Manager: "Brand_Manager";
-        Communications_Officer: "Communications_Officer";
-        Config_Equipment: "Config_Equipment";
-        Config_Starbase_Equipment: "Config_Starbase_Equipment";
-        Container_Take_1: "Container_Take_1";
-        Container_Take_2: "Container_Take_2";
-        Container_Take_3: "Container_Take_3";
-        Container_Take_4: "Container_Take_4";
-        Container_Take_5: "Container_Take_5";
-        Container_Take_6: "Container_Take_6";
-        Container_Take_7: "Container_Take_7";
-        Contract_Manager: "Contract_Manager";
-        Deliveries_Container_Take: "Deliveries_Container_Take";
-        Deliveries_Query: "Deliveries_Query";
-        Deliveries_Take: "Deliveries_Take";
-        Diplomat: "Diplomat";
-        Director: "Director";
-        Factory_Manager: "Factory_Manager";
-        Fitting_Manager: "Fitting_Manager";
-        Hangar_Query_1: "Hangar_Query_1";
-        Hangar_Query_2: "Hangar_Query_2";
-        Hangar_Query_3: "Hangar_Query_3";
-        Hangar_Query_4: "Hangar_Query_4";
-        Hangar_Query_5: "Hangar_Query_5";
-        Hangar_Query_6: "Hangar_Query_6";
-        Hangar_Query_7: "Hangar_Query_7";
-        Hangar_Take_1: "Hangar_Take_1";
-        Hangar_Take_2: "Hangar_Take_2";
-        Hangar_Take_3: "Hangar_Take_3";
-        Hangar_Take_4: "Hangar_Take_4";
-        Hangar_Take_5: "Hangar_Take_5";
-        Hangar_Take_6: "Hangar_Take_6";
-        Hangar_Take_7: "Hangar_Take_7";
-        Junior_Accountant: "Junior_Accountant";
-        Personnel_Manager: "Personnel_Manager";
-        Project_Manager: "Project_Manager";
-        Rent_Factory_Facility: "Rent_Factory_Facility";
-        Rent_Office: "Rent_Office";
-        Rent_Research_Facility: "Rent_Research_Facility";
-        Security_Officer: "Security_Officer";
-        Skill_Plan_Manager: "Skill_Plan_Manager";
-        Starbase_Defense_Operator: "Starbase_Defense_Operator";
-        Starbase_Fuel_Technician: "Starbase_Fuel_Technician";
-        Station_Manager: "Station_Manager";
-        Trader: "Trader";
-    }>>>;
-    roles_at_other: z.ZodOptional<z.ZodArray<z.ZodEnum<{
-        Account_Take_1: "Account_Take_1";
-        Account_Take_2: "Account_Take_2";
-        Account_Take_3: "Account_Take_3";
-        Account_Take_4: "Account_Take_4";
-        Account_Take_5: "Account_Take_5";
-        Account_Take_6: "Account_Take_6";
-        Account_Take_7: "Account_Take_7";
-        Accountant: "Accountant";
-        Auditor: "Auditor";
-        Brand_Manager: "Brand_Manager";
-        Communications_Officer: "Communications_Officer";
-        Config_Equipment: "Config_Equipment";
-        Config_Starbase_Equipment: "Config_Starbase_Equipment";
-        Container_Take_1: "Container_Take_1";
-        Container_Take_2: "Container_Take_2";
-        Container_Take_3: "Container_Take_3";
-        Container_Take_4: "Container_Take_4";
-        Container_Take_5: "Container_Take_5";
-        Container_Take_6: "Container_Take_6";
-        Container_Take_7: "Container_Take_7";
-        Contract_Manager: "Contract_Manager";
-        Deliveries_Container_Take: "Deliveries_Container_Take";
-        Deliveries_Query: "Deliveries_Query";
-        Deliveries_Take: "Deliveries_Take";
-        Diplomat: "Diplomat";
-        Director: "Director";
-        Factory_Manager: "Factory_Manager";
-        Fitting_Manager: "Fitting_Manager";
-        Hangar_Query_1: "Hangar_Query_1";
-        Hangar_Query_2: "Hangar_Query_2";
-        Hangar_Query_3: "Hangar_Query_3";
-        Hangar_Query_4: "Hangar_Query_4";
-        Hangar_Query_5: "Hangar_Query_5";
-        Hangar_Query_6: "Hangar_Query_6";
-        Hangar_Query_7: "Hangar_Query_7";
-        Hangar_Take_1: "Hangar_Take_1";
-        Hangar_Take_2: "Hangar_Take_2";
-        Hangar_Take_3: "Hangar_Take_3";
-        Hangar_Take_4: "Hangar_Take_4";
-        Hangar_Take_5: "Hangar_Take_5";
-        Hangar_Take_6: "Hangar_Take_6";
-        Hangar_Take_7: "Hangar_Take_7";
-        Junior_Accountant: "Junior_Accountant";
-        Personnel_Manager: "Personnel_Manager";
-        Project_Manager: "Project_Manager";
-        Rent_Factory_Facility: "Rent_Factory_Facility";
-        Rent_Office: "Rent_Office";
-        Rent_Research_Facility: "Rent_Research_Facility";
-        Security_Officer: "Security_Officer";
-        Skill_Plan_Manager: "Skill_Plan_Manager";
-        Starbase_Defense_Operator: "Starbase_Defense_Operator";
-        Starbase_Fuel_Technician: "Starbase_Fuel_Technician";
-        Station_Manager: "Station_Manager";
-        Trader: "Trader";
-    }>>>;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface CorporationsCorporationIdRolesHistoryGet {
     // (undocumented)
     changed_at: string;
@@ -5965,135 +3006,6 @@ interface CorporationsCorporationIdRolesHistoryGet {
 }
 
 // @public (undocumented)
-const CorporationsCorporationIdRolesHistoryGetSchema: z.ZodObject<{
-    changed_at: z.ZodString;
-    character_id: z.ZodNumber;
-    issuer_id: z.ZodNumber;
-    new_roles: z.ZodArray<z.ZodEnum<{
-        Account_Take_1: "Account_Take_1";
-        Account_Take_2: "Account_Take_2";
-        Account_Take_3: "Account_Take_3";
-        Account_Take_4: "Account_Take_4";
-        Account_Take_5: "Account_Take_5";
-        Account_Take_6: "Account_Take_6";
-        Account_Take_7: "Account_Take_7";
-        Accountant: "Accountant";
-        Auditor: "Auditor";
-        Brand_Manager: "Brand_Manager";
-        Communications_Officer: "Communications_Officer";
-        Config_Equipment: "Config_Equipment";
-        Config_Starbase_Equipment: "Config_Starbase_Equipment";
-        Container_Take_1: "Container_Take_1";
-        Container_Take_2: "Container_Take_2";
-        Container_Take_3: "Container_Take_3";
-        Container_Take_4: "Container_Take_4";
-        Container_Take_5: "Container_Take_5";
-        Container_Take_6: "Container_Take_6";
-        Container_Take_7: "Container_Take_7";
-        Contract_Manager: "Contract_Manager";
-        Deliveries_Container_Take: "Deliveries_Container_Take";
-        Deliveries_Query: "Deliveries_Query";
-        Deliveries_Take: "Deliveries_Take";
-        Diplomat: "Diplomat";
-        Director: "Director";
-        Factory_Manager: "Factory_Manager";
-        Fitting_Manager: "Fitting_Manager";
-        Hangar_Query_1: "Hangar_Query_1";
-        Hangar_Query_2: "Hangar_Query_2";
-        Hangar_Query_3: "Hangar_Query_3";
-        Hangar_Query_4: "Hangar_Query_4";
-        Hangar_Query_5: "Hangar_Query_5";
-        Hangar_Query_6: "Hangar_Query_6";
-        Hangar_Query_7: "Hangar_Query_7";
-        Hangar_Take_1: "Hangar_Take_1";
-        Hangar_Take_2: "Hangar_Take_2";
-        Hangar_Take_3: "Hangar_Take_3";
-        Hangar_Take_4: "Hangar_Take_4";
-        Hangar_Take_5: "Hangar_Take_5";
-        Hangar_Take_6: "Hangar_Take_6";
-        Hangar_Take_7: "Hangar_Take_7";
-        Junior_Accountant: "Junior_Accountant";
-        Personnel_Manager: "Personnel_Manager";
-        Project_Manager: "Project_Manager";
-        Rent_Factory_Facility: "Rent_Factory_Facility";
-        Rent_Office: "Rent_Office";
-        Rent_Research_Facility: "Rent_Research_Facility";
-        Security_Officer: "Security_Officer";
-        Skill_Plan_Manager: "Skill_Plan_Manager";
-        Starbase_Defense_Operator: "Starbase_Defense_Operator";
-        Starbase_Fuel_Technician: "Starbase_Fuel_Technician";
-        Station_Manager: "Station_Manager";
-        Trader: "Trader";
-    }>>;
-    old_roles: z.ZodArray<z.ZodEnum<{
-        Account_Take_1: "Account_Take_1";
-        Account_Take_2: "Account_Take_2";
-        Account_Take_3: "Account_Take_3";
-        Account_Take_4: "Account_Take_4";
-        Account_Take_5: "Account_Take_5";
-        Account_Take_6: "Account_Take_6";
-        Account_Take_7: "Account_Take_7";
-        Accountant: "Accountant";
-        Auditor: "Auditor";
-        Brand_Manager: "Brand_Manager";
-        Communications_Officer: "Communications_Officer";
-        Config_Equipment: "Config_Equipment";
-        Config_Starbase_Equipment: "Config_Starbase_Equipment";
-        Container_Take_1: "Container_Take_1";
-        Container_Take_2: "Container_Take_2";
-        Container_Take_3: "Container_Take_3";
-        Container_Take_4: "Container_Take_4";
-        Container_Take_5: "Container_Take_5";
-        Container_Take_6: "Container_Take_6";
-        Container_Take_7: "Container_Take_7";
-        Contract_Manager: "Contract_Manager";
-        Deliveries_Container_Take: "Deliveries_Container_Take";
-        Deliveries_Query: "Deliveries_Query";
-        Deliveries_Take: "Deliveries_Take";
-        Diplomat: "Diplomat";
-        Director: "Director";
-        Factory_Manager: "Factory_Manager";
-        Fitting_Manager: "Fitting_Manager";
-        Hangar_Query_1: "Hangar_Query_1";
-        Hangar_Query_2: "Hangar_Query_2";
-        Hangar_Query_3: "Hangar_Query_3";
-        Hangar_Query_4: "Hangar_Query_4";
-        Hangar_Query_5: "Hangar_Query_5";
-        Hangar_Query_6: "Hangar_Query_6";
-        Hangar_Query_7: "Hangar_Query_7";
-        Hangar_Take_1: "Hangar_Take_1";
-        Hangar_Take_2: "Hangar_Take_2";
-        Hangar_Take_3: "Hangar_Take_3";
-        Hangar_Take_4: "Hangar_Take_4";
-        Hangar_Take_5: "Hangar_Take_5";
-        Hangar_Take_6: "Hangar_Take_6";
-        Hangar_Take_7: "Hangar_Take_7";
-        Junior_Accountant: "Junior_Accountant";
-        Personnel_Manager: "Personnel_Manager";
-        Project_Manager: "Project_Manager";
-        Rent_Factory_Facility: "Rent_Factory_Facility";
-        Rent_Office: "Rent_Office";
-        Rent_Research_Facility: "Rent_Research_Facility";
-        Security_Officer: "Security_Officer";
-        Skill_Plan_Manager: "Skill_Plan_Manager";
-        Starbase_Defense_Operator: "Starbase_Defense_Operator";
-        Starbase_Fuel_Technician: "Starbase_Fuel_Technician";
-        Station_Manager: "Station_Manager";
-        Trader: "Trader";
-    }>>;
-    role_type: z.ZodEnum<{
-        roles: "roles";
-        roles_at_hq: "roles_at_hq";
-        roles_at_base: "roles_at_base";
-        roles_at_other: "roles_at_other";
-        grantable_roles: "grantable_roles";
-        grantable_roles_at_hq: "grantable_roles_at_hq";
-        grantable_roles_at_base: "grantable_roles_at_base";
-        grantable_roles_at_other: "grantable_roles_at_other";
-    }>;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface CorporationsCorporationIdShareholdersGet {
     // (undocumented)
     share_count: number;
@@ -6104,16 +3016,6 @@ interface CorporationsCorporationIdShareholdersGet {
 }
 
 // @public (undocumented)
-const CorporationsCorporationIdShareholdersGetSchema: z.ZodObject<{
-    share_count: z.ZodNumber;
-    shareholder_id: z.ZodNumber;
-    shareholder_type: z.ZodEnum<{
-        character: "character";
-        corporation: "corporation";
-    }>;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface CorporationsCorporationIdStandingsGet {
     // (undocumented)
     from_id: number;
@@ -6122,17 +3024,6 @@ interface CorporationsCorporationIdStandingsGet {
     // (undocumented)
     standing: number;
 }
-
-// @public (undocumented)
-const CorporationsCorporationIdStandingsGetSchema: z.ZodObject<{
-    from_id: z.ZodNumber;
-    from_type: z.ZodEnum<{
-        agent: "agent";
-        npc_corp: "npc_corp";
-        faction: "faction";
-    }>;
-    standing: z.ZodNumber;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface CorporationsCorporationIdStarbasesGet {
@@ -6153,24 +3044,6 @@ interface CorporationsCorporationIdStarbasesGet {
     // (undocumented)
     unanchor_at?: string;
 }
-
-// @public (undocumented)
-const CorporationsCorporationIdStarbasesGetSchema: z.ZodObject<{
-    moon_id: z.ZodOptional<z.ZodNumber>;
-    onlined_since: z.ZodOptional<z.ZodString>;
-    reinforced_until: z.ZodOptional<z.ZodString>;
-    starbase_id: z.ZodNumber;
-    state: z.ZodOptional<z.ZodEnum<{
-        offline: "offline";
-        online: "online";
-        onlining: "onlining";
-        reinforced: "reinforced";
-        unanchoring: "unanchoring";
-    }>>;
-    system_id: z.ZodNumber;
-    type_id: z.ZodNumber;
-    unanchor_at: z.ZodOptional<z.ZodString>;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface CorporationsCorporationIdStarbasesStarbaseIdGet {
@@ -6206,57 +3079,6 @@ interface CorporationsCorporationIdStarbasesStarbaseIdGet {
     // (undocumented)
     use_alliance_standings: boolean;
 }
-
-// @public (undocumented)
-const CorporationsCorporationIdStarbasesStarbaseIdGetSchema: z.ZodObject<{
-    allow_alliance_members: z.ZodBoolean;
-    allow_corporation_members: z.ZodBoolean;
-    anchor: z.ZodEnum<{
-        alliance_member: "alliance_member";
-        config_starbase_equipment_role: "config_starbase_equipment_role";
-        corporation_member: "corporation_member";
-        starbase_fuel_technician_role: "starbase_fuel_technician_role";
-    }>;
-    attack_if_at_war: z.ZodBoolean;
-    attack_if_other_security_status_dropping: z.ZodBoolean;
-    attack_security_status_threshold: z.ZodOptional<z.ZodNumber>;
-    attack_standing_threshold: z.ZodOptional<z.ZodNumber>;
-    fuel_bay_take: z.ZodEnum<{
-        alliance_member: "alliance_member";
-        config_starbase_equipment_role: "config_starbase_equipment_role";
-        corporation_member: "corporation_member";
-        starbase_fuel_technician_role: "starbase_fuel_technician_role";
-    }>;
-    fuel_bay_view: z.ZodEnum<{
-        alliance_member: "alliance_member";
-        config_starbase_equipment_role: "config_starbase_equipment_role";
-        corporation_member: "corporation_member";
-        starbase_fuel_technician_role: "starbase_fuel_technician_role";
-    }>;
-    fuels: z.ZodOptional<z.ZodArray<z.ZodObject<{
-        quantity: z.ZodNumber;
-        type_id: z.ZodNumber;
-    }, z.core.$loose>>>;
-    offline: z.ZodEnum<{
-        alliance_member: "alliance_member";
-        config_starbase_equipment_role: "config_starbase_equipment_role";
-        corporation_member: "corporation_member";
-        starbase_fuel_technician_role: "starbase_fuel_technician_role";
-    }>;
-    online: z.ZodEnum<{
-        alliance_member: "alliance_member";
-        config_starbase_equipment_role: "config_starbase_equipment_role";
-        corporation_member: "corporation_member";
-        starbase_fuel_technician_role: "starbase_fuel_technician_role";
-    }>;
-    unanchor: z.ZodEnum<{
-        alliance_member: "alliance_member";
-        config_starbase_equipment_role: "config_starbase_equipment_role";
-        corporation_member: "corporation_member";
-        starbase_fuel_technician_role: "starbase_fuel_technician_role";
-    }>;
-    use_alliance_standings: z.ZodBoolean;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface CorporationsCorporationIdStructuresGet {
@@ -6296,46 +3118,6 @@ interface CorporationsCorporationIdStructuresGet {
 }
 
 // @public (undocumented)
-const CorporationsCorporationIdStructuresGetSchema: z.ZodObject<{
-    corporation_id: z.ZodNumber;
-    fuel_expires: z.ZodOptional<z.ZodString>;
-    name: z.ZodOptional<z.ZodString>;
-    next_reinforce_apply: z.ZodOptional<z.ZodString>;
-    next_reinforce_hour: z.ZodOptional<z.ZodNumber>;
-    profile_id: z.ZodNumber;
-    reinforce_hour: z.ZodOptional<z.ZodNumber>;
-    services: z.ZodOptional<z.ZodArray<z.ZodObject<{
-        name: z.ZodString;
-        state: z.ZodEnum<{
-            offline: "offline";
-            online: "online";
-            cleanup: "cleanup";
-        }>;
-    }, z.core.$loose>>>;
-    state: z.ZodEnum<{
-        unknown: "unknown";
-        anchor_vulnerable: "anchor_vulnerable";
-        anchoring: "anchoring";
-        armor_reinforce: "armor_reinforce";
-        armor_vulnerable: "armor_vulnerable";
-        deploy_vulnerable: "deploy_vulnerable";
-        fitting_invulnerable: "fitting_invulnerable";
-        hull_reinforce: "hull_reinforce";
-        hull_vulnerable: "hull_vulnerable";
-        online_deprecated: "online_deprecated";
-        onlining_vulnerable: "onlining_vulnerable";
-        shield_vulnerable: "shield_vulnerable";
-        unanchored: "unanchored";
-    }>;
-    state_timer_end: z.ZodOptional<z.ZodString>;
-    state_timer_start: z.ZodOptional<z.ZodString>;
-    structure_id: z.ZodNumber;
-    system_id: z.ZodNumber;
-    type_id: z.ZodNumber;
-    unanchors_at: z.ZodOptional<z.ZodString>;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface CorporationsCorporationIdTitlesGet {
     // (undocumented)
     grantable_roles?: 'Account_Take_1' | 'Account_Take_2' | 'Account_Take_3' | 'Account_Take_4' | 'Account_Take_5' | 'Account_Take_6' | 'Account_Take_7' | 'Accountant' | 'Auditor' | 'Brand_Manager' | 'Communications_Officer' | 'Config_Equipment' | 'Config_Starbase_Equipment' | 'Container_Take_1' | 'Container_Take_2' | 'Container_Take_3' | 'Container_Take_4' | 'Container_Take_5' | 'Container_Take_6' | 'Container_Take_7' | 'Contract_Manager' | 'Deliveries_Container_Take' | 'Deliveries_Query' | 'Deliveries_Take' | 'Diplomat' | 'Director' | 'Factory_Manager' | 'Fitting_Manager' | 'Hangar_Query_1' | 'Hangar_Query_2' | 'Hangar_Query_3' | 'Hangar_Query_4' | 'Hangar_Query_5' | 'Hangar_Query_6' | 'Hangar_Query_7' | 'Hangar_Take_1' | 'Hangar_Take_2' | 'Hangar_Take_3' | 'Hangar_Take_4' | 'Hangar_Take_5' | 'Hangar_Take_6' | 'Hangar_Take_7' | 'Junior_Accountant' | 'Personnel_Manager' | 'Project_Manager' | 'Rent_Factory_Facility' | 'Rent_Office' | 'Rent_Research_Facility' | 'Security_Officer' | 'Skill_Plan_Manager' | 'Starbase_Defense_Operator' | 'Starbase_Fuel_Technician' | 'Station_Manager' | 'Trader'[];
@@ -6358,460 +3140,6 @@ interface CorporationsCorporationIdTitlesGet {
     // (undocumented)
     title_id?: number;
 }
-
-// @public (undocumented)
-const CorporationsCorporationIdTitlesGetSchema: z.ZodObject<{
-    grantable_roles: z.ZodOptional<z.ZodArray<z.ZodEnum<{
-        Account_Take_1: "Account_Take_1";
-        Account_Take_2: "Account_Take_2";
-        Account_Take_3: "Account_Take_3";
-        Account_Take_4: "Account_Take_4";
-        Account_Take_5: "Account_Take_5";
-        Account_Take_6: "Account_Take_6";
-        Account_Take_7: "Account_Take_7";
-        Accountant: "Accountant";
-        Auditor: "Auditor";
-        Brand_Manager: "Brand_Manager";
-        Communications_Officer: "Communications_Officer";
-        Config_Equipment: "Config_Equipment";
-        Config_Starbase_Equipment: "Config_Starbase_Equipment";
-        Container_Take_1: "Container_Take_1";
-        Container_Take_2: "Container_Take_2";
-        Container_Take_3: "Container_Take_3";
-        Container_Take_4: "Container_Take_4";
-        Container_Take_5: "Container_Take_5";
-        Container_Take_6: "Container_Take_6";
-        Container_Take_7: "Container_Take_7";
-        Contract_Manager: "Contract_Manager";
-        Deliveries_Container_Take: "Deliveries_Container_Take";
-        Deliveries_Query: "Deliveries_Query";
-        Deliveries_Take: "Deliveries_Take";
-        Diplomat: "Diplomat";
-        Director: "Director";
-        Factory_Manager: "Factory_Manager";
-        Fitting_Manager: "Fitting_Manager";
-        Hangar_Query_1: "Hangar_Query_1";
-        Hangar_Query_2: "Hangar_Query_2";
-        Hangar_Query_3: "Hangar_Query_3";
-        Hangar_Query_4: "Hangar_Query_4";
-        Hangar_Query_5: "Hangar_Query_5";
-        Hangar_Query_6: "Hangar_Query_6";
-        Hangar_Query_7: "Hangar_Query_7";
-        Hangar_Take_1: "Hangar_Take_1";
-        Hangar_Take_2: "Hangar_Take_2";
-        Hangar_Take_3: "Hangar_Take_3";
-        Hangar_Take_4: "Hangar_Take_4";
-        Hangar_Take_5: "Hangar_Take_5";
-        Hangar_Take_6: "Hangar_Take_6";
-        Hangar_Take_7: "Hangar_Take_7";
-        Junior_Accountant: "Junior_Accountant";
-        Personnel_Manager: "Personnel_Manager";
-        Project_Manager: "Project_Manager";
-        Rent_Factory_Facility: "Rent_Factory_Facility";
-        Rent_Office: "Rent_Office";
-        Rent_Research_Facility: "Rent_Research_Facility";
-        Security_Officer: "Security_Officer";
-        Skill_Plan_Manager: "Skill_Plan_Manager";
-        Starbase_Defense_Operator: "Starbase_Defense_Operator";
-        Starbase_Fuel_Technician: "Starbase_Fuel_Technician";
-        Station_Manager: "Station_Manager";
-        Trader: "Trader";
-    }>>>;
-    grantable_roles_at_base: z.ZodOptional<z.ZodArray<z.ZodEnum<{
-        Account_Take_1: "Account_Take_1";
-        Account_Take_2: "Account_Take_2";
-        Account_Take_3: "Account_Take_3";
-        Account_Take_4: "Account_Take_4";
-        Account_Take_5: "Account_Take_5";
-        Account_Take_6: "Account_Take_6";
-        Account_Take_7: "Account_Take_7";
-        Accountant: "Accountant";
-        Auditor: "Auditor";
-        Brand_Manager: "Brand_Manager";
-        Communications_Officer: "Communications_Officer";
-        Config_Equipment: "Config_Equipment";
-        Config_Starbase_Equipment: "Config_Starbase_Equipment";
-        Container_Take_1: "Container_Take_1";
-        Container_Take_2: "Container_Take_2";
-        Container_Take_3: "Container_Take_3";
-        Container_Take_4: "Container_Take_4";
-        Container_Take_5: "Container_Take_5";
-        Container_Take_6: "Container_Take_6";
-        Container_Take_7: "Container_Take_7";
-        Contract_Manager: "Contract_Manager";
-        Deliveries_Container_Take: "Deliveries_Container_Take";
-        Deliveries_Query: "Deliveries_Query";
-        Deliveries_Take: "Deliveries_Take";
-        Diplomat: "Diplomat";
-        Director: "Director";
-        Factory_Manager: "Factory_Manager";
-        Fitting_Manager: "Fitting_Manager";
-        Hangar_Query_1: "Hangar_Query_1";
-        Hangar_Query_2: "Hangar_Query_2";
-        Hangar_Query_3: "Hangar_Query_3";
-        Hangar_Query_4: "Hangar_Query_4";
-        Hangar_Query_5: "Hangar_Query_5";
-        Hangar_Query_6: "Hangar_Query_6";
-        Hangar_Query_7: "Hangar_Query_7";
-        Hangar_Take_1: "Hangar_Take_1";
-        Hangar_Take_2: "Hangar_Take_2";
-        Hangar_Take_3: "Hangar_Take_3";
-        Hangar_Take_4: "Hangar_Take_4";
-        Hangar_Take_5: "Hangar_Take_5";
-        Hangar_Take_6: "Hangar_Take_6";
-        Hangar_Take_7: "Hangar_Take_7";
-        Junior_Accountant: "Junior_Accountant";
-        Personnel_Manager: "Personnel_Manager";
-        Project_Manager: "Project_Manager";
-        Rent_Factory_Facility: "Rent_Factory_Facility";
-        Rent_Office: "Rent_Office";
-        Rent_Research_Facility: "Rent_Research_Facility";
-        Security_Officer: "Security_Officer";
-        Skill_Plan_Manager: "Skill_Plan_Manager";
-        Starbase_Defense_Operator: "Starbase_Defense_Operator";
-        Starbase_Fuel_Technician: "Starbase_Fuel_Technician";
-        Station_Manager: "Station_Manager";
-        Trader: "Trader";
-    }>>>;
-    grantable_roles_at_hq: z.ZodOptional<z.ZodArray<z.ZodEnum<{
-        Account_Take_1: "Account_Take_1";
-        Account_Take_2: "Account_Take_2";
-        Account_Take_3: "Account_Take_3";
-        Account_Take_4: "Account_Take_4";
-        Account_Take_5: "Account_Take_5";
-        Account_Take_6: "Account_Take_6";
-        Account_Take_7: "Account_Take_7";
-        Accountant: "Accountant";
-        Auditor: "Auditor";
-        Brand_Manager: "Brand_Manager";
-        Communications_Officer: "Communications_Officer";
-        Config_Equipment: "Config_Equipment";
-        Config_Starbase_Equipment: "Config_Starbase_Equipment";
-        Container_Take_1: "Container_Take_1";
-        Container_Take_2: "Container_Take_2";
-        Container_Take_3: "Container_Take_3";
-        Container_Take_4: "Container_Take_4";
-        Container_Take_5: "Container_Take_5";
-        Container_Take_6: "Container_Take_6";
-        Container_Take_7: "Container_Take_7";
-        Contract_Manager: "Contract_Manager";
-        Deliveries_Container_Take: "Deliveries_Container_Take";
-        Deliveries_Query: "Deliveries_Query";
-        Deliveries_Take: "Deliveries_Take";
-        Diplomat: "Diplomat";
-        Director: "Director";
-        Factory_Manager: "Factory_Manager";
-        Fitting_Manager: "Fitting_Manager";
-        Hangar_Query_1: "Hangar_Query_1";
-        Hangar_Query_2: "Hangar_Query_2";
-        Hangar_Query_3: "Hangar_Query_3";
-        Hangar_Query_4: "Hangar_Query_4";
-        Hangar_Query_5: "Hangar_Query_5";
-        Hangar_Query_6: "Hangar_Query_6";
-        Hangar_Query_7: "Hangar_Query_7";
-        Hangar_Take_1: "Hangar_Take_1";
-        Hangar_Take_2: "Hangar_Take_2";
-        Hangar_Take_3: "Hangar_Take_3";
-        Hangar_Take_4: "Hangar_Take_4";
-        Hangar_Take_5: "Hangar_Take_5";
-        Hangar_Take_6: "Hangar_Take_6";
-        Hangar_Take_7: "Hangar_Take_7";
-        Junior_Accountant: "Junior_Accountant";
-        Personnel_Manager: "Personnel_Manager";
-        Project_Manager: "Project_Manager";
-        Rent_Factory_Facility: "Rent_Factory_Facility";
-        Rent_Office: "Rent_Office";
-        Rent_Research_Facility: "Rent_Research_Facility";
-        Security_Officer: "Security_Officer";
-        Skill_Plan_Manager: "Skill_Plan_Manager";
-        Starbase_Defense_Operator: "Starbase_Defense_Operator";
-        Starbase_Fuel_Technician: "Starbase_Fuel_Technician";
-        Station_Manager: "Station_Manager";
-        Trader: "Trader";
-    }>>>;
-    grantable_roles_at_other: z.ZodOptional<z.ZodArray<z.ZodEnum<{
-        Account_Take_1: "Account_Take_1";
-        Account_Take_2: "Account_Take_2";
-        Account_Take_3: "Account_Take_3";
-        Account_Take_4: "Account_Take_4";
-        Account_Take_5: "Account_Take_5";
-        Account_Take_6: "Account_Take_6";
-        Account_Take_7: "Account_Take_7";
-        Accountant: "Accountant";
-        Auditor: "Auditor";
-        Brand_Manager: "Brand_Manager";
-        Communications_Officer: "Communications_Officer";
-        Config_Equipment: "Config_Equipment";
-        Config_Starbase_Equipment: "Config_Starbase_Equipment";
-        Container_Take_1: "Container_Take_1";
-        Container_Take_2: "Container_Take_2";
-        Container_Take_3: "Container_Take_3";
-        Container_Take_4: "Container_Take_4";
-        Container_Take_5: "Container_Take_5";
-        Container_Take_6: "Container_Take_6";
-        Container_Take_7: "Container_Take_7";
-        Contract_Manager: "Contract_Manager";
-        Deliveries_Container_Take: "Deliveries_Container_Take";
-        Deliveries_Query: "Deliveries_Query";
-        Deliveries_Take: "Deliveries_Take";
-        Diplomat: "Diplomat";
-        Director: "Director";
-        Factory_Manager: "Factory_Manager";
-        Fitting_Manager: "Fitting_Manager";
-        Hangar_Query_1: "Hangar_Query_1";
-        Hangar_Query_2: "Hangar_Query_2";
-        Hangar_Query_3: "Hangar_Query_3";
-        Hangar_Query_4: "Hangar_Query_4";
-        Hangar_Query_5: "Hangar_Query_5";
-        Hangar_Query_6: "Hangar_Query_6";
-        Hangar_Query_7: "Hangar_Query_7";
-        Hangar_Take_1: "Hangar_Take_1";
-        Hangar_Take_2: "Hangar_Take_2";
-        Hangar_Take_3: "Hangar_Take_3";
-        Hangar_Take_4: "Hangar_Take_4";
-        Hangar_Take_5: "Hangar_Take_5";
-        Hangar_Take_6: "Hangar_Take_6";
-        Hangar_Take_7: "Hangar_Take_7";
-        Junior_Accountant: "Junior_Accountant";
-        Personnel_Manager: "Personnel_Manager";
-        Project_Manager: "Project_Manager";
-        Rent_Factory_Facility: "Rent_Factory_Facility";
-        Rent_Office: "Rent_Office";
-        Rent_Research_Facility: "Rent_Research_Facility";
-        Security_Officer: "Security_Officer";
-        Skill_Plan_Manager: "Skill_Plan_Manager";
-        Starbase_Defense_Operator: "Starbase_Defense_Operator";
-        Starbase_Fuel_Technician: "Starbase_Fuel_Technician";
-        Station_Manager: "Station_Manager";
-        Trader: "Trader";
-    }>>>;
-    name: z.ZodOptional<z.ZodString>;
-    roles: z.ZodOptional<z.ZodArray<z.ZodEnum<{
-        Account_Take_1: "Account_Take_1";
-        Account_Take_2: "Account_Take_2";
-        Account_Take_3: "Account_Take_3";
-        Account_Take_4: "Account_Take_4";
-        Account_Take_5: "Account_Take_5";
-        Account_Take_6: "Account_Take_6";
-        Account_Take_7: "Account_Take_7";
-        Accountant: "Accountant";
-        Auditor: "Auditor";
-        Brand_Manager: "Brand_Manager";
-        Communications_Officer: "Communications_Officer";
-        Config_Equipment: "Config_Equipment";
-        Config_Starbase_Equipment: "Config_Starbase_Equipment";
-        Container_Take_1: "Container_Take_1";
-        Container_Take_2: "Container_Take_2";
-        Container_Take_3: "Container_Take_3";
-        Container_Take_4: "Container_Take_4";
-        Container_Take_5: "Container_Take_5";
-        Container_Take_6: "Container_Take_6";
-        Container_Take_7: "Container_Take_7";
-        Contract_Manager: "Contract_Manager";
-        Deliveries_Container_Take: "Deliveries_Container_Take";
-        Deliveries_Query: "Deliveries_Query";
-        Deliveries_Take: "Deliveries_Take";
-        Diplomat: "Diplomat";
-        Director: "Director";
-        Factory_Manager: "Factory_Manager";
-        Fitting_Manager: "Fitting_Manager";
-        Hangar_Query_1: "Hangar_Query_1";
-        Hangar_Query_2: "Hangar_Query_2";
-        Hangar_Query_3: "Hangar_Query_3";
-        Hangar_Query_4: "Hangar_Query_4";
-        Hangar_Query_5: "Hangar_Query_5";
-        Hangar_Query_6: "Hangar_Query_6";
-        Hangar_Query_7: "Hangar_Query_7";
-        Hangar_Take_1: "Hangar_Take_1";
-        Hangar_Take_2: "Hangar_Take_2";
-        Hangar_Take_3: "Hangar_Take_3";
-        Hangar_Take_4: "Hangar_Take_4";
-        Hangar_Take_5: "Hangar_Take_5";
-        Hangar_Take_6: "Hangar_Take_6";
-        Hangar_Take_7: "Hangar_Take_7";
-        Junior_Accountant: "Junior_Accountant";
-        Personnel_Manager: "Personnel_Manager";
-        Project_Manager: "Project_Manager";
-        Rent_Factory_Facility: "Rent_Factory_Facility";
-        Rent_Office: "Rent_Office";
-        Rent_Research_Facility: "Rent_Research_Facility";
-        Security_Officer: "Security_Officer";
-        Skill_Plan_Manager: "Skill_Plan_Manager";
-        Starbase_Defense_Operator: "Starbase_Defense_Operator";
-        Starbase_Fuel_Technician: "Starbase_Fuel_Technician";
-        Station_Manager: "Station_Manager";
-        Trader: "Trader";
-    }>>>;
-    roles_at_base: z.ZodOptional<z.ZodArray<z.ZodEnum<{
-        Account_Take_1: "Account_Take_1";
-        Account_Take_2: "Account_Take_2";
-        Account_Take_3: "Account_Take_3";
-        Account_Take_4: "Account_Take_4";
-        Account_Take_5: "Account_Take_5";
-        Account_Take_6: "Account_Take_6";
-        Account_Take_7: "Account_Take_7";
-        Accountant: "Accountant";
-        Auditor: "Auditor";
-        Brand_Manager: "Brand_Manager";
-        Communications_Officer: "Communications_Officer";
-        Config_Equipment: "Config_Equipment";
-        Config_Starbase_Equipment: "Config_Starbase_Equipment";
-        Container_Take_1: "Container_Take_1";
-        Container_Take_2: "Container_Take_2";
-        Container_Take_3: "Container_Take_3";
-        Container_Take_4: "Container_Take_4";
-        Container_Take_5: "Container_Take_5";
-        Container_Take_6: "Container_Take_6";
-        Container_Take_7: "Container_Take_7";
-        Contract_Manager: "Contract_Manager";
-        Deliveries_Container_Take: "Deliveries_Container_Take";
-        Deliveries_Query: "Deliveries_Query";
-        Deliveries_Take: "Deliveries_Take";
-        Diplomat: "Diplomat";
-        Director: "Director";
-        Factory_Manager: "Factory_Manager";
-        Fitting_Manager: "Fitting_Manager";
-        Hangar_Query_1: "Hangar_Query_1";
-        Hangar_Query_2: "Hangar_Query_2";
-        Hangar_Query_3: "Hangar_Query_3";
-        Hangar_Query_4: "Hangar_Query_4";
-        Hangar_Query_5: "Hangar_Query_5";
-        Hangar_Query_6: "Hangar_Query_6";
-        Hangar_Query_7: "Hangar_Query_7";
-        Hangar_Take_1: "Hangar_Take_1";
-        Hangar_Take_2: "Hangar_Take_2";
-        Hangar_Take_3: "Hangar_Take_3";
-        Hangar_Take_4: "Hangar_Take_4";
-        Hangar_Take_5: "Hangar_Take_5";
-        Hangar_Take_6: "Hangar_Take_6";
-        Hangar_Take_7: "Hangar_Take_7";
-        Junior_Accountant: "Junior_Accountant";
-        Personnel_Manager: "Personnel_Manager";
-        Project_Manager: "Project_Manager";
-        Rent_Factory_Facility: "Rent_Factory_Facility";
-        Rent_Office: "Rent_Office";
-        Rent_Research_Facility: "Rent_Research_Facility";
-        Security_Officer: "Security_Officer";
-        Skill_Plan_Manager: "Skill_Plan_Manager";
-        Starbase_Defense_Operator: "Starbase_Defense_Operator";
-        Starbase_Fuel_Technician: "Starbase_Fuel_Technician";
-        Station_Manager: "Station_Manager";
-        Trader: "Trader";
-    }>>>;
-    roles_at_hq: z.ZodOptional<z.ZodArray<z.ZodEnum<{
-        Account_Take_1: "Account_Take_1";
-        Account_Take_2: "Account_Take_2";
-        Account_Take_3: "Account_Take_3";
-        Account_Take_4: "Account_Take_4";
-        Account_Take_5: "Account_Take_5";
-        Account_Take_6: "Account_Take_6";
-        Account_Take_7: "Account_Take_7";
-        Accountant: "Accountant";
-        Auditor: "Auditor";
-        Brand_Manager: "Brand_Manager";
-        Communications_Officer: "Communications_Officer";
-        Config_Equipment: "Config_Equipment";
-        Config_Starbase_Equipment: "Config_Starbase_Equipment";
-        Container_Take_1: "Container_Take_1";
-        Container_Take_2: "Container_Take_2";
-        Container_Take_3: "Container_Take_3";
-        Container_Take_4: "Container_Take_4";
-        Container_Take_5: "Container_Take_5";
-        Container_Take_6: "Container_Take_6";
-        Container_Take_7: "Container_Take_7";
-        Contract_Manager: "Contract_Manager";
-        Deliveries_Container_Take: "Deliveries_Container_Take";
-        Deliveries_Query: "Deliveries_Query";
-        Deliveries_Take: "Deliveries_Take";
-        Diplomat: "Diplomat";
-        Director: "Director";
-        Factory_Manager: "Factory_Manager";
-        Fitting_Manager: "Fitting_Manager";
-        Hangar_Query_1: "Hangar_Query_1";
-        Hangar_Query_2: "Hangar_Query_2";
-        Hangar_Query_3: "Hangar_Query_3";
-        Hangar_Query_4: "Hangar_Query_4";
-        Hangar_Query_5: "Hangar_Query_5";
-        Hangar_Query_6: "Hangar_Query_6";
-        Hangar_Query_7: "Hangar_Query_7";
-        Hangar_Take_1: "Hangar_Take_1";
-        Hangar_Take_2: "Hangar_Take_2";
-        Hangar_Take_3: "Hangar_Take_3";
-        Hangar_Take_4: "Hangar_Take_4";
-        Hangar_Take_5: "Hangar_Take_5";
-        Hangar_Take_6: "Hangar_Take_6";
-        Hangar_Take_7: "Hangar_Take_7";
-        Junior_Accountant: "Junior_Accountant";
-        Personnel_Manager: "Personnel_Manager";
-        Project_Manager: "Project_Manager";
-        Rent_Factory_Facility: "Rent_Factory_Facility";
-        Rent_Office: "Rent_Office";
-        Rent_Research_Facility: "Rent_Research_Facility";
-        Security_Officer: "Security_Officer";
-        Skill_Plan_Manager: "Skill_Plan_Manager";
-        Starbase_Defense_Operator: "Starbase_Defense_Operator";
-        Starbase_Fuel_Technician: "Starbase_Fuel_Technician";
-        Station_Manager: "Station_Manager";
-        Trader: "Trader";
-    }>>>;
-    roles_at_other: z.ZodOptional<z.ZodArray<z.ZodEnum<{
-        Account_Take_1: "Account_Take_1";
-        Account_Take_2: "Account_Take_2";
-        Account_Take_3: "Account_Take_3";
-        Account_Take_4: "Account_Take_4";
-        Account_Take_5: "Account_Take_5";
-        Account_Take_6: "Account_Take_6";
-        Account_Take_7: "Account_Take_7";
-        Accountant: "Accountant";
-        Auditor: "Auditor";
-        Brand_Manager: "Brand_Manager";
-        Communications_Officer: "Communications_Officer";
-        Config_Equipment: "Config_Equipment";
-        Config_Starbase_Equipment: "Config_Starbase_Equipment";
-        Container_Take_1: "Container_Take_1";
-        Container_Take_2: "Container_Take_2";
-        Container_Take_3: "Container_Take_3";
-        Container_Take_4: "Container_Take_4";
-        Container_Take_5: "Container_Take_5";
-        Container_Take_6: "Container_Take_6";
-        Container_Take_7: "Container_Take_7";
-        Contract_Manager: "Contract_Manager";
-        Deliveries_Container_Take: "Deliveries_Container_Take";
-        Deliveries_Query: "Deliveries_Query";
-        Deliveries_Take: "Deliveries_Take";
-        Diplomat: "Diplomat";
-        Director: "Director";
-        Factory_Manager: "Factory_Manager";
-        Fitting_Manager: "Fitting_Manager";
-        Hangar_Query_1: "Hangar_Query_1";
-        Hangar_Query_2: "Hangar_Query_2";
-        Hangar_Query_3: "Hangar_Query_3";
-        Hangar_Query_4: "Hangar_Query_4";
-        Hangar_Query_5: "Hangar_Query_5";
-        Hangar_Query_6: "Hangar_Query_6";
-        Hangar_Query_7: "Hangar_Query_7";
-        Hangar_Take_1: "Hangar_Take_1";
-        Hangar_Take_2: "Hangar_Take_2";
-        Hangar_Take_3: "Hangar_Take_3";
-        Hangar_Take_4: "Hangar_Take_4";
-        Hangar_Take_5: "Hangar_Take_5";
-        Hangar_Take_6: "Hangar_Take_6";
-        Hangar_Take_7: "Hangar_Take_7";
-        Junior_Accountant: "Junior_Accountant";
-        Personnel_Manager: "Personnel_Manager";
-        Project_Manager: "Project_Manager";
-        Rent_Factory_Facility: "Rent_Factory_Facility";
-        Rent_Office: "Rent_Office";
-        Rent_Research_Facility: "Rent_Research_Facility";
-        Security_Officer: "Security_Officer";
-        Skill_Plan_Manager: "Skill_Plan_Manager";
-        Starbase_Defense_Operator: "Starbase_Defense_Operator";
-        Starbase_Fuel_Technician: "Starbase_Fuel_Technician";
-        Station_Manager: "Station_Manager";
-        Trader: "Trader";
-    }>>>;
-    title_id: z.ZodOptional<z.ZodNumber>;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface CorporationsCorporationIdWalletsDivisionJournalGet {
@@ -6844,199 +3172,6 @@ interface CorporationsCorporationIdWalletsDivisionJournalGet {
 }
 
 // @public (undocumented)
-const CorporationsCorporationIdWalletsDivisionJournalGetSchema: z.ZodObject<{
-    amount: z.ZodOptional<z.ZodNumber>;
-    balance: z.ZodOptional<z.ZodNumber>;
-    context_id: z.ZodOptional<z.ZodNumber>;
-    context_id_type: z.ZodOptional<z.ZodEnum<{
-        alliance_id: "alliance_id";
-        character_id: "character_id";
-        corporation_id: "corporation_id";
-        type_id: "type_id";
-        system_id: "system_id";
-        structure_id: "structure_id";
-        planet_id: "planet_id";
-        station_id: "station_id";
-        contract_id: "contract_id";
-        market_transaction_id: "market_transaction_id";
-        eve_system: "eve_system";
-        industry_job_id: "industry_job_id";
-    }>>;
-    date: z.ZodString;
-    description: z.ZodString;
-    first_party_id: z.ZodOptional<z.ZodNumber>;
-    id: z.ZodNumber;
-    reason: z.ZodOptional<z.ZodString>;
-    ref_type: z.ZodEnum<{
-        shares: "shares";
-        copying: "copying";
-        manufacturing: "manufacturing";
-        reaction: "reaction";
-        researching_technology: "researching_technology";
-        reverse_engineering: "reverse_engineering";
-        insurance: "insurance";
-        acceleration_gate_fee: "acceleration_gate_fee";
-        achievement_category_milestone_reward: "achievement_category_milestone_reward";
-        achievement_milestone_reward: "achievement_milestone_reward";
-        advertisement_listing_fee: "advertisement_listing_fee";
-        agent_donation: "agent_donation";
-        agent_location_services: "agent_location_services";
-        agent_miscellaneous: "agent_miscellaneous";
-        agent_mission_collateral_paid: "agent_mission_collateral_paid";
-        agent_mission_collateral_refunded: "agent_mission_collateral_refunded";
-        agent_mission_reward: "agent_mission_reward";
-        agent_mission_reward_corporation_tax: "agent_mission_reward_corporation_tax";
-        agent_mission_security_tax: "agent_mission_security_tax";
-        agent_mission_time_bonus_reward: "agent_mission_time_bonus_reward";
-        agent_mission_time_bonus_reward_corporation_tax: "agent_mission_time_bonus_reward_corporation_tax";
-        agent_security_services: "agent_security_services";
-        agent_services_rendered: "agent_services_rendered";
-        agents_preward: "agents_preward";
-        air_career_program_reward: "air_career_program_reward";
-        alliance_maintainance_fee: "alliance_maintainance_fee";
-        alliance_registration_fee: "alliance_registration_fee";
-        allignment_based_gate_toll: "allignment_based_gate_toll";
-        asset_safety_recovery_tax: "asset_safety_recovery_tax";
-        bounty: "bounty";
-        bounty_prize: "bounty_prize";
-        bounty_prize_corporation_tax: "bounty_prize_corporation_tax";
-        bounty_prizes: "bounty_prizes";
-        bounty_reimbursement: "bounty_reimbursement";
-        bounty_surcharge: "bounty_surcharge";
-        brokers_fee: "brokers_fee";
-        campaign_objective_isk_reward: "campaign_objective_isk_reward";
-        clone_activation: "clone_activation";
-        clone_transfer: "clone_transfer";
-        contraband_fine: "contraband_fine";
-        contract_auction_bid: "contract_auction_bid";
-        contract_auction_bid_corp: "contract_auction_bid_corp";
-        contract_auction_bid_refund: "contract_auction_bid_refund";
-        contract_auction_sold: "contract_auction_sold";
-        contract_brokers_fee: "contract_brokers_fee";
-        contract_brokers_fee_corp: "contract_brokers_fee_corp";
-        contract_collateral: "contract_collateral";
-        contract_collateral_deposited_corp: "contract_collateral_deposited_corp";
-        contract_collateral_payout: "contract_collateral_payout";
-        contract_collateral_refund: "contract_collateral_refund";
-        contract_deposit: "contract_deposit";
-        contract_deposit_corp: "contract_deposit_corp";
-        contract_deposit_refund: "contract_deposit_refund";
-        contract_deposit_sales_tax: "contract_deposit_sales_tax";
-        contract_price: "contract_price";
-        contract_price_payment_corp: "contract_price_payment_corp";
-        contract_reversal: "contract_reversal";
-        contract_reward: "contract_reward";
-        contract_reward_deposited: "contract_reward_deposited";
-        contract_reward_deposited_corp: "contract_reward_deposited_corp";
-        contract_reward_refund: "contract_reward_refund";
-        contract_sales_tax: "contract_sales_tax";
-        corporate_reward_payout: "corporate_reward_payout";
-        corporate_reward_tax: "corporate_reward_tax";
-        corporation_account_withdrawal: "corporation_account_withdrawal";
-        corporation_bulk_payment: "corporation_bulk_payment";
-        corporation_dividend_payment: "corporation_dividend_payment";
-        corporation_liquidation: "corporation_liquidation";
-        corporation_logo_change_cost: "corporation_logo_change_cost";
-        corporation_payment: "corporation_payment";
-        corporation_registration_fee: "corporation_registration_fee";
-        cosmetic_market_component_item_purchase: "cosmetic_market_component_item_purchase";
-        cosmetic_market_skin_purchase: "cosmetic_market_skin_purchase";
-        cosmetic_market_skin_sale: "cosmetic_market_skin_sale";
-        cosmetic_market_skin_sale_broker_fee: "cosmetic_market_skin_sale_broker_fee";
-        cosmetic_market_skin_sale_tax: "cosmetic_market_skin_sale_tax";
-        cosmetic_market_skin_transaction: "cosmetic_market_skin_transaction";
-        courier_mission_escrow: "courier_mission_escrow";
-        cspa: "cspa";
-        cspaofflinerefund: "cspaofflinerefund";
-        daily_challenge_reward: "daily_challenge_reward";
-        daily_goal_payouts: "daily_goal_payouts";
-        daily_goal_payouts_tax: "daily_goal_payouts_tax";
-        datacore_fee: "datacore_fee";
-        dna_modification_fee: "dna_modification_fee";
-        docking_fee: "docking_fee";
-        duel_wager_escrow: "duel_wager_escrow";
-        duel_wager_payment: "duel_wager_payment";
-        duel_wager_refund: "duel_wager_refund";
-        ess_escrow_transfer: "ess_escrow_transfer";
-        external_trade_delivery: "external_trade_delivery";
-        external_trade_freeze: "external_trade_freeze";
-        external_trade_thaw: "external_trade_thaw";
-        factory_slot_rental_fee: "factory_slot_rental_fee";
-        flux_payout: "flux_payout";
-        flux_tax: "flux_tax";
-        flux_ticket_repayment: "flux_ticket_repayment";
-        flux_ticket_sale: "flux_ticket_sale";
-        freelance_jobs_broadcasting_fee: "freelance_jobs_broadcasting_fee";
-        freelance_jobs_duration_fee: "freelance_jobs_duration_fee";
-        freelance_jobs_escrow_refund: "freelance_jobs_escrow_refund";
-        freelance_jobs_reward: "freelance_jobs_reward";
-        freelance_jobs_reward_corporation_tax: "freelance_jobs_reward_corporation_tax";
-        freelance_jobs_reward_escrow: "freelance_jobs_reward_escrow";
-        gm_cash_transfer: "gm_cash_transfer";
-        gm_plex_fee_refund: "gm_plex_fee_refund";
-        industry_job_tax: "industry_job_tax";
-        industry_security_tax: "industry_security_tax";
-        infrastructure_hub_maintenance: "infrastructure_hub_maintenance";
-        inheritance: "inheritance";
-        insurgency_corruption_contribution_reward: "insurgency_corruption_contribution_reward";
-        insurgency_suppression_contribution_reward: "insurgency_suppression_contribution_reward";
-        item_trader_payment: "item_trader_payment";
-        jump_clone_activation_fee: "jump_clone_activation_fee";
-        jump_clone_installation_fee: "jump_clone_installation_fee";
-        kill_right_fee: "kill_right_fee";
-        lp_store: "lp_store";
-        market_escrow: "market_escrow";
-        market_fine_paid: "market_fine_paid";
-        market_provider_tax: "market_provider_tax";
-        market_security_tax: "market_security_tax";
-        market_transaction: "market_transaction";
-        medal_creation: "medal_creation";
-        medal_issued: "medal_issued";
-        milestone_reward_payment: "milestone_reward_payment";
-        mission_completion: "mission_completion";
-        mission_cost: "mission_cost";
-        mission_expiration: "mission_expiration";
-        mission_reward: "mission_reward";
-        npc_bounty_security_tax: "npc_bounty_security_tax";
-        office_rental_fee: "office_rental_fee";
-        operation_bonus: "operation_bonus";
-        opportunity_reward: "opportunity_reward";
-        planetary_construction: "planetary_construction";
-        planetary_export_tax: "planetary_export_tax";
-        planetary_import_tax: "planetary_import_tax";
-        player_donation: "player_donation";
-        player_trading: "player_trading";
-        project_discovery_reward: "project_discovery_reward";
-        project_discovery_tax: "project_discovery_tax";
-        project_payouts: "project_payouts";
-        redeemed_isk_token: "redeemed_isk_token";
-        release_of_impounded_property: "release_of_impounded_property";
-        repair_bill: "repair_bill";
-        reprocessing_tax: "reprocessing_tax";
-        researching_material_productivity: "researching_material_productivity";
-        researching_time_productivity: "researching_time_productivity";
-        resource_wars_reward: "resource_wars_reward";
-        season_challenge_reward: "season_challenge_reward";
-        security_processing_fee: "security_processing_fee";
-        skill_purchase: "skill_purchase";
-        skyhook_claim_fee: "skyhook_claim_fee";
-        sovereignity_bill: "sovereignity_bill";
-        store_purchase: "store_purchase";
-        store_purchase_refund: "store_purchase_refund";
-        structure_gate_jump: "structure_gate_jump";
-        transaction_tax: "transaction_tax";
-        under_construction: "under_construction";
-        upkeep_adjustment_fee: "upkeep_adjustment_fee";
-        war_ally_contract: "war_ally_contract";
-        war_fee: "war_fee";
-        war_fee_surrender: "war_fee_surrender";
-    }>;
-    second_party_id: z.ZodOptional<z.ZodNumber>;
-    tax: z.ZodOptional<z.ZodNumber>;
-    tax_receiver_id: z.ZodOptional<z.ZodNumber>;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface CorporationsCorporationIdWalletsDivisionTransactionsGet {
     // (undocumented)
     client_id: number;
@@ -7059,31 +3194,12 @@ interface CorporationsCorporationIdWalletsDivisionTransactionsGet {
 }
 
 // @public (undocumented)
-const CorporationsCorporationIdWalletsDivisionTransactionsGetSchema: z.ZodObject<{
-    client_id: z.ZodNumber;
-    date: z.ZodString;
-    is_buy: z.ZodBoolean;
-    journal_ref_id: z.ZodNumber;
-    location_id: z.ZodNumber;
-    quantity: z.ZodNumber;
-    transaction_id: z.ZodNumber;
-    type_id: z.ZodNumber;
-    unit_price: z.ZodNumber;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface CorporationsCorporationIdWalletsGet {
     // (undocumented)
     balance: number;
     // (undocumented)
     division: number;
 }
-
-// @public (undocumented)
-const CorporationsCorporationIdWalletsGetSchema: z.ZodObject<{
-    balance: z.ZodNumber;
-    division: z.ZodNumber;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface CorporationsDetail {
@@ -7118,24 +3234,6 @@ interface CorporationsDetail {
 }
 
 // @public (undocumented)
-const CorporationsDetailSchema: z.ZodObject<{
-    alliance_id: z.ZodOptional<z.ZodNumber>;
-    ceo_id: z.ZodNumber;
-    creator_id: z.ZodNumber;
-    date_founded: z.ZodOptional<z.ZodString>;
-    description: z.ZodOptional<z.ZodString>;
-    faction_id: z.ZodOptional<z.ZodNumber>;
-    home_station_id: z.ZodOptional<z.ZodNumber>;
-    member_count: z.ZodNumber;
-    name: z.ZodString;
-    shares: z.ZodOptional<z.ZodNumber>;
-    tax_rate: z.ZodNumber;
-    ticker: z.ZodString;
-    url: z.ZodOptional<z.ZodString>;
-    war_eligible: z.ZodOptional<z.ZodBoolean>;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface CorporationsFreelanceJobsListing {
     // (undocumented)
     cursor?: {
@@ -7160,35 +3258,6 @@ interface CorporationsFreelanceJobsListing {
 }
 
 // @public (undocumented)
-const CorporationsFreelanceJobsListingSchema: z.ZodObject<{
-    cursor: z.ZodOptional<z.ZodObject<{
-        after: z.ZodOptional<z.ZodString>;
-        before: z.ZodOptional<z.ZodString>;
-    }, z.core.$loose>>;
-    freelance_jobs: z.ZodArray<z.ZodObject<{
-        id: z.ZodString;
-        last_modified: z.ZodString;
-        name: z.ZodString;
-        progress: z.ZodObject<{
-            current: z.ZodNumber;
-            desired: z.ZodNumber;
-        }, z.core.$loose>;
-        reward: z.ZodOptional<z.ZodObject<{
-            initial: z.ZodNumber;
-            remaining: z.ZodNumber;
-        }, z.core.$loose>>;
-        state: z.ZodEnum<{
-            Unspecified: "Unspecified";
-            Active: "Active";
-            Closed: "Closed";
-            Completed: "Completed";
-            Expired: "Expired";
-            Deleted: "Deleted";
-        }>;
-    }, z.core.$loose>>;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface CorporationsFreelanceJobsParticipants {
     // (undocumented)
     cursor?: {
@@ -7203,25 +3272,6 @@ interface CorporationsFreelanceJobsParticipants {
         state: 'Unspecified' | 'Committed' | 'Kicked' | 'Resigned';
     })[];
 }
-
-// @public (undocumented)
-const CorporationsFreelanceJobsParticipantsSchema: z.ZodObject<{
-    cursor: z.ZodOptional<z.ZodObject<{
-        after: z.ZodOptional<z.ZodString>;
-        before: z.ZodOptional<z.ZodString>;
-    }, z.core.$loose>>;
-    participants: z.ZodArray<z.ZodObject<{
-        contributed: z.ZodNumber;
-        id: z.ZodNumber;
-        name: z.ZodString;
-        state: z.ZodEnum<{
-            Unspecified: "Unspecified";
-            Committed: "Committed";
-            Kicked: "Kicked";
-            Resigned: "Resigned";
-        }>;
-    }, z.core.$loose>>;
-}, z.core.$loose>;
 
 // @public (undocumented)
 export type CorporationShareholder = z.infer<typeof CorporationShareholderSchema>;
@@ -7245,12 +3295,6 @@ interface CorporationsProjectsContribution {
 }
 
 // @public (undocumented)
-const CorporationsProjectsContributionSchema: z.ZodObject<{
-    contributed: z.ZodNumber;
-    last_modified: z.ZodOptional<z.ZodString>;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface CorporationsProjectsContributors {
     // (undocumented)
     contributors: ({
@@ -7264,19 +3308,6 @@ interface CorporationsProjectsContributors {
         before?: string;
     };
 }
-
-// @public (undocumented)
-const CorporationsProjectsContributorsSchema: z.ZodObject<{
-    contributors: z.ZodArray<z.ZodObject<{
-        contributed: z.ZodNumber;
-        id: z.ZodNumber;
-        name: z.ZodString;
-    }, z.core.$loose>>;
-    cursor: z.ZodOptional<z.ZodObject<{
-        after: z.ZodOptional<z.ZodString>;
-        before: z.ZodOptional<z.ZodString>;
-    }, z.core.$loose>>;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface CorporationsProjectsDetail {
@@ -7323,53 +3354,6 @@ interface CorporationsProjectsDetail {
 }
 
 // @public (undocumented)
-const CorporationsProjectsDetailSchema: z.ZodObject<{
-    configuration: z.ZodUnknown;
-    contribution: z.ZodOptional<z.ZodObject<{
-        participation_limit: z.ZodOptional<z.ZodNumber>;
-        reward_per_contribution: z.ZodOptional<z.ZodNumber>;
-        submission_limit: z.ZodOptional<z.ZodNumber>;
-        submission_multiplier: z.ZodOptional<z.ZodNumber>;
-    }, z.core.$loose>>;
-    creator: z.ZodObject<{
-        id: z.ZodNumber;
-        name: z.ZodString;
-    }, z.core.$loose>;
-    details: z.ZodObject<{
-        career: z.ZodEnum<{
-            Unspecified: "Unspecified";
-            Explorer: "Explorer";
-            Industrialist: "Industrialist";
-            Enforcer: "Enforcer";
-            "Soldier of Fortune": "Soldier of Fortune";
-        }>;
-        created: z.ZodString;
-        description: z.ZodString;
-        expires: z.ZodOptional<z.ZodString>;
-        finished: z.ZodOptional<z.ZodString>;
-    }, z.core.$loose>;
-    id: z.ZodString;
-    last_modified: z.ZodString;
-    name: z.ZodString;
-    progress: z.ZodObject<{
-        current: z.ZodNumber;
-        desired: z.ZodNumber;
-    }, z.core.$loose>;
-    reward: z.ZodOptional<z.ZodObject<{
-        initial: z.ZodNumber;
-        remaining: z.ZodNumber;
-    }, z.core.$loose>>;
-    state: z.ZodEnum<{
-        Unspecified: "Unspecified";
-        Active: "Active";
-        Closed: "Closed";
-        Completed: "Completed";
-        Expired: "Expired";
-        Deleted: "Deleted";
-    }>;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface CorporationsProjectsListing {
     // (undocumented)
     cursor?: {
@@ -7392,35 +3376,6 @@ interface CorporationsProjectsListing {
         state: 'Unspecified' | 'Active' | 'Closed' | 'Completed' | 'Expired' | 'Deleted';
     })[];
 }
-
-// @public (undocumented)
-const CorporationsProjectsListingSchema: z.ZodObject<{
-    cursor: z.ZodOptional<z.ZodObject<{
-        after: z.ZodOptional<z.ZodString>;
-        before: z.ZodOptional<z.ZodString>;
-    }, z.core.$loose>>;
-    projects: z.ZodArray<z.ZodObject<{
-        id: z.ZodString;
-        last_modified: z.ZodString;
-        name: z.ZodString;
-        progress: z.ZodObject<{
-            current: z.ZodNumber;
-            desired: z.ZodNumber;
-        }, z.core.$loose>;
-        reward: z.ZodOptional<z.ZodObject<{
-            initial: z.ZodNumber;
-            remaining: z.ZodNumber;
-        }, z.core.$loose>>;
-        state: z.ZodEnum<{
-            Unspecified: "Unspecified";
-            Active: "Active";
-            Closed: "Closed";
-            Completed: "Completed";
-            Expired: "Expired";
-            Deleted: "Deleted";
-        }>;
-    }, z.core.$loose>>;
-}, z.core.$loose>;
 
 // @public (undocumented)
 export type CorporationStarbase = z.infer<typeof CorporationStarbaseSchema>;
@@ -7705,20 +3660,6 @@ interface DogmaAttributesAttributeIdGet {
 }
 
 // @public (undocumented)
-const DogmaAttributesAttributeIdGetSchema: z.ZodObject<{
-    attribute_id: z.ZodNumber;
-    default_value: z.ZodOptional<z.ZodNumber>;
-    description: z.ZodOptional<z.ZodString>;
-    display_name: z.ZodOptional<z.ZodString>;
-    high_is_good: z.ZodOptional<z.ZodBoolean>;
-    icon_id: z.ZodOptional<z.ZodNumber>;
-    name: z.ZodOptional<z.ZodString>;
-    published: z.ZodOptional<z.ZodBoolean>;
-    stackable: z.ZodOptional<z.ZodBoolean>;
-    unit_id: z.ZodOptional<z.ZodNumber>;
-}, z.core.$loose>;
-
-// @public (undocumented)
 const DogmaAttributeSchema: z.ZodObject<{
     attribute_id: z.ZodNumber;
     name: z.ZodString;
@@ -7781,21 +3722,6 @@ interface DogmaDynamicItemsTypeIdItemIdGet {
     // (undocumented)
     source_type_id: number;
 }
-
-// @public (undocumented)
-const DogmaDynamicItemsTypeIdItemIdGetSchema: z.ZodObject<{
-    created_by: z.ZodNumber;
-    dogma_attributes: z.ZodArray<z.ZodObject<{
-        attribute_id: z.ZodNumber;
-        value: z.ZodNumber;
-    }, z.core.$loose>>;
-    dogma_effects: z.ZodArray<z.ZodObject<{
-        effect_id: z.ZodNumber;
-        is_default: z.ZodBoolean;
-    }, z.core.$loose>>;
-    mutator_type_id: z.ZodNumber;
-    source_type_id: z.ZodNumber;
-}, z.core.$loose>;
 
 // @public (undocumented)
 export type DogmaEffect = z.infer<typeof DogmaEffectSchema>;
@@ -7884,38 +3810,6 @@ interface DogmaEffectsEffectIdGet {
     // (undocumented)
     tracking_speed_attribute_id?: number;
 }
-
-// @public (undocumented)
-const DogmaEffectsEffectIdGetSchema: z.ZodObject<{
-    description: z.ZodOptional<z.ZodString>;
-    disallow_auto_repeat: z.ZodOptional<z.ZodBoolean>;
-    discharge_attribute_id: z.ZodOptional<z.ZodNumber>;
-    display_name: z.ZodOptional<z.ZodString>;
-    duration_attribute_id: z.ZodOptional<z.ZodNumber>;
-    effect_category: z.ZodOptional<z.ZodNumber>;
-    effect_id: z.ZodNumber;
-    electronic_chance: z.ZodOptional<z.ZodBoolean>;
-    falloff_attribute_id: z.ZodOptional<z.ZodNumber>;
-    icon_id: z.ZodOptional<z.ZodNumber>;
-    is_assistance: z.ZodOptional<z.ZodBoolean>;
-    is_offensive: z.ZodOptional<z.ZodBoolean>;
-    is_warp_safe: z.ZodOptional<z.ZodBoolean>;
-    modifiers: z.ZodOptional<z.ZodArray<z.ZodObject<{
-        domain: z.ZodOptional<z.ZodString>;
-        effect_id: z.ZodOptional<z.ZodNumber>;
-        func: z.ZodString;
-        modified_attribute_id: z.ZodOptional<z.ZodNumber>;
-        modifying_attribute_id: z.ZodOptional<z.ZodNumber>;
-        operator: z.ZodOptional<z.ZodNumber>;
-    }, z.core.$loose>>>;
-    name: z.ZodOptional<z.ZodString>;
-    post_expression: z.ZodOptional<z.ZodNumber>;
-    pre_expression: z.ZodOptional<z.ZodNumber>;
-    published: z.ZodOptional<z.ZodBoolean>;
-    range_attribute_id: z.ZodOptional<z.ZodNumber>;
-    range_chance: z.ZodOptional<z.ZodBoolean>;
-    tracking_speed_attribute_id: z.ZodOptional<z.ZodNumber>;
-}, z.core.$loose>;
 
 // @public (undocumented)
 export class EsiApiFactory {
@@ -9049,14 +4943,6 @@ interface FleetsFleetIdGet {
 }
 
 // @public (undocumented)
-const FleetsFleetIdGetSchema: z.ZodObject<{
-    is_free_move: z.ZodBoolean;
-    is_registered: z.ZodBoolean;
-    is_voice_enabled: z.ZodBoolean;
-    motd: z.ZodString;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface FleetsFleetIdMembersGet {
     // (undocumented)
     character_id: number;
@@ -9081,25 +4967,6 @@ interface FleetsFleetIdMembersGet {
 }
 
 // @public (undocumented)
-const FleetsFleetIdMembersGetSchema: z.ZodObject<{
-    character_id: z.ZodNumber;
-    join_time: z.ZodString;
-    role: z.ZodEnum<{
-        fleet_commander: "fleet_commander";
-        wing_commander: "wing_commander";
-        squad_commander: "squad_commander";
-        squad_member: "squad_member";
-    }>;
-    role_name: z.ZodString;
-    ship_type_id: z.ZodNumber;
-    solar_system_id: z.ZodNumber;
-    squad_id: z.ZodNumber;
-    station_id: z.ZodOptional<z.ZodNumber>;
-    takes_fleet_warp: z.ZodBoolean;
-    wing_id: z.ZodNumber;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface FleetsFleetIdWingsGet {
     // (undocumented)
     id: number;
@@ -9111,16 +4978,6 @@ interface FleetsFleetIdWingsGet {
         name: string;
     })[];
 }
-
-// @public (undocumented)
-const FleetsFleetIdWingsGetSchema: z.ZodObject<{
-    id: z.ZodNumber;
-    name: z.ZodString;
-    squads: z.ZodArray<z.ZodObject<{
-        id: z.ZodNumber;
-        name: z.ZodString;
-    }, z.core.$loose>>;
-}, z.core.$loose>;
 
 // @public (undocumented)
 export type FleetWing = z.infer<typeof FleetWingSchema>;
@@ -9291,75 +5148,6 @@ interface FreelanceJobsDetail {
 }
 
 // @public (undocumented)
-const FreelanceJobsDetailSchema: z.ZodObject<{
-    access_and_visibility: z.ZodObject<{
-        acl_protected: z.ZodBoolean;
-        broadcast_locations: z.ZodOptional<z.ZodArray<z.ZodObject<{
-            id: z.ZodNumber;
-            name: z.ZodString;
-        }, z.core.$loose>>>;
-        restrictions: z.ZodOptional<z.ZodObject<{
-            maximum_age: z.ZodOptional<z.ZodNumber>;
-            minimum_age: z.ZodOptional<z.ZodNumber>;
-        }, z.core.$loose>>;
-    }, z.core.$loose>;
-    configuration: z.ZodObject<{
-        method: z.ZodString;
-        parameters: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-        version: z.ZodNumber;
-    }, z.core.$loose>;
-    contribution: z.ZodOptional<z.ZodObject<{
-        contribution_per_participant_limit: z.ZodOptional<z.ZodNumber>;
-        max_committed_participants: z.ZodNumber;
-        reward_per_contribution: z.ZodOptional<z.ZodNumber>;
-        submission_limit: z.ZodOptional<z.ZodNumber>;
-        submission_multiplier: z.ZodOptional<z.ZodNumber>;
-    }, z.core.$loose>>;
-    details: z.ZodObject<{
-        career: z.ZodEnum<{
-            Unspecified: "Unspecified";
-            Explorer: "Explorer";
-            Industrialist: "Industrialist";
-            Enforcer: "Enforcer";
-            "Soldier of Fortune": "Soldier of Fortune";
-        }>;
-        created: z.ZodString;
-        creator: z.ZodObject<{
-            character: z.ZodObject<{
-                id: z.ZodNumber;
-                name: z.ZodString;
-            }, z.core.$loose>;
-            corporation: z.ZodObject<{
-                id: z.ZodNumber;
-                name: z.ZodString;
-            }, z.core.$loose>;
-        }, z.core.$loose>;
-        description: z.ZodString;
-        expires: z.ZodOptional<z.ZodString>;
-        finished: z.ZodOptional<z.ZodString>;
-    }, z.core.$loose>;
-    id: z.ZodString;
-    last_modified: z.ZodString;
-    name: z.ZodString;
-    progress: z.ZodObject<{
-        current: z.ZodNumber;
-        desired: z.ZodNumber;
-    }, z.core.$loose>;
-    reward: z.ZodOptional<z.ZodObject<{
-        initial: z.ZodNumber;
-        remaining: z.ZodNumber;
-    }, z.core.$loose>>;
-    state: z.ZodEnum<{
-        Unspecified: "Unspecified";
-        Active: "Active";
-        Closed: "Closed";
-        Completed: "Completed";
-        Expired: "Expired";
-        Deleted: "Deleted";
-    }>;
-}, z.core.$loose>;
-
-// @public (undocumented)
 export type FreelanceJobsListing = z.infer<typeof FreelanceJobsListingSchema>;
 
 // @public (undocumented)
@@ -9405,35 +5193,6 @@ const FreelanceJobsListingSchema: z.ZodObject<{
             initial: z.ZodNumber;
             remaining: z.ZodNumber;
         }, z.core.$loose>>;
-    }, z.core.$loose>>;
-}, z.core.$loose>;
-
-// @public (undocumented)
-const FreelanceJobsListingSchema_2: z.ZodObject<{
-    cursor: z.ZodOptional<z.ZodObject<{
-        after: z.ZodOptional<z.ZodString>;
-        before: z.ZodOptional<z.ZodString>;
-    }, z.core.$loose>>;
-    freelance_jobs: z.ZodArray<z.ZodObject<{
-        id: z.ZodString;
-        last_modified: z.ZodString;
-        name: z.ZodString;
-        progress: z.ZodObject<{
-            current: z.ZodNumber;
-            desired: z.ZodNumber;
-        }, z.core.$loose>;
-        reward: z.ZodOptional<z.ZodObject<{
-            initial: z.ZodNumber;
-            remaining: z.ZodNumber;
-        }, z.core.$loose>>;
-        state: z.ZodEnum<{
-            Unspecified: "Unspecified";
-            Active: "Active";
-            Closed: "Closed";
-            Completed: "Completed";
-            Expired: "Expired";
-            Deleted: "Deleted";
-        }>;
     }, z.core.$loose>>;
 }, z.core.$loose>;
 
@@ -9491,38 +5250,6 @@ interface FwLeaderboardsCharactersGet {
 }
 
 // @public (undocumented)
-const FwLeaderboardsCharactersGetSchema: z.ZodObject<{
-    kills: z.ZodObject<{
-        active_total: z.ZodArray<z.ZodObject<{
-            amount: z.ZodOptional<z.ZodNumber>;
-            character_id: z.ZodOptional<z.ZodNumber>;
-        }, z.core.$loose>>;
-        last_week: z.ZodArray<z.ZodObject<{
-            amount: z.ZodOptional<z.ZodNumber>;
-            character_id: z.ZodOptional<z.ZodNumber>;
-        }, z.core.$loose>>;
-        yesterday: z.ZodArray<z.ZodObject<{
-            amount: z.ZodOptional<z.ZodNumber>;
-            character_id: z.ZodOptional<z.ZodNumber>;
-        }, z.core.$loose>>;
-    }, z.core.$loose>;
-    victory_points: z.ZodObject<{
-        active_total: z.ZodArray<z.ZodObject<{
-            amount: z.ZodOptional<z.ZodNumber>;
-            character_id: z.ZodOptional<z.ZodNumber>;
-        }, z.core.$loose>>;
-        last_week: z.ZodArray<z.ZodObject<{
-            amount: z.ZodOptional<z.ZodNumber>;
-            character_id: z.ZodOptional<z.ZodNumber>;
-        }, z.core.$loose>>;
-        yesterday: z.ZodArray<z.ZodObject<{
-            amount: z.ZodOptional<z.ZodNumber>;
-            character_id: z.ZodOptional<z.ZodNumber>;
-        }, z.core.$loose>>;
-    }, z.core.$loose>;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface FwLeaderboardsCorporationsGet {
     // (undocumented)
     kills: {
@@ -9555,38 +5282,6 @@ interface FwLeaderboardsCorporationsGet {
         })[];
     };
 }
-
-// @public (undocumented)
-const FwLeaderboardsCorporationsGetSchema: z.ZodObject<{
-    kills: z.ZodObject<{
-        active_total: z.ZodArray<z.ZodObject<{
-            amount: z.ZodOptional<z.ZodNumber>;
-            corporation_id: z.ZodOptional<z.ZodNumber>;
-        }, z.core.$loose>>;
-        last_week: z.ZodArray<z.ZodObject<{
-            amount: z.ZodOptional<z.ZodNumber>;
-            corporation_id: z.ZodOptional<z.ZodNumber>;
-        }, z.core.$loose>>;
-        yesterday: z.ZodArray<z.ZodObject<{
-            amount: z.ZodOptional<z.ZodNumber>;
-            corporation_id: z.ZodOptional<z.ZodNumber>;
-        }, z.core.$loose>>;
-    }, z.core.$loose>;
-    victory_points: z.ZodObject<{
-        active_total: z.ZodArray<z.ZodObject<{
-            amount: z.ZodOptional<z.ZodNumber>;
-            corporation_id: z.ZodOptional<z.ZodNumber>;
-        }, z.core.$loose>>;
-        last_week: z.ZodArray<z.ZodObject<{
-            amount: z.ZodOptional<z.ZodNumber>;
-            corporation_id: z.ZodOptional<z.ZodNumber>;
-        }, z.core.$loose>>;
-        yesterday: z.ZodArray<z.ZodObject<{
-            amount: z.ZodOptional<z.ZodNumber>;
-            corporation_id: z.ZodOptional<z.ZodNumber>;
-        }, z.core.$loose>>;
-    }, z.core.$loose>;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface FwLeaderboardsGet {
@@ -9623,38 +5318,6 @@ interface FwLeaderboardsGet {
 }
 
 // @public (undocumented)
-const FwLeaderboardsGetSchema: z.ZodObject<{
-    kills: z.ZodObject<{
-        active_total: z.ZodArray<z.ZodObject<{
-            amount: z.ZodOptional<z.ZodNumber>;
-            faction_id: z.ZodOptional<z.ZodNumber>;
-        }, z.core.$loose>>;
-        last_week: z.ZodArray<z.ZodObject<{
-            amount: z.ZodOptional<z.ZodNumber>;
-            faction_id: z.ZodOptional<z.ZodNumber>;
-        }, z.core.$loose>>;
-        yesterday: z.ZodArray<z.ZodObject<{
-            amount: z.ZodOptional<z.ZodNumber>;
-            faction_id: z.ZodOptional<z.ZodNumber>;
-        }, z.core.$loose>>;
-    }, z.core.$loose>;
-    victory_points: z.ZodObject<{
-        active_total: z.ZodArray<z.ZodObject<{
-            amount: z.ZodOptional<z.ZodNumber>;
-            faction_id: z.ZodOptional<z.ZodNumber>;
-        }, z.core.$loose>>;
-        last_week: z.ZodArray<z.ZodObject<{
-            amount: z.ZodOptional<z.ZodNumber>;
-            faction_id: z.ZodOptional<z.ZodNumber>;
-        }, z.core.$loose>>;
-        yesterday: z.ZodArray<z.ZodObject<{
-            amount: z.ZodOptional<z.ZodNumber>;
-            faction_id: z.ZodOptional<z.ZodNumber>;
-        }, z.core.$loose>>;
-    }, z.core.$loose>;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface FwStatsGet {
     // (undocumented)
     faction_id: number;
@@ -9677,23 +5340,6 @@ interface FwStatsGet {
 }
 
 // @public (undocumented)
-const FwStatsGetSchema: z.ZodObject<{
-    faction_id: z.ZodNumber;
-    kills: z.ZodObject<{
-        last_week: z.ZodNumber;
-        total: z.ZodNumber;
-        yesterday: z.ZodNumber;
-    }, z.core.$loose>;
-    pilots: z.ZodNumber;
-    systems_controlled: z.ZodNumber;
-    victory_points: z.ZodObject<{
-        last_week: z.ZodNumber;
-        total: z.ZodNumber;
-        yesterday: z.ZodNumber;
-    }, z.core.$loose>;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface FwSystemsGet {
     // (undocumented)
     contested: 'captured' | 'contested' | 'uncontested' | 'vulnerable';
@@ -9710,198 +5356,11 @@ interface FwSystemsGet {
 }
 
 // @public (undocumented)
-const FwSystemsGetSchema: z.ZodObject<{
-    contested: z.ZodEnum<{
-        contested: "contested";
-        captured: "captured";
-        uncontested: "uncontested";
-        vulnerable: "vulnerable";
-    }>;
-    occupier_faction_id: z.ZodNumber;
-    owner_faction_id: z.ZodNumber;
-    solar_system_id: z.ZodNumber;
-    victory_points: z.ZodNumber;
-    victory_points_threshold: z.ZodNumber;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface FwWarsGet {
     // (undocumented)
     against_id: number;
     // (undocumented)
     faction_id: number;
-}
-
-// @public (undocumented)
-const FwWarsGetSchema: z.ZodObject<{
-    against_id: z.ZodNumber;
-    faction_id: z.ZodNumber;
-}, z.core.$loose>;
-
-declare namespace generatedSchemas {
-    export {
-        AllianceDetailSchema,
-        AlliancesAllianceIdIconsGetSchema,
-        CharactersCharacterIdAssetsGetSchema,
-        CharactersCharacterIdAssetsLocationsPostSchema,
-        CharactersCharacterIdAssetsNamesPostSchema,
-        CorporationsCorporationIdAssetsGetSchema,
-        CorporationsCorporationIdAssetsLocationsPostSchema,
-        CorporationsCorporationIdAssetsNamesPostSchema,
-        CharactersCharacterIdCalendarEventIdAttendeesGetSchema,
-        CharactersCharacterIdCalendarEventIdGetSchema,
-        CharactersCharacterIdCalendarGetSchema,
-        CharactersAffiliationPostSchema,
-        CharactersCharacterIdAgentsResearchGetSchema,
-        CharactersCharacterIdBlueprintsGetSchema,
-        CharactersCharacterIdCorporationhistoryGetSchema,
-        CharactersCharacterIdFatigueGetSchema,
-        CharactersCharacterIdMedalsGetSchema,
-        CharactersCharacterIdNotificationsContactsGetSchema,
-        CharactersCharacterIdNotificationsGetSchema,
-        CharactersCharacterIdPortraitGetSchema,
-        CharactersCharacterIdRolesGetSchema,
-        CharactersCharacterIdStandingsGetSchema,
-        CharactersCharacterIdTitlesGetSchema,
-        CharactersDetailSchema,
-        CharactersCharacterIdClonesGetSchema,
-        AlliancesAllianceIdContactsGetSchema,
-        AlliancesAllianceIdContactsLabelsGetSchema,
-        CharactersCharacterIdContactsGetSchema,
-        CharactersCharacterIdContactsLabelsGetSchema,
-        CorporationsCorporationIdContactsGetSchema,
-        CorporationsCorporationIdContactsLabelsGetSchema,
-        CharactersCharacterIdContractsContractIdBidsGetSchema,
-        CharactersCharacterIdContractsContractIdItemsGetSchema,
-        CharactersCharacterIdContractsGetSchema,
-        ContractsPublicBidsContractIdGetSchema,
-        ContractsPublicItemsContractIdGetSchema,
-        ContractsPublicRegionIdGetSchema,
-        CorporationsCorporationIdContractsContractIdBidsGetSchema,
-        CorporationsCorporationIdContractsContractIdItemsGetSchema,
-        CorporationsCorporationIdContractsGetSchema,
-        CorporationsProjectsContributionSchema,
-        CorporationsProjectsContributorsSchema,
-        CorporationsProjectsDetailSchema,
-        CorporationsProjectsListingSchema,
-        CorporationsCorporationIdAlliancehistoryGetSchema,
-        CorporationsCorporationIdBlueprintsGetSchema,
-        CorporationsCorporationIdContainersLogsGetSchema,
-        CorporationsCorporationIdDivisionsGetSchema,
-        CorporationsCorporationIdFacilitiesGetSchema,
-        CorporationsCorporationIdIconsGetSchema,
-        CorporationsCorporationIdMedalsGetSchema,
-        CorporationsCorporationIdMedalsIssuedGetSchema,
-        CorporationsCorporationIdMembersTitlesGetSchema,
-        CorporationsCorporationIdMembertrackingGetSchema,
-        CorporationsCorporationIdRolesGetSchema,
-        CorporationsCorporationIdRolesHistoryGetSchema,
-        CorporationsCorporationIdShareholdersGetSchema,
-        CorporationsCorporationIdStandingsGetSchema,
-        CorporationsCorporationIdStarbasesGetSchema,
-        CorporationsCorporationIdStarbasesStarbaseIdGetSchema,
-        CorporationsCorporationIdStructuresGetSchema,
-        CorporationsCorporationIdTitlesGetSchema,
-        CorporationsDetailSchema,
-        DogmaAttributesAttributeIdGetSchema,
-        DogmaDynamicItemsTypeIdItemIdGetSchema,
-        DogmaEffectsEffectIdGetSchema,
-        CharactersCharacterIdFwStatsGetSchema,
-        CorporationsCorporationIdFwStatsGetSchema,
-        FwLeaderboardsCharactersGetSchema,
-        FwLeaderboardsCorporationsGetSchema,
-        FwLeaderboardsGetSchema,
-        FwStatsGetSchema,
-        FwSystemsGetSchema,
-        FwWarsGetSchema,
-        CharactersCharacterIdFittingsGetSchema,
-        CharactersCharacterIdFleetGetSchema,
-        FleetsFleetIdGetSchema,
-        FleetsFleetIdMembersGetSchema,
-        FleetsFleetIdWingsGetSchema,
-        CharactersFreelanceJobsListingSchema,
-        CharactersFreelanceJobsParticipationSchema,
-        CorporationsFreelanceJobsListingSchema,
-        CorporationsFreelanceJobsParticipantsSchema,
-        FreelanceJobsDetailSchema,
-        FreelanceJobsListingSchema_2 as FreelanceJobsListingSchema,
-        IncursionsGetSchema,
-        CharactersCharacterIdIndustryJobsGetSchema,
-        CharactersCharacterIdMiningGetSchema,
-        CorporationCorporationIdMiningExtractionsGetSchema,
-        CorporationCorporationIdMiningObserversGetSchema,
-        CorporationCorporationIdMiningObserversObserverIdGetSchema,
-        CorporationsCorporationIdIndustryJobsGetSchema,
-        IndustryFacilitiesGetSchema,
-        IndustrySystemsGetSchema,
-        InsurancePricesGetSchema,
-        CharactersCharacterIdKillmailsRecentGetSchema,
-        CorporationsCorporationIdKillmailsRecentGetSchema,
-        KillmailsKillmailIdKillmailHashGetSchema,
-        CharactersCharacterIdLocationGetSchema,
-        CharactersCharacterIdOnlineGetSchema,
-        CharactersCharacterIdShipGetSchema,
-        CharactersCharacterIdLoyaltyPointsGetSchema,
-        LoyaltyStoresCorporationIdOffersGetSchema,
-        CharactersCharacterIdMailGetSchema,
-        CharactersCharacterIdMailLabelsGetSchema,
-        CharactersCharacterIdMailListsGetSchema,
-        CharactersCharacterIdMailMailIdGetSchema,
-        CharactersCharacterIdOrdersGetSchema,
-        CharactersCharacterIdOrdersHistoryGetSchema,
-        CorporationsCorporationIdOrdersGetSchema,
-        CorporationsCorporationIdOrdersHistoryGetSchema,
-        MarketsGroupsMarketGroupIdGetSchema,
-        MarketsPricesGetSchema,
-        MarketsRegionIdHistoryGetSchema,
-        MarketsRegionIdOrdersGetSchema,
-        MarketsStructuresStructureIdGetSchema,
-        MetaChangelogSchema,
-        MetaCompatibilityDatesSchema,
-        MetaStatusSchema,
-        CharactersCharacterIdPlanetsGetSchema,
-        CharactersCharacterIdPlanetsPlanetIdGetSchema,
-        CorporationsCorporationIdCustomsOfficesGetSchema,
-        UniverseSchematicsSchematicIdGetSchema,
-        RouteSchema,
-        CharactersCharacterIdSearchGetSchema,
-        CharactersCharacterIdAttributesGetSchema,
-        CharactersSkillqueueSkillSchema,
-        CharactersSkillsSchema,
-        SovereigntyCampaignsGetSchema,
-        SovereigntyMapGetSchema,
-        SovereigntyStructuresGetSchema,
-        StatusGetSchema,
-        UniverseAncestriesGetSchema,
-        UniverseAsteroidBeltsAsteroidBeltIdGetSchema,
-        UniverseBloodlinesGetSchema,
-        UniverseCategoriesCategoryIdGetSchema,
-        UniverseConstellationsConstellationIdGetSchema,
-        UniverseFactionsGetSchema,
-        UniverseGraphicsGraphicIdGetSchema,
-        UniverseGroupsGroupIdGetSchema,
-        UniverseIdsPostSchema,
-        UniverseMoonsMoonIdGetSchema,
-        UniverseNamesPostSchema,
-        UniversePlanetsPlanetIdGetSchema,
-        UniverseRacesGetSchema,
-        UniverseRegionsRegionIdGetSchema,
-        UniverseStargatesStargateIdGetSchema,
-        UniverseStarsStarIdGetSchema,
-        UniverseStationsStationIdGetSchema,
-        UniverseStructuresStructureIdGetSchema,
-        UniverseSystemJumpsGetSchema,
-        UniverseSystemKillsGetSchema,
-        UniverseSystemsSystemIdGetSchema,
-        UniverseTypesTypeIdGetSchema,
-        CharactersCharacterIdWalletJournalGetSchema,
-        CharactersCharacterIdWalletTransactionsGetSchema,
-        CorporationsCorporationIdWalletsDivisionJournalGetSchema,
-        CorporationsCorporationIdWalletsDivisionTransactionsGetSchema,
-        CorporationsCorporationIdWalletsGetSchema,
-        WarsWarIdGetSchema,
-        WarsWarIdKillmailsGetSchema
-    }
 }
 
 // @public (undocumented)
@@ -10050,22 +5509,6 @@ interface IncursionsGet {
     type: string;
 }
 
-// @public (undocumented)
-const IncursionsGetSchema: z.ZodObject<{
-    constellation_id: z.ZodNumber;
-    faction_id: z.ZodNumber;
-    has_boss: z.ZodBoolean;
-    infested_solar_systems: z.ZodArray<z.ZodNumber>;
-    influence: z.ZodNumber;
-    staging_solar_system_id: z.ZodNumber;
-    state: z.ZodEnum<{
-        withdrawing: "withdrawing";
-        mobilizing: "mobilizing";
-        established: "established";
-    }>;
-    type: z.ZodString;
-}, z.core.$loose>;
-
 // Warning: (ae-forgotten-export) The symbol "industryEndpoints" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
@@ -10096,16 +5539,6 @@ interface IndustryFacilitiesGet {
     // (undocumented)
     type_id: number;
 }
-
-// @public (undocumented)
-const IndustryFacilitiesGetSchema: z.ZodObject<{
-    facility_id: z.ZodNumber;
-    owner_id: z.ZodNumber;
-    region_id: z.ZodNumber;
-    solar_system_id: z.ZodNumber;
-    tax: z.ZodOptional<z.ZodNumber>;
-    type_id: z.ZodNumber;
-}, z.core.$loose>;
 
 // @public (undocumented)
 export type IndustryFacility = z.infer<typeof IndustryFacilitySchema>;
@@ -10179,26 +5612,6 @@ interface IndustrySystemsGet {
     solar_system_id: number;
 }
 
-// @public (undocumented)
-const IndustrySystemsGetSchema: z.ZodObject<{
-    cost_indices: z.ZodArray<z.ZodObject<{
-        activity: z.ZodEnum<{
-            copying: "copying";
-            duplicating: "duplicating";
-            invention: "invention";
-            manufacturing: "manufacturing";
-            none: "none";
-            reaction: "reaction";
-            researching_material_efficiency: "researching_material_efficiency";
-            researching_technology: "researching_technology";
-            researching_time_efficiency: "researching_time_efficiency";
-            reverse_engineering: "reverse_engineering";
-        }>;
-        cost_index: z.ZodNumber;
-    }, z.core.$loose>>;
-    solar_system_id: z.ZodNumber;
-}, z.core.$loose>;
-
 // @public
 export type InferEndpointResult<D> = D extends {
     cursorPagination: true;
@@ -10240,16 +5653,6 @@ interface InsurancePricesGet {
     // (undocumented)
     type_id: number;
 }
-
-// @public (undocumented)
-const InsurancePricesGetSchema: z.ZodObject<{
-    levels: z.ZodArray<z.ZodObject<{
-        cost: z.ZodNumber;
-        name: z.ZodString;
-        payout: z.ZodNumber;
-    }, z.core.$loose>>;
-    type_id: z.ZodNumber;
-}, z.core.$loose>;
 
 // @public (undocumented)
 export interface IRateLimiter {
@@ -10453,53 +5856,6 @@ interface KillmailsKillmailIdKillmailHashGet {
 }
 
 // @public (undocumented)
-const KillmailsKillmailIdKillmailHashGetSchema: z.ZodObject<{
-    attackers: z.ZodArray<z.ZodObject<{
-        alliance_id: z.ZodOptional<z.ZodNumber>;
-        character_id: z.ZodOptional<z.ZodNumber>;
-        corporation_id: z.ZodOptional<z.ZodNumber>;
-        damage_done: z.ZodNumber;
-        faction_id: z.ZodOptional<z.ZodNumber>;
-        final_blow: z.ZodBoolean;
-        security_status: z.ZodNumber;
-        ship_type_id: z.ZodOptional<z.ZodNumber>;
-        weapon_type_id: z.ZodOptional<z.ZodNumber>;
-    }, z.core.$loose>>;
-    killmail_id: z.ZodNumber;
-    killmail_time: z.ZodString;
-    moon_id: z.ZodOptional<z.ZodNumber>;
-    solar_system_id: z.ZodNumber;
-    victim: z.ZodObject<{
-        alliance_id: z.ZodOptional<z.ZodNumber>;
-        character_id: z.ZodOptional<z.ZodNumber>;
-        corporation_id: z.ZodOptional<z.ZodNumber>;
-        damage_taken: z.ZodNumber;
-        faction_id: z.ZodOptional<z.ZodNumber>;
-        items: z.ZodOptional<z.ZodArray<z.ZodObject<{
-            flag: z.ZodNumber;
-            item_type_id: z.ZodNumber;
-            items: z.ZodOptional<z.ZodArray<z.ZodObject<{
-                flag: z.ZodNumber;
-                item_type_id: z.ZodNumber;
-                quantity_destroyed: z.ZodOptional<z.ZodNumber>;
-                quantity_dropped: z.ZodOptional<z.ZodNumber>;
-                singleton: z.ZodNumber;
-            }, z.core.$loose>>>;
-            quantity_destroyed: z.ZodOptional<z.ZodNumber>;
-            quantity_dropped: z.ZodOptional<z.ZodNumber>;
-            singleton: z.ZodNumber;
-        }, z.core.$loose>>>;
-        position: z.ZodOptional<z.ZodObject<{
-            x: z.ZodNumber;
-            y: z.ZodNumber;
-            z: z.ZodNumber;
-        }, z.core.$loose>>;
-        ship_type_id: z.ZodNumber;
-    }, z.core.$loose>;
-    war_id: z.ZodOptional<z.ZodNumber>;
-}, z.core.$loose>;
-
-// @public (undocumented)
 export type KillmailSummary = z.infer<typeof KillmailSummarySchema>;
 
 // @public (undocumented)
@@ -10573,20 +5929,6 @@ interface LoyaltyStoresCorporationIdOffersGet {
     // (undocumented)
     type_id: number;
 }
-
-// @public (undocumented)
-const LoyaltyStoresCorporationIdOffersGetSchema: z.ZodObject<{
-    ak_cost: z.ZodOptional<z.ZodNumber>;
-    isk_cost: z.ZodNumber;
-    lp_cost: z.ZodNumber;
-    offer_id: z.ZodNumber;
-    quantity: z.ZodNumber;
-    required_items: z.ZodArray<z.ZodObject<{
-        quantity: z.ZodNumber;
-        type_id: z.ZodNumber;
-    }, z.core.$loose>>;
-    type_id: z.ZodNumber;
-}, z.core.$loose>;
 
 // Warning: (ae-forgotten-export) The symbol "mailEndpoints" needs to be exported by the entry point index.d.ts
 //
@@ -10760,15 +6102,6 @@ interface MarketsGroupsMarketGroupIdGet {
 }
 
 // @public (undocumented)
-const MarketsGroupsMarketGroupIdGetSchema: z.ZodObject<{
-    description: z.ZodString;
-    market_group_id: z.ZodNumber;
-    name: z.ZodString;
-    parent_group_id: z.ZodOptional<z.ZodNumber>;
-    types: z.ZodArray<z.ZodNumber>;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface MarketsPricesGet {
     // (undocumented)
     adjusted_price?: number;
@@ -10777,13 +6110,6 @@ interface MarketsPricesGet {
     // (undocumented)
     type_id: number;
 }
-
-// @public (undocumented)
-const MarketsPricesGetSchema: z.ZodObject<{
-    adjusted_price: z.ZodOptional<z.ZodNumber>;
-    average_price: z.ZodOptional<z.ZodNumber>;
-    type_id: z.ZodNumber;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface MarketsRegionIdHistoryGet {
@@ -10800,16 +6126,6 @@ interface MarketsRegionIdHistoryGet {
     // (undocumented)
     volume: number;
 }
-
-// @public (undocumented)
-const MarketsRegionIdHistoryGetSchema: z.ZodObject<{
-    average: z.ZodNumber;
-    date: z.ZodString;
-    highest: z.ZodNumber;
-    lowest: z.ZodNumber;
-    order_count: z.ZodNumber;
-    volume: z.ZodNumber;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface MarketsRegionIdOrdersGet {
@@ -10840,35 +6156,6 @@ interface MarketsRegionIdOrdersGet {
 }
 
 // @public (undocumented)
-const MarketsRegionIdOrdersGetSchema: z.ZodObject<{
-    duration: z.ZodNumber;
-    is_buy_order: z.ZodBoolean;
-    issued: z.ZodString;
-    location_id: z.ZodNumber;
-    min_volume: z.ZodNumber;
-    order_id: z.ZodNumber;
-    price: z.ZodNumber;
-    range: z.ZodEnum<{
-        1: "1";
-        2: "2";
-        3: "3";
-        4: "4";
-        region: "region";
-        5: "5";
-        station: "station";
-        10: "10";
-        20: "20";
-        30: "30";
-        40: "40";
-        solarsystem: "solarsystem";
-    }>;
-    system_id: z.ZodNumber;
-    type_id: z.ZodNumber;
-    volume_remain: z.ZodNumber;
-    volume_total: z.ZodNumber;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface MarketsStructuresStructureIdGet {
     // (undocumented)
     duration: number;
@@ -10893,34 +6180,6 @@ interface MarketsStructuresStructureIdGet {
     // (undocumented)
     volume_total: number;
 }
-
-// @public (undocumented)
-const MarketsStructuresStructureIdGetSchema: z.ZodObject<{
-    duration: z.ZodNumber;
-    is_buy_order: z.ZodBoolean;
-    issued: z.ZodString;
-    location_id: z.ZodNumber;
-    min_volume: z.ZodNumber;
-    order_id: z.ZodNumber;
-    price: z.ZodNumber;
-    range: z.ZodEnum<{
-        1: "1";
-        2: "2";
-        3: "3";
-        4: "4";
-        region: "region";
-        5: "5";
-        station: "station";
-        10: "10";
-        20: "20";
-        30: "30";
-        40: "40";
-        solarsystem: "solarsystem";
-    }>;
-    type_id: z.ZodNumber;
-    volume_remain: z.ZodNumber;
-    volume_total: z.ZodNumber;
-}, z.core.$loose>;
 
 // @public (undocumented)
 export type Medal = z.infer<typeof MedalSchema>;
@@ -10994,11 +6253,6 @@ interface MetaChangelog {
     changelog: Record<string, unknown>;
 }
 
-// @public (undocumented)
-const MetaChangelogSchema: z.ZodObject<{
-    changelog: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-}, z.core.$loose>;
-
 // Warning: (ae-forgotten-export) The symbol "metaEndpoints" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
@@ -11015,11 +6269,6 @@ interface MetaCompatibilityDates {
 }
 
 // @public (undocumented)
-const MetaCompatibilityDatesSchema: z.ZodObject<{
-    compatibility_dates: z.ZodArray<z.ZodString>;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface MetaStatus {
     // (undocumented)
     routes: ({
@@ -11028,26 +6277,6 @@ interface MetaStatus {
         status: 'Unknown' | 'OK' | 'Degraded' | 'Down' | 'Recovering';
     })[];
 }
-
-// @public (undocumented)
-const MetaStatusSchema: z.ZodObject<{
-    routes: z.ZodArray<z.ZodObject<{
-        method: z.ZodEnum<{
-            GET: "GET";
-            POST: "POST";
-            PUT: "PUT";
-            DELETE: "DELETE";
-        }>;
-        path: z.ZodString;
-        status: z.ZodEnum<{
-            Unknown: "Unknown";
-            OK: "OK";
-            Degraded: "Degraded";
-            Down: "Down";
-            Recovering: "Recovering";
-        }>;
-    }, z.core.$loose>>;
-}, z.core.$loose>;
 
 // @public (undocumented)
 export type MiningLedgerEntry = z.infer<typeof MiningLedgerEntrySchema>;
@@ -11473,16 +6702,10 @@ export interface RouteOptions {
 }
 
 // @public (undocumented)
-const RouteSchema: z.ZodObject<{
-    route: z.ZodArray<z.ZodNumber>;
-}, z.core.$loose>;
-
-// @public (undocumented)
 export function sanitizeUrl(url?: string): string | undefined;
 
 declare namespace schemas {
     export {
-        generatedSchemas,
         esiResponse,
         StandingSchema,
         RateLimitMetaSchema,
@@ -11784,28 +7007,6 @@ interface SovereigntyCampaignsGet {
     structure_id: number;
 }
 
-// @public (undocumented)
-const SovereigntyCampaignsGetSchema: z.ZodObject<{
-    attackers_score: z.ZodOptional<z.ZodNumber>;
-    campaign_id: z.ZodNumber;
-    constellation_id: z.ZodNumber;
-    defender_id: z.ZodOptional<z.ZodNumber>;
-    defender_score: z.ZodOptional<z.ZodNumber>;
-    event_type: z.ZodEnum<{
-        tcu_defense: "tcu_defense";
-        ihub_defense: "ihub_defense";
-        station_defense: "station_defense";
-        station_freeport: "station_freeport";
-    }>;
-    participants: z.ZodOptional<z.ZodArray<z.ZodObject<{
-        alliance_id: z.ZodNumber;
-        score: z.ZodNumber;
-    }, z.core.$loose>>>;
-    solar_system_id: z.ZodNumber;
-    start_time: z.ZodString;
-    structure_id: z.ZodNumber;
-}, z.core.$loose>;
-
 // Warning: (ae-forgotten-export) The symbol "sovereigntyEndpoints" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
@@ -11842,14 +7043,6 @@ interface SovereigntyMapGet {
 }
 
 // @public (undocumented)
-const SovereigntyMapGetSchema: z.ZodObject<{
-    alliance_id: z.ZodOptional<z.ZodNumber>;
-    corporation_id: z.ZodOptional<z.ZodNumber>;
-    faction_id: z.ZodOptional<z.ZodNumber>;
-    system_id: z.ZodNumber;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface SovereigntyStructuresGet {
     // (undocumented)
     alliance_id: number;
@@ -11866,17 +7059,6 @@ interface SovereigntyStructuresGet {
     // (undocumented)
     vulnerable_start_time?: string;
 }
-
-// @public (undocumented)
-const SovereigntyStructuresGetSchema: z.ZodObject<{
-    alliance_id: z.ZodNumber;
-    solar_system_id: z.ZodNumber;
-    structure_id: z.ZodNumber;
-    structure_type_id: z.ZodNumber;
-    vulnerability_occupancy_level: z.ZodOptional<z.ZodNumber>;
-    vulnerable_end_time: z.ZodOptional<z.ZodString>;
-    vulnerable_start_time: z.ZodOptional<z.ZodString>;
-}, z.core.$loose>;
 
 // @public (undocumented)
 export type SovereigntySystem = z.infer<typeof SovereigntySystemSchema>;
@@ -12024,14 +7206,6 @@ interface StatusGet {
 }
 
 // @public (undocumented)
-const StatusGetSchema: z.ZodObject<{
-    players: z.ZodNumber;
-    server_version: z.ZodString;
-    start_time: z.ZodString;
-    vip: z.ZodOptional<z.ZodBoolean>;
-}, z.core.$loose>;
-
-// @public (undocumented)
 export type StructureId = Brand<number, 'StructureId'>;
 
 // @public (undocumented)
@@ -12163,16 +7337,6 @@ interface UniverseAncestriesGet {
 }
 
 // @public (undocumented)
-const UniverseAncestriesGetSchema: z.ZodObject<{
-    bloodline_id: z.ZodNumber;
-    description: z.ZodString;
-    icon_id: z.ZodOptional<z.ZodNumber>;
-    id: z.ZodNumber;
-    name: z.ZodString;
-    short_description: z.ZodOptional<z.ZodString>;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface UniverseAsteroidBeltsAsteroidBeltIdGet {
     // (undocumented)
     name: string;
@@ -12185,17 +7349,6 @@ interface UniverseAsteroidBeltsAsteroidBeltIdGet {
     // (undocumented)
     system_id: number;
 }
-
-// @public (undocumented)
-const UniverseAsteroidBeltsAsteroidBeltIdGetSchema: z.ZodObject<{
-    name: z.ZodString;
-    position: z.ZodObject<{
-        x: z.ZodNumber;
-        y: z.ZodNumber;
-        z: z.ZodNumber;
-    }, z.core.$loose>;
-    system_id: z.ZodNumber;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface UniverseBloodlinesGet {
@@ -12224,21 +7377,6 @@ interface UniverseBloodlinesGet {
 }
 
 // @public (undocumented)
-const UniverseBloodlinesGetSchema: z.ZodObject<{
-    bloodline_id: z.ZodNumber;
-    charisma: z.ZodNumber;
-    corporation_id: z.ZodNumber;
-    description: z.ZodString;
-    intelligence: z.ZodNumber;
-    memory: z.ZodNumber;
-    name: z.ZodString;
-    perception: z.ZodNumber;
-    race_id: z.ZodNumber;
-    ship_type_id: z.ZodNumber;
-    willpower: z.ZodNumber;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface UniverseCategoriesCategoryIdGet {
     // (undocumented)
     category_id: number;
@@ -12249,14 +7387,6 @@ interface UniverseCategoriesCategoryIdGet {
     // (undocumented)
     published: boolean;
 }
-
-// @public (undocumented)
-const UniverseCategoriesCategoryIdGetSchema: z.ZodObject<{
-    category_id: z.ZodNumber;
-    groups: z.ZodArray<z.ZodNumber>;
-    name: z.ZodString;
-    published: z.ZodBoolean;
-}, z.core.$loose>;
 
 // Warning: (ae-forgotten-export) The symbol "universeEndpoints" needs to be exported by the entry point index.d.ts
 //
@@ -12315,19 +7445,6 @@ interface UniverseConstellationsConstellationIdGet {
 }
 
 // @public (undocumented)
-const UniverseConstellationsConstellationIdGetSchema: z.ZodObject<{
-    constellation_id: z.ZodNumber;
-    name: z.ZodString;
-    position: z.ZodObject<{
-        x: z.ZodNumber;
-        y: z.ZodNumber;
-        z: z.ZodNumber;
-    }, z.core.$loose>;
-    region_id: z.ZodNumber;
-    systems: z.ZodArray<z.ZodNumber>;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface UniverseFactionsGet {
     // (undocumented)
     corporation_id?: number;
@@ -12352,20 +7469,6 @@ interface UniverseFactionsGet {
 }
 
 // @public (undocumented)
-const UniverseFactionsGetSchema: z.ZodObject<{
-    corporation_id: z.ZodOptional<z.ZodNumber>;
-    description: z.ZodString;
-    faction_id: z.ZodNumber;
-    is_unique: z.ZodBoolean;
-    militia_corporation_id: z.ZodOptional<z.ZodNumber>;
-    name: z.ZodString;
-    size_factor: z.ZodNumber;
-    solar_system_id: z.ZodOptional<z.ZodNumber>;
-    station_count: z.ZodNumber;
-    station_system_count: z.ZodNumber;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface UniverseGraphicsGraphicIdGet {
     // (undocumented)
     collision_file?: string;
@@ -12386,18 +7489,6 @@ interface UniverseGraphicsGraphicIdGet {
 }
 
 // @public (undocumented)
-const UniverseGraphicsGraphicIdGetSchema: z.ZodObject<{
-    collision_file: z.ZodOptional<z.ZodString>;
-    graphic_file: z.ZodOptional<z.ZodString>;
-    graphic_id: z.ZodNumber;
-    icon_folder: z.ZodOptional<z.ZodString>;
-    sof_dna: z.ZodOptional<z.ZodString>;
-    sof_fation_name: z.ZodOptional<z.ZodString>;
-    sof_hull_name: z.ZodOptional<z.ZodString>;
-    sof_race_name: z.ZodOptional<z.ZodString>;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface UniverseGroupsGroupIdGet {
     // (undocumented)
     category_id: number;
@@ -12410,15 +7501,6 @@ interface UniverseGroupsGroupIdGet {
     // (undocumented)
     types: number[];
 }
-
-// @public (undocumented)
-const UniverseGroupsGroupIdGetSchema: z.ZodObject<{
-    category_id: z.ZodNumber;
-    group_id: z.ZodNumber;
-    name: z.ZodString;
-    published: z.ZodBoolean;
-    types: z.ZodArray<z.ZodNumber>;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface UniverseIdsPost {
@@ -12475,50 +7557,6 @@ interface UniverseIdsPost {
 }
 
 // @public (undocumented)
-const UniverseIdsPostSchema: z.ZodObject<{
-    agents: z.ZodOptional<z.ZodArray<z.ZodObject<{
-        id: z.ZodOptional<z.ZodNumber>;
-        name: z.ZodOptional<z.ZodString>;
-    }, z.core.$loose>>>;
-    alliances: z.ZodOptional<z.ZodArray<z.ZodObject<{
-        id: z.ZodOptional<z.ZodNumber>;
-        name: z.ZodOptional<z.ZodString>;
-    }, z.core.$loose>>>;
-    characters: z.ZodOptional<z.ZodArray<z.ZodObject<{
-        id: z.ZodOptional<z.ZodNumber>;
-        name: z.ZodOptional<z.ZodString>;
-    }, z.core.$loose>>>;
-    constellations: z.ZodOptional<z.ZodArray<z.ZodObject<{
-        id: z.ZodOptional<z.ZodNumber>;
-        name: z.ZodOptional<z.ZodString>;
-    }, z.core.$loose>>>;
-    corporations: z.ZodOptional<z.ZodArray<z.ZodObject<{
-        id: z.ZodOptional<z.ZodNumber>;
-        name: z.ZodOptional<z.ZodString>;
-    }, z.core.$loose>>>;
-    factions: z.ZodOptional<z.ZodArray<z.ZodObject<{
-        id: z.ZodOptional<z.ZodNumber>;
-        name: z.ZodOptional<z.ZodString>;
-    }, z.core.$loose>>>;
-    inventory_types: z.ZodOptional<z.ZodArray<z.ZodObject<{
-        id: z.ZodOptional<z.ZodNumber>;
-        name: z.ZodOptional<z.ZodString>;
-    }, z.core.$loose>>>;
-    regions: z.ZodOptional<z.ZodArray<z.ZodObject<{
-        id: z.ZodOptional<z.ZodNumber>;
-        name: z.ZodOptional<z.ZodString>;
-    }, z.core.$loose>>>;
-    stations: z.ZodOptional<z.ZodArray<z.ZodObject<{
-        id: z.ZodOptional<z.ZodNumber>;
-        name: z.ZodOptional<z.ZodString>;
-    }, z.core.$loose>>>;
-    systems: z.ZodOptional<z.ZodArray<z.ZodObject<{
-        id: z.ZodOptional<z.ZodNumber>;
-        name: z.ZodOptional<z.ZodString>;
-    }, z.core.$loose>>>;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface UniverseMoonsMoonIdGet {
     // (undocumented)
     moon_id: number;
@@ -12535,18 +7573,6 @@ interface UniverseMoonsMoonIdGet {
 }
 
 // @public (undocumented)
-const UniverseMoonsMoonIdGetSchema: z.ZodObject<{
-    moon_id: z.ZodNumber;
-    name: z.ZodString;
-    position: z.ZodObject<{
-        x: z.ZodNumber;
-        y: z.ZodNumber;
-        z: z.ZodNumber;
-    }, z.core.$loose>;
-    system_id: z.ZodNumber;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface UniverseNamesPost {
     // (undocumented)
     category: 'alliance' | 'character' | 'constellation' | 'corporation' | 'inventory_type' | 'region' | 'solar_system' | 'station' | 'faction';
@@ -12555,23 +7581,6 @@ interface UniverseNamesPost {
     // (undocumented)
     name: string;
 }
-
-// @public (undocumented)
-const UniverseNamesPostSchema: z.ZodObject<{
-    category: z.ZodEnum<{
-        faction: "faction";
-        character: "character";
-        corporation: "corporation";
-        alliance: "alliance";
-        constellation: "constellation";
-        inventory_type: "inventory_type";
-        region: "region";
-        solar_system: "solar_system";
-        station: "station";
-    }>;
-    id: z.ZodNumber;
-    name: z.ZodString;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface UniversePlanetsPlanetIdGet {
@@ -12592,19 +7601,6 @@ interface UniversePlanetsPlanetIdGet {
 }
 
 // @public (undocumented)
-const UniversePlanetsPlanetIdGetSchema: z.ZodObject<{
-    name: z.ZodString;
-    planet_id: z.ZodNumber;
-    position: z.ZodObject<{
-        x: z.ZodNumber;
-        y: z.ZodNumber;
-        z: z.ZodNumber;
-    }, z.core.$loose>;
-    system_id: z.ZodNumber;
-    type_id: z.ZodNumber;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface UniverseRacesGet {
     // (undocumented)
     alliance_id: number;
@@ -12615,14 +7611,6 @@ interface UniverseRacesGet {
     // (undocumented)
     race_id: number;
 }
-
-// @public (undocumented)
-const UniverseRacesGetSchema: z.ZodObject<{
-    alliance_id: z.ZodNumber;
-    description: z.ZodString;
-    name: z.ZodString;
-    race_id: z.ZodNumber;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface UniverseRegionsRegionIdGet {
@@ -12637,26 +7625,12 @@ interface UniverseRegionsRegionIdGet {
 }
 
 // @public (undocumented)
-const UniverseRegionsRegionIdGetSchema: z.ZodObject<{
-    constellations: z.ZodArray<z.ZodNumber>;
-    description: z.ZodOptional<z.ZodString>;
-    name: z.ZodString;
-    region_id: z.ZodNumber;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface UniverseSchematicsSchematicIdGet {
     // (undocumented)
     cycle_time: number;
     // (undocumented)
     schematic_name: string;
 }
-
-// @public (undocumented)
-const UniverseSchematicsSchematicIdGetSchema: z.ZodObject<{
-    cycle_time: z.ZodNumber;
-    schematic_name: z.ZodString;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface UniverseStargatesStargateIdGet {
@@ -12682,23 +7656,6 @@ interface UniverseStargatesStargateIdGet {
 }
 
 // @public (undocumented)
-const UniverseStargatesStargateIdGetSchema: z.ZodObject<{
-    destination: z.ZodObject<{
-        stargate_id: z.ZodNumber;
-        system_id: z.ZodNumber;
-    }, z.core.$loose>;
-    name: z.ZodString;
-    position: z.ZodObject<{
-        x: z.ZodNumber;
-        y: z.ZodNumber;
-        z: z.ZodNumber;
-    }, z.core.$loose>;
-    stargate_id: z.ZodNumber;
-    system_id: z.ZodNumber;
-    type_id: z.ZodNumber;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface UniverseStarsStarIdGet {
     // (undocumented)
     age: number;
@@ -12717,108 +7674,6 @@ interface UniverseStarsStarIdGet {
     // (undocumented)
     type_id: number;
 }
-
-// @public (undocumented)
-const UniverseStarsStarIdGetSchema: z.ZodObject<{
-    age: z.ZodNumber;
-    luminosity: z.ZodNumber;
-    name: z.ZodString;
-    radius: z.ZodNumber;
-    solar_system_id: z.ZodNumber;
-    spectral_class: z.ZodEnum<{
-        "K2 V": "K2 V";
-        "K4 V": "K4 V";
-        "G2 V": "G2 V";
-        "G8 V": "G8 V";
-        "M7 V": "M7 V";
-        "K7 V": "K7 V";
-        "M2 V": "M2 V";
-        "K5 V": "K5 V";
-        "M3 V": "M3 V";
-        "G0 V": "G0 V";
-        "G7 V": "G7 V";
-        "G3 V": "G3 V";
-        "F9 V": "F9 V";
-        "G5 V": "G5 V";
-        "F6 V": "F6 V";
-        "K8 V": "K8 V";
-        "K9 V": "K9 V";
-        "K6 V": "K6 V";
-        "G9 V": "G9 V";
-        "G6 V": "G6 V";
-        "G4 VI": "G4 VI";
-        "G4 V": "G4 V";
-        "F8 V": "F8 V";
-        "F2 V": "F2 V";
-        "F1 V": "F1 V";
-        "K3 V": "K3 V";
-        "F0 VI": "F0 VI";
-        "G1 VI": "G1 VI";
-        "G0 VI": "G0 VI";
-        "K1 V": "K1 V";
-        "M4 V": "M4 V";
-        "M1 V": "M1 V";
-        "M6 V": "M6 V";
-        "M0 V": "M0 V";
-        "K2 IV": "K2 IV";
-        "G2 VI": "G2 VI";
-        "K0 V": "K0 V";
-        "K5 IV": "K5 IV";
-        "F5 VI": "F5 VI";
-        "G6 VI": "G6 VI";
-        "F6 VI": "F6 VI";
-        "F2 IV": "F2 IV";
-        "G3 VI": "G3 VI";
-        "M8 V": "M8 V";
-        "F1 VI": "F1 VI";
-        "K1 IV": "K1 IV";
-        "F7 V": "F7 V";
-        "G5 VI": "G5 VI";
-        "M5 V": "M5 V";
-        "G7 VI": "G7 VI";
-        "F5 V": "F5 V";
-        "F4 VI": "F4 VI";
-        "F8 VI": "F8 VI";
-        "K3 IV": "K3 IV";
-        "F4 IV": "F4 IV";
-        "F0 V": "F0 V";
-        "G7 IV": "G7 IV";
-        "G8 VI": "G8 VI";
-        "F2 VI": "F2 VI";
-        "F4 V": "F4 V";
-        "F7 VI": "F7 VI";
-        "F3 V": "F3 V";
-        "G1 V": "G1 V";
-        "G9 VI": "G9 VI";
-        "F3 IV": "F3 IV";
-        "F9 VI": "F9 VI";
-        "M9 V": "M9 V";
-        "K0 IV": "K0 IV";
-        "F1 IV": "F1 IV";
-        "G4 IV": "G4 IV";
-        "F3 VI": "F3 VI";
-        "K4 IV": "K4 IV";
-        "G5 IV": "G5 IV";
-        "G3 IV": "G3 IV";
-        "G1 IV": "G1 IV";
-        "K7 IV": "K7 IV";
-        "G0 IV": "G0 IV";
-        "K6 IV": "K6 IV";
-        "K9 IV": "K9 IV";
-        "G2 IV": "G2 IV";
-        "F9 IV": "F9 IV";
-        "F0 IV": "F0 IV";
-        "K8 IV": "K8 IV";
-        "G8 IV": "G8 IV";
-        "F6 IV": "F6 IV";
-        "F5 IV": "F5 IV";
-        A0: "A0";
-        A0IV: "A0IV";
-        A0IV2: "A0IV2";
-    }>;
-    temperature: z.ZodNumber;
-    type_id: z.ZodNumber;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface UniverseStationsStationIdGet {
@@ -12853,54 +7708,6 @@ interface UniverseStationsStationIdGet {
 }
 
 // @public (undocumented)
-const UniverseStationsStationIdGetSchema: z.ZodObject<{
-    max_dockable_ship_volume: z.ZodNumber;
-    name: z.ZodString;
-    office_rental_cost: z.ZodNumber;
-    owner: z.ZodOptional<z.ZodNumber>;
-    position: z.ZodObject<{
-        x: z.ZodNumber;
-        y: z.ZodNumber;
-        z: z.ZodNumber;
-    }, z.core.$loose>;
-    race_id: z.ZodOptional<z.ZodNumber>;
-    reprocessing_efficiency: z.ZodNumber;
-    reprocessing_stations_take: z.ZodNumber;
-    services: z.ZodArray<z.ZodEnum<{
-        "bounty-missions": "bounty-missions";
-        "assasination-missions": "assasination-missions";
-        "courier-missions": "courier-missions";
-        interbus: "interbus";
-        "reprocessing-plant": "reprocessing-plant";
-        refinery: "refinery";
-        market: "market";
-        "black-market": "black-market";
-        "stock-exchange": "stock-exchange";
-        cloning: "cloning";
-        surgery: "surgery";
-        "dna-therapy": "dna-therapy";
-        "repair-facilities": "repair-facilities";
-        factory: "factory";
-        labratory: "labratory";
-        gambling: "gambling";
-        fitting: "fitting";
-        paintshop: "paintshop";
-        news: "news";
-        storage: "storage";
-        insurance: "insurance";
-        docking: "docking";
-        "office-rental": "office-rental";
-        "jump-clone-facility": "jump-clone-facility";
-        "loyalty-point-store": "loyalty-point-store";
-        "navy-offices": "navy-offices";
-        "security-offices": "security-offices";
-    }>>;
-    station_id: z.ZodNumber;
-    system_id: z.ZodNumber;
-    type_id: z.ZodNumber;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface UniverseStructuresStructureIdGet {
     // (undocumented)
     name: string;
@@ -12919,31 +7726,12 @@ interface UniverseStructuresStructureIdGet {
 }
 
 // @public (undocumented)
-const UniverseStructuresStructureIdGetSchema: z.ZodObject<{
-    name: z.ZodString;
-    owner_id: z.ZodNumber;
-    position: z.ZodOptional<z.ZodObject<{
-        x: z.ZodNumber;
-        y: z.ZodNumber;
-        z: z.ZodNumber;
-    }, z.core.$loose>>;
-    solar_system_id: z.ZodNumber;
-    type_id: z.ZodOptional<z.ZodNumber>;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface UniverseSystemJumpsGet {
     // (undocumented)
     ship_jumps: number;
     // (undocumented)
     system_id: number;
 }
-
-// @public (undocumented)
-const UniverseSystemJumpsGetSchema: z.ZodObject<{
-    ship_jumps: z.ZodNumber;
-    system_id: z.ZodNumber;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface UniverseSystemKillsGet {
@@ -12956,14 +7744,6 @@ interface UniverseSystemKillsGet {
     // (undocumented)
     system_id: number;
 }
-
-// @public (undocumented)
-const UniverseSystemKillsGetSchema: z.ZodObject<{
-    npc_kills: z.ZodNumber;
-    pod_kills: z.ZodNumber;
-    ship_kills: z.ZodNumber;
-    system_id: z.ZodNumber;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface UniverseSystemsSystemIdGet {
@@ -12996,28 +7776,6 @@ interface UniverseSystemsSystemIdGet {
     // (undocumented)
     system_id: number;
 }
-
-// @public (undocumented)
-const UniverseSystemsSystemIdGetSchema: z.ZodObject<{
-    constellation_id: z.ZodNumber;
-    name: z.ZodString;
-    planets: z.ZodOptional<z.ZodArray<z.ZodObject<{
-        asteroid_belts: z.ZodOptional<z.ZodArray<z.ZodNumber>>;
-        moons: z.ZodOptional<z.ZodArray<z.ZodNumber>>;
-        planet_id: z.ZodNumber;
-    }, z.core.$loose>>>;
-    position: z.ZodObject<{
-        x: z.ZodNumber;
-        y: z.ZodNumber;
-        z: z.ZodNumber;
-    }, z.core.$loose>;
-    security_class: z.ZodOptional<z.ZodString>;
-    security_status: z.ZodNumber;
-    star_id: z.ZodOptional<z.ZodNumber>;
-    stargates: z.ZodOptional<z.ZodArray<z.ZodNumber>>;
-    stations: z.ZodOptional<z.ZodArray<z.ZodNumber>>;
-    system_id: z.ZodNumber;
-}, z.core.$loose>;
 
 // @public (undocumented)
 interface UniverseTypesTypeIdGet {
@@ -13060,32 +7818,6 @@ interface UniverseTypesTypeIdGet {
     // (undocumented)
     volume?: number;
 }
-
-// @public (undocumented)
-const UniverseTypesTypeIdGetSchema: z.ZodObject<{
-    capacity: z.ZodOptional<z.ZodNumber>;
-    description: z.ZodString;
-    dogma_attributes: z.ZodOptional<z.ZodArray<z.ZodObject<{
-        attribute_id: z.ZodNumber;
-        value: z.ZodNumber;
-    }, z.core.$loose>>>;
-    dogma_effects: z.ZodOptional<z.ZodArray<z.ZodObject<{
-        effect_id: z.ZodNumber;
-        is_default: z.ZodBoolean;
-    }, z.core.$loose>>>;
-    graphic_id: z.ZodOptional<z.ZodNumber>;
-    group_id: z.ZodNumber;
-    icon_id: z.ZodOptional<z.ZodNumber>;
-    market_group_id: z.ZodOptional<z.ZodNumber>;
-    mass: z.ZodOptional<z.ZodNumber>;
-    name: z.ZodString;
-    packaged_volume: z.ZodOptional<z.ZodNumber>;
-    portion_size: z.ZodOptional<z.ZodNumber>;
-    published: z.ZodBoolean;
-    radius: z.ZodOptional<z.ZodNumber>;
-    type_id: z.ZodNumber;
-    volume: z.ZodOptional<z.ZodNumber>;
-}, z.core.$loose>;
 
 // @public
 export type UnwrapArray<T> = T extends readonly (infer E)[] ? E : T;
@@ -13230,45 +7962,12 @@ interface WarsWarIdGet {
 }
 
 // @public (undocumented)
-const WarsWarIdGetSchema: z.ZodObject<{
-    aggressor: z.ZodObject<{
-        alliance_id: z.ZodOptional<z.ZodNumber>;
-        corporation_id: z.ZodOptional<z.ZodNumber>;
-        isk_destroyed: z.ZodNumber;
-        ships_killed: z.ZodNumber;
-    }, z.core.$loose>;
-    allies: z.ZodOptional<z.ZodArray<z.ZodObject<{
-        alliance_id: z.ZodOptional<z.ZodNumber>;
-        corporation_id: z.ZodOptional<z.ZodNumber>;
-    }, z.core.$loose>>>;
-    declared: z.ZodString;
-    defender: z.ZodObject<{
-        alliance_id: z.ZodOptional<z.ZodNumber>;
-        corporation_id: z.ZodOptional<z.ZodNumber>;
-        isk_destroyed: z.ZodNumber;
-        ships_killed: z.ZodNumber;
-    }, z.core.$loose>;
-    finished: z.ZodOptional<z.ZodString>;
-    id: z.ZodNumber;
-    mutual: z.ZodBoolean;
-    open_for_allies: z.ZodBoolean;
-    retracted: z.ZodOptional<z.ZodString>;
-    started: z.ZodOptional<z.ZodString>;
-}, z.core.$loose>;
-
-// @public (undocumented)
 interface WarsWarIdKillmailsGet {
     // (undocumented)
     killmail_hash: string;
     // (undocumented)
     killmail_id: number;
 }
-
-// @public (undocumented)
-const WarsWarIdKillmailsGetSchema: z.ZodObject<{
-    killmail_hash: z.ZodString;
-    killmail_id: z.ZodNumber;
-}, z.core.$loose>;
 
 // @public (undocumented)
 export type WithMetadata<T> = {

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -31,5 +31,6 @@ export * from './universe';
 export * from './wallet';
 export * from './wars';
 
-// Auto-generated schemas from OpenAPI spec
-export * as generatedSchemas from './generated';
+// Generated schemas (src/schemas/generated/) are internal-only and used
+// exclusively by scripts/generate-schema-drift-report.ts for drift detection.
+// They are intentionally NOT re-exported from the public API surface.

--- a/tests/tdd/core/__snapshots__/apiSurfaceSnapshots.test.ts.snap
+++ b/tests/tdd/core/__snapshots__/apiSurfaceSnapshots.test.ts.snap
@@ -271,6 +271,5 @@ exports[`API surface snapshots schema exports should match snapshot 1`] = `
   "WalletTransactionSchema",
   "WarSchema",
   "esiResponse",
-  "generatedSchemas",
 ]
 `;


### PR DESCRIPTION
## Summary
- Removes `export * as generatedSchemas from './generated'` from `src/schemas/index.ts`
- Generated schemas remain in `src/schemas/generated/` as internal-only drift-detection baseline for `npm run schema:drift`
- API surface report shrinks by ~5,300 lines (all generated schema type declarations removed)
- Updated `apiSurfaceSnapshots.test.ts` snapshot to remove `generatedSchemas` entry

## Test plan
- [ ] Typecheck passes
- [ ] `npm run schema:drift` still works (imports generated schemas directly, not through removed re-export)
- [ ] API surface report regenerated and committed
- [ ] No remaining references to `generatedSchemas` in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)