### PR TITLE
feat: add opt-in request-body Zod validation for mutation endpoints

### DIFF
--- a/etc/esi.ts.api.md
+++ b/etc/esi.ts.api.md
@@ -271,6 +271,8 @@ export class ApiClient {
     // (undocumented)
     getTimeout(): number;
     // (undocumented)
+    getValidateRequest(): boolean;
+    // (undocumented)
     getValidateResponse(): boolean;
     // (undocumented)
     hasTokenProvider(): boolean;
@@ -298,6 +300,8 @@ export class ApiClient {
     setTimeout(timeout: number): void;
     // (undocumented)
     setTokenProvider(provider: TokenProvider | undefined): void;
+    // (undocumented)
+    setValidateRequest(validate: boolean): void;
     // (undocumented)
     setValidateResponse(validate: boolean): void;
     // (undocumented)
@@ -8099,6 +8103,8 @@ export interface EsiClientConfig {
     // (undocumented)
     unsafeAllowCustomHost?: boolean;
     // (undocumented)
+    validateRequest?: boolean;
+    // (undocumented)
     validateResponse?: boolean;
 }
 
@@ -8736,7 +8742,9 @@ declare namespace EsiSpec {
 
 // @public (undocumented)
 export class EsiValidationError extends EsiError {
-    constructor(url: string, zodError: unknown, requestId?: string);
+    constructor(url: string, zodError: unknown, requestId?: string, direction?: ValidationDirection);
+    // (undocumented)
+    readonly direction: ValidationDirection;
     // (undocumented)
     readonly validationError: unknown;
 }
@@ -13089,6 +13097,9 @@ const UniverseTypesTypeIdGetSchema: z.ZodObject<{
 
 // @public
 export type UnwrapArray<T> = T extends readonly (infer E)[] ? E : T;
+
+// @public (undocumented)
+export type ValidationDirection = 'request' | 'response';
 
 // Warning: (ae-forgotten-export) The symbol "walletEndpoints" needs to be exported by the entry point index.d.ts
 //

--- a/src/EsiClient.ts
+++ b/src/EsiClient.ts
@@ -82,6 +82,7 @@ export interface EsiClientConfig {
   requestInterceptors?: RequestInterceptor[];
   responseInterceptors?: ResponseInterceptor[];
   validateResponse?: boolean;
+  validateRequest?: boolean;
 }
 
 export class EsiClient {

--- a/src/core/ApiClient.ts
+++ b/src/core/ApiClient.ts
@@ -27,6 +27,7 @@ export class ApiClient {
   private retryConfig: RetryConfig | null = null;
   private retryStrategy: IRetryStrategy | null = null;
   private validateResponse: boolean = true;
+  private validateRequest: boolean = false;
   private language?: string;
 
   constructor(
@@ -101,6 +102,14 @@ export class ApiClient {
     this.validateResponse = validate;
   }
 
+  getValidateRequest(): boolean {
+    return this.validateRequest;
+  }
+
+  setValidateRequest(validate: boolean): void {
+    this.validateRequest = validate;
+  }
+
   getMiddleware(): MiddlewareManager {
     return this.middleware;
   }
@@ -163,6 +172,7 @@ export class ApiClient {
       hasDeduplicator: this.deduplicator !== null,
       hasTokenProvider: this.tokenProvider !== undefined,
       validateResponse: this.validateResponse,
+      validateRequest: this.validateRequest,
       language: this.language,
     };
   }

--- a/src/core/configureApiClient.ts
+++ b/src/core/configureApiClient.ts
@@ -73,6 +73,11 @@ export function configureApiClient(
     client.setValidateResponse(config.validateResponse);
   }
 
+  // Validate request (opt-in, default false)
+  if (config?.validateRequest !== undefined) {
+    client.setValidateRequest(config.validateRequest);
+  }
+
   // Timeout
   if (config?.timeout !== undefined) {
     client.setTimeout(config.timeout);

--- a/src/core/endpoints/EndpointDefinition.ts
+++ b/src/core/endpoints/EndpointDefinition.ts
@@ -30,6 +30,8 @@ export interface EndpointDefinition {
   deprecated?: DeprecationInfo;
   /** Zod schema for runtime response validation */
   responseSchema?: z.ZodTypeAny;
+  /** Zod schema for runtime request body validation (opt-in via validateRequest) */
+  requestSchema?: z.ZodTypeAny;
 }
 
 export type EndpointMap = Record<string, EndpointDefinition>;

--- a/src/core/endpoints/contactEndpoints.ts
+++ b/src/core/endpoints/contactEndpoints.ts
@@ -52,6 +52,7 @@ export const contactEndpoints = {
     pathParams: ['characterId'],
     queryParams: { standing: 'standing' },
     bodyBuilder: (contactIds: number[]) => contactIds,
+    requestSchema: z.array(z.number().int()),
   },
   editContacts: {
     path: 'characters/{characterId}/contacts',

--- a/src/core/endpoints/createClient.ts
+++ b/src/core/endpoints/createClient.ts
@@ -121,6 +121,23 @@ export function createClient<T extends EndpointMap>(
         let path = built.path;
         const body = built.body;
 
+        // Opt-in request body validation
+        if (
+          apiClient.getValidateRequest() &&
+          def.requestSchema &&
+          body != null
+        ) {
+          const reqResult = def.requestSchema.safeParse(body);
+          if (!reqResult.success) {
+            throw new EsiValidationError(
+              `${apiClient.getLink()}/${path}`,
+              reqResult.error,
+              undefined,
+              'request',
+            );
+          }
+        }
+
         if (def.cursorPagination) {
           const lastArg = args[args.length - 1];
           const isCursorArg =

--- a/src/core/endpoints/fleetEndpoints.ts
+++ b/src/core/endpoints/fleetEndpoints.ts
@@ -28,6 +28,10 @@ export const fleetEndpoints = {
     requiresAuth: true,
     pathParams: ['fleetId'],
     hasBody: true,
+    requestSchema: z.looseObject({
+      is_free_move: z.boolean().optional(),
+      motd: z.string().optional(),
+    }),
   },
   getFleetMembers: {
     path: 'fleets/{fleetId}/members',

--- a/src/core/endpoints/mailEndpoints.ts
+++ b/src/core/endpoints/mailEndpoints.ts
@@ -21,6 +21,21 @@ export const mailEndpoints = {
     requiresAuth: true,
     pathParams: ['characterId'],
     hasBody: true,
+    requestSchema: z.looseObject({
+      recipients: z.array(
+        z.looseObject({
+          recipient_id: z.number().int(),
+          recipient_type: z.enum([
+            'alliance',
+            'character',
+            'corporation',
+            'mailing_list',
+          ]),
+        }),
+      ),
+      subject: z.string().min(1),
+      body: z.string().min(1),
+    }),
   },
   getMail: {
     path: 'characters/{characterId}/mail/{mailId}/',

--- a/src/core/endpoints/universeEndpoints.ts
+++ b/src/core/endpoints/universeEndpoints.ts
@@ -110,6 +110,7 @@ export const universeEndpoints = {
     requiresAuth: false,
     bodyBuilder: (names: string[]) => names,
     responseSchema: BulkIdResultSchema,
+    requestSchema: z.array(z.string().min(1)),
   },
   getMoonById: {
     path: 'universe/moons/{moonId}',
@@ -124,6 +125,7 @@ export const universeEndpoints = {
     requiresAuth: false,
     bodyBuilder: (ids: number[]) => ids,
     responseSchema: z.array(NameAndCategorySchema),
+    requestSchema: z.array(z.number().int()),
   },
   getPlanetById: {
     path: 'universe/planets/{planetId}',

--- a/src/core/util/error.ts
+++ b/src/core/util/error.ts
@@ -133,14 +133,24 @@ export const buildError = (
   return error;
 };
 
+export type ValidationDirection = 'request' | 'response';
+
 export class EsiValidationError extends EsiError {
   public readonly validationError: unknown;
+  public readonly direction: ValidationDirection;
 
-  constructor(url: string, zodError: unknown, requestId?: string) {
+  constructor(
+    url: string,
+    zodError: unknown,
+    requestId?: string,
+    direction: ValidationDirection = 'response',
+  ) {
     const safeUrl = sanitizeUrl(url) ?? url;
-    super(0, `Response validation failed for ${safeUrl}`, url, requestId);
+    const label = direction === 'request' ? 'Request body' : 'Response';
+    super(0, `${label} validation failed for ${safeUrl}`, url, requestId);
     this.name = 'EsiValidationError';
     this.validationError = zodError;
+    this.direction = direction;
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,7 @@ export {
   isValidationError,
   sanitizeUrl,
 } from './core/util/error';
+export type { ValidationDirection } from './core/util/error';
 
 // Endpoint definition types
 export { DeprecationInfo } from './core/endpoints/EndpointDefinition';

--- a/tests/tdd/core/requestBodyValidation.test.ts
+++ b/tests/tdd/core/requestBodyValidation.test.ts
@@ -1,0 +1,258 @@
+import { z } from 'zod';
+import { ApiClient } from '../../../src/core/ApiClient';
+import { createClient } from '../../../src/core/endpoints/createClient';
+import { EndpointMap } from '../../../src/core/endpoints/EndpointDefinition';
+import { EsiValidationError } from '../../../src/core/util/error';
+import { RateLimiter } from '../../../src/core/rateLimiter/RateLimiter';
+import fetchMock from 'jest-fetch-mock';
+
+fetchMock.enableMocks();
+
+const BASE_URL = 'https://esi.evetech.net';
+
+describe('request body validation', () => {
+  let apiClient: ApiClient;
+  let rateLimiter: RateLimiter;
+
+  beforeEach(() => {
+    fetchMock.resetMocks();
+    rateLimiter = new RateLimiter();
+    rateLimiter.setTestMode(true);
+    apiClient = new ApiClient('test', BASE_URL);
+    apiClient.setRateLimiter(rateLimiter);
+  });
+
+  afterEach(() => {
+    rateLimiter.setTestMode(false);
+  });
+
+  const endpointsWithRequestSchema = {
+    postNames: {
+      path: 'universe/ids',
+      method: 'POST' as const,
+      requiresAuth: false,
+      bodyBuilder: (names: string[]) => names,
+      requestSchema: z.array(z.string().min(1)),
+    },
+    postIds: {
+      path: 'universe/names',
+      method: 'POST' as const,
+      requiresAuth: false,
+      bodyBuilder: (ids: number[]) => ids,
+      requestSchema: z.array(z.number().int()),
+    },
+    postWithBody: {
+      path: 'test/body',
+      method: 'POST' as const,
+      requiresAuth: false,
+      hasBody: true,
+      requestSchema: z.looseObject({
+        name: z.string(),
+        count: z.number(),
+      }),
+    },
+  } satisfies EndpointMap;
+
+  const endpointsWithoutRequestSchema = {
+    postNoSchema: {
+      path: 'test/no-schema',
+      method: 'POST' as const,
+      requiresAuth: false,
+      hasBody: true,
+    },
+  } satisfies EndpointMap;
+
+  const getOnlyEndpoints = {
+    getStatus: {
+      path: 'latest/status/',
+      method: 'GET' as const,
+      requiresAuth: false,
+    },
+  } satisfies EndpointMap;
+
+  describe('when validateRequest is true', () => {
+    beforeEach(() => {
+      apiClient.setValidateRequest(true);
+    });
+
+    it('should reject invalid body for bodyBuilder endpoint', async () => {
+      const client = createClient(apiClient, endpointsWithRequestSchema);
+
+      // Pass numbers instead of strings
+      await expect(
+        (client.postNames as (...args: unknown[]) => Promise<unknown>)([
+          123, 456,
+        ]),
+      ).rejects.toThrow(EsiValidationError);
+    });
+
+    it('should reject invalid body for hasBody endpoint', async () => {
+      const client = createClient(apiClient, endpointsWithRequestSchema);
+
+      // Pass object missing required fields
+      await expect(
+        (client.postWithBody as (...args: unknown[]) => Promise<unknown>)({
+          name: 'test',
+          // missing count
+        }),
+      ).rejects.toThrow(EsiValidationError);
+    });
+
+    it('should pass through valid body for bodyBuilder endpoint', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ characters: [] }));
+      const client = createClient(apiClient, endpointsWithRequestSchema);
+
+      await expect(
+        (client.postNames as (...args: unknown[]) => Promise<unknown>)([
+          'Tritanium',
+          'Pyerite',
+        ]),
+      ).resolves.toBeDefined();
+    });
+
+    it('should pass through valid body for hasBody endpoint', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ ok: true }));
+      const client = createClient(apiClient, endpointsWithRequestSchema);
+
+      await expect(
+        (client.postWithBody as (...args: unknown[]) => Promise<unknown>)({
+          name: 'test',
+          count: 5,
+        }),
+      ).resolves.toBeDefined();
+    });
+
+    it('should skip validation for endpoints without requestSchema', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ ok: true }));
+      const client = createClient(apiClient, endpointsWithoutRequestSchema);
+
+      // Any body should pass since no requestSchema is defined
+      await expect(
+        (client.postNoSchema as (...args: unknown[]) => Promise<unknown>)({
+          anything: 'goes',
+        }),
+      ).resolves.toBeDefined();
+    });
+
+    it('should skip validation for GET endpoints', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ players: 100 }));
+      const client = createClient(apiClient, getOnlyEndpoints);
+
+      await expect(client.getStatus()).resolves.toBeDefined();
+    });
+
+    it('should include direction "request" in the validation error', async () => {
+      const client = createClient(apiClient, endpointsWithRequestSchema);
+
+      try {
+        await (client.postNames as (...args: unknown[]) => Promise<unknown>)([
+          123,
+        ]);
+        fail('Expected EsiValidationError to be thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(EsiValidationError);
+        const validationError = err as EsiValidationError;
+        expect(validationError.direction).toBe('request');
+        expect(validationError.message).toContain('Request body');
+      }
+    });
+
+    it('should include the endpoint URL in the error', async () => {
+      const client = createClient(apiClient, endpointsWithRequestSchema);
+
+      try {
+        await (client.postNames as (...args: unknown[]) => Promise<unknown>)([
+          123,
+        ]);
+        fail('Expected EsiValidationError to be thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(EsiValidationError);
+        const validationError = err as EsiValidationError;
+        expect(validationError.message).toContain('universe/ids');
+      }
+    });
+
+    it('should validate integer constraint on number arrays', async () => {
+      const client = createClient(apiClient, endpointsWithRequestSchema);
+
+      // Pass floating point numbers instead of integers
+      await expect(
+        (client.postIds as (...args: unknown[]) => Promise<unknown>)([
+          1.5, 2.7,
+        ]),
+      ).rejects.toThrow(EsiValidationError);
+    });
+
+    it('should accept valid integer arrays', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify([{ id: 1, name: 'Test', category: 'character' }]),
+      );
+      const client = createClient(apiClient, endpointsWithRequestSchema);
+
+      await expect(
+        (client.postIds as (...args: unknown[]) => Promise<unknown>)([1, 2, 3]),
+      ).resolves.toBeDefined();
+    });
+
+    it('should allow extra fields with looseObject schemas', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ ok: true }));
+      const client = createClient(apiClient, endpointsWithRequestSchema);
+
+      // looseObject should permit extra fields
+      await expect(
+        (client.postWithBody as (...args: unknown[]) => Promise<unknown>)({
+          name: 'test',
+          count: 5,
+          extraField: 'allowed',
+        }),
+      ).resolves.toBeDefined();
+    });
+  });
+
+  describe('when validateRequest is false (default)', () => {
+    it('should default to false', () => {
+      expect(apiClient.getValidateRequest()).toBe(false);
+    });
+
+    it('should skip validation even with invalid body', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ characters: [] }));
+      const client = createClient(apiClient, endpointsWithRequestSchema);
+
+      // Invalid body (numbers instead of strings) should pass without validation
+      await expect(
+        (client.postNames as (...args: unknown[]) => Promise<unknown>)([
+          123, 456,
+        ]),
+      ).resolves.toBeDefined();
+    });
+
+    it('should skip validation for hasBody endpoints', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ ok: true }));
+      const client = createClient(apiClient, endpointsWithRequestSchema);
+
+      // Missing required field should pass without validation
+      await expect(
+        (client.postWithBody as (...args: unknown[]) => Promise<unknown>)({
+          name: 'test',
+          // missing count
+        }),
+      ).resolves.toBeDefined();
+    });
+  });
+
+  describe('validateRequest getter/setter', () => {
+    it('should set and get validateRequest', () => {
+      apiClient.setValidateRequest(true);
+      expect(apiClient.getValidateRequest()).toBe(true);
+
+      apiClient.setValidateRequest(false);
+      expect(apiClient.getValidateRequest()).toBe(false);
+    });
+
+    it('should include validateRequest in toJSON', () => {
+      apiClient.setValidateRequest(true);
+      const json = apiClient.toJSON();
+      expect(json.validateRequest).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds optional `requestSchema` field to `EndpointDefinition` for defining request body schemas
- Adds `validateRequest` config option (default `false`, opt-in) mirroring the existing `validateResponse` pattern
- Validates request bodies in `createClient.ts` before `handleRequest()` — throws `EsiValidationError` with `direction: 'request'` on failure
- Wired through `configureApiClient` for all three construction surfaces
- Request schemas added for 5 endpoints: `postBulkNamesToIds`, `postNamesAndCategories`, `sendMail`, `updateFleet`, `addContacts`
- 16 new tests covering valid/invalid bodies, skip-when-disabled, skip-without-schema, error direction

## Test plan
- [ ] 16 new tests in `requestBodyValidation.test.ts` pass
- [ ] All existing tests pass (no behavioral change when `validateRequest` is false)
- [ ] Typecheck passes
- [ ] API surface report updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)