### PR TITLE
test: push all coverage metrics above 90%

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Tools like `openapi-typescript` or `openapi-generator` can produce a typed clien
 | **Batch operations**            | None.                                                                                                               | `batch()` with bounded concurrency for GET fan-out, `batchPost()` with auto-chunking for large POST payloads.                                                                                                                      |
 | **Domain knowledge**            | None — generic HTTP client.                                                                                         | 35 domain clients with typed methods, JSDoc documentation, and input validation (e.g., fleet wing/squad names are capped at 10 characters before hitting the API).                                                                 |
 | **Streaming pagination**        | None.                                                                                                               | 21 domain clients with 73+ `stream*` methods via `AsyncGenerator` — process large datasets page-by-page without loading everything into memory.                                                                                    |
-| **Testing**                     | Whatever you write.                                                                                                 | 95+ test suites, 3,800+ tests across 9 tiers including property-based fuzzing (fast-check), mutation testing (Stryker), deep contract tests against live OpenAPI spec, and consumer type tests (tsd). 43 runnable example scripts. |
+| **Testing**                     | Whatever you write.                                                                                                 | 139 test suites, 4,080+ tests across 9 tiers including property-based fuzzing (fast-check), mutation testing (Stryker), deep contract tests against live OpenAPI spec, and consumer type tests (tsd). 43 runnable example scripts. |
 
 ### The real problem with generated clients
 
@@ -74,7 +74,7 @@ Verify everything works:
 
 ```bash
 npm run example:status   # quick smoke test — checks ESI is reachable
-npm test                 # run the full test suite (95+ suites, 3,800+ tests)
+npm test                 # run the full test suite (139 suites, 4,080+ tests)
 ```
 
 ## Quick Start
@@ -821,7 +821,7 @@ try {
 
 ## Testing
 
-ESI.ts has a comprehensive multi-tier testing strategy with 95+ suites and 3,800+ tests:
+ESI.ts has a comprehensive multi-tier testing strategy with 139 suites and 4,080+ tests:
 
 | Tier                       | Tests            | Purpose                                                            |
 | -------------------------- | ---------------- | ------------------------------------------------------------------ |
@@ -839,7 +839,7 @@ ESI.ts has a comprehensive multi-tier testing strategy with 95+ suites and 3,800
 | **Spec-alignment**         | Type assertions  | Ensures hand-written types align with generated OpenAPI types      |
 
 ```bash
-npm test          # Unit + BDD tests (95+ suites, 3,800+ tests)
+npm test          # Unit + BDD tests (139 suites, 4,080+ tests)
 npm run coverage  # Tests with coverage report (thresholds enforced)
 npm run bdd       # BDD scenario tests only
 npm run contract  # Contract tests (skipped without ESI_LIVE_TESTS=true)
@@ -849,7 +849,7 @@ npm run benchmark # Performance benchmark tests
 npm run test:types # tsd consumer type tests
 ```
 
-Coverage thresholds are enforced in CI: branches 80%, functions 75%, lines 90%, statements 90%.
+Coverage: statements 98.47%, branches 90.10%, functions 97.54%, lines 98.59%. Thresholds enforced in CI: branches 80%, functions 75%, lines 90%, statements 90%.
 
 See [guides/TESTING.md](guides/TESTING.md) for the full testing guide, and [guides/ARCHITECTURE.md](guides/ARCHITECTURE.md) for architecture diagrams.
 
@@ -886,7 +886,7 @@ npm run format             # Format code with Prettier
 npm run format:check       # Check formatting without modifying
 
 # Testing
-npm test                   # Unit tests (95+ suites, 3,800+ tests)
+npm test                   # Unit tests (139 suites, 4,080+ tests)
 npm run test:all           # Unit + BDD + integration + fuzz + type tests
 npm run coverage           # Tests with coverage report (thresholds enforced)
 npm run bdd                # BDD scenario tests

--- a/guides/TESTING.md
+++ b/guides/TESTING.md
@@ -6,7 +6,7 @@ ESI.ts uses a multi-tier testing strategy to ensure correctness at every level �
 
 | Tier                 |      Tests |   Suites | Purpose                                                                     |
 | -------------------- | ---------: | -------: | --------------------------------------------------------------------------- |
-| TDD (unit)           |      3,238 |       85 | Per-module unit tests with mocked HTTP                                      |
+| TDD (unit)           |      3,480 |       99 | Per-module unit tests with mocked HTTP                                      |
 | BDD (behavioral)     |        600 |       40 | Gherkin-style scenarios covering user-facing behaviors                      |
 | Benchmark (perf)     |         17 |        4 | Performance regression guards for core infrastructure                       |
 | Integration (mocked) |         20 |        1 | Full request lifecycle with mocked fetch                                    |
@@ -15,7 +15,7 @@ ESI.ts uses a multi-tier testing strategy to ensure correctness at every level �
 | Contract (deep)      |         15 |        2 | Endpoint definitions validated against live OpenAPI spec (8 categories)     |
 | Fuzz (fast-check)    |        601 |        4 | Property-based testing of validation, URLs, schemas, pagination             |
 | Type (tsd)           |            |        1 | Consumer API type correctness                                               |
-| **Total**            | **4,400+** | **130+** | (`npm test` runs TDD + BDD; `npm run test:all` includes fuzz + types)       |
+| **Total**            | **4,600+** | **140+** | (`npm test` runs TDD + BDD; `npm run test:all` includes fuzz + types)       |
 
 ## Coverage
 
@@ -23,30 +23,33 @@ Current coverage (unit + BDD, measured by Jest):
 
 | Metric     |  Value | Threshold |
 | ---------- | -----: | --------: |
-| Statements | 96.35% |       90% |
-| Branches   | 87.40% |       80% |
-| Functions  | 93.20% |       75% |
-| Lines      | 96.38% |       90% |
+| Statements | 98.47% |       90% |
+| Branches   | 90.10% |       80% |
+| Functions  | 97.54% |       75% |
+| Lines      | 98.59% |       90% |
 
 Coverage is collected from `src/**/*.ts` (excluding `.d.ts` and `src/types/`).
 
 ### Per-File Test Breakdown (Notable Test Suites)
 
-| File                           | Tests | Category                                        |
-| ------------------------------ | ----: | ----------------------------------------------- |
-| `resilience.test.ts`           |    12 | Rate limits, malformed responses, retry, dedup  |
-| `security.test.ts`             |    23 | Token leakage, HTTPS, host allowlist, injection |
-| `configValidation.test.ts`     |    33 | Builder, factory, config combos, shutdown       |
-| `publicApiSurface.test.ts`     |   135 | Export snapshot — breaking-change detector      |
-| `crossCutting.test.ts`         |    15 | Diagnostics, middleware ordering, logger        |
-| `apiSurfaceSnapshots.test.ts`  |     5 | API export & shape snapshot regression          |
-| `concurrency.test.ts`          |    11 | Deduplicator, batch fetch, rate limiter races   |
-| `utilFunctions.test.ts`        |    25 | camelToSnake, sleep, retryDelay, buildError     |
-| `schemaRejection.test.ts`      |   423 | Valid/invalid/extra-field for all 33 schemas    |
-| `clientErrorTests.ts` (helper) |   150 | HTTP 401/403/404/429/500 across 30 clients      |
-| `esi-spec-contract.test.ts`    |    10 | Live OpenAPI drift detection                    |
-| `client-integration.test.ts`   |    11 | Full EsiClient against live ESI                 |
-| `live-esi.test.ts` (expanded)  |    40 | Smoke tests across 42 endpoints                 |
+| File                           | Tests | Category                                          |
+| ------------------------------ | ----: | ------------------------------------------------- |
+| `resilience.test.ts`           |    12 | Rate limits, malformed responses, retry, dedup    |
+| `security.test.ts`             |    23 | Token leakage, HTTPS, host allowlist, injection   |
+| `configValidation.test.ts`     |    33 | Builder, factory, config combos, shutdown         |
+| `publicApiSurface.test.ts`     |   135 | Export snapshot — breaking-change detector        |
+| `crossCutting.test.ts`         |    15 | Diagnostics, middleware ordering, logger          |
+| `apiSurfaceSnapshots.test.ts`  |     5 | API export & shape snapshot regression            |
+| `concurrency.test.ts`          |    11 | Deduplicator, batch fetch, rate limiter races     |
+| `utilFunctions.test.ts`        |    25 | camelToSnake, sleep, retryDelay, buildError       |
+| `schemaRejection.test.ts`      |   423 | Valid/invalid/extra-field for all 33 schemas      |
+| `clientErrorTests.ts` (helper) |   150 | HTTP 401/403/404/429/500 across 30 clients        |
+| `esi-spec-contract.test.ts`    |    10 | Live OpenAPI drift detection                      |
+| `client-integration.test.ts`   |    11 | Full EsiClient against live ESI                   |
+| `live-esi.test.ts` (expanded)  |    40 | Smoke tests across 42 endpoints                   |
+| `streamMethods.test.ts`        |    71 | Stream method delegation across 19 domain clients |
+| `coverageBranches.test.ts`     |    13 | BaseEsiClient, EsiClient, builder branch coverage |
+| `paginationBranches.test.ts`   |    12 | Pagination handler edge case branches             |
 
 ## Test Structure
 
@@ -100,7 +103,11 @@ tests/
 │   │   ├── tokenRefresh.test.ts
 │   │   ├── utilFunctions.test.ts           # Core utility functions (25 tests)
 │   │   ├── validation.test.ts
-│   │   └── WithMetadata.test.ts
+│   │   ├── WithMetadata.test.ts
+│   │   ├── coverageBranches.test.ts        # BaseEsiClient, EsiClient, builder branches (13 tests)
+│   │   └── paginationBranches.test.ts      # Pagination handler edge cases (12 tests)
+│   ├── clients/
+│   │   └── streamMethods.test.ts           # Stream method delegation across 19 clients (71 tests)
 │   ├── helpers/                  # Shared test utilities
 │   │   └── clientErrorTests.ts             # Reusable HTTP error test generator
 │   ├── schemas/                  # Schema validation tests (Zod)
@@ -174,7 +181,7 @@ tests/
 ## Running Tests
 
 ```bash
-# All unit + BDD tests (default) — 125 suites, 3,838 tests
+# All unit + BDD tests (default) — 139 suites, 4,080 tests
 npm test
 
 # Watch mode for development
@@ -220,7 +227,7 @@ npm run bdd:performance
 **Config:** `jest.unit.config.cjs`
 **Run:** `npm test`
 
-85 test files covering:
+99 test files covering:
 
 - **Domain clients** (35 files) — One per ESI API module (AllianceClient, MarketClient, etc.). Each mocks `fetch` and verifies correct URL construction, response parsing, and type safety. All 30 non-trivial clients include HTTP error path coverage (401, 403, 404, 429, 500) via the shared `describeClientErrors` helper.
 - **Core infrastructure** (35+ files) — Circuit breaker, rate limiter, pagination (offset + cursor), ETag cache, request deduplication, retry with backoff, middleware pipeline, endpoint definitions, validation, error handling, timeout behavior, diagnostics, and configuration.
@@ -233,6 +240,9 @@ npm run bdd:performance
 - **Configuration** (`configValidation.test.ts`) — Default config, all features enabled simultaneously, EsiClientBuilder selective/full client registration, EsiApiFactory methods, token provider, datasource/language config, shutdown idempotency, legacy retry config.
 - **Public API Surface** (`publicApiSurface.test.ts`) — Snapshot of all 35 domain client exports, 21 class/function exports, 8 type guard functions, 35 domain accessors on EsiClient, and 13 EsiClient methods. Acts as a contract — if a public export is accidentally removed, this test breaks.
 - **Cross-Cutting** (`crossCutting.test.ts`) — Diagnostics accuracy (cache stats, circuit breaker stats, clearCache, resetCircuitBreaker), middleware ordering (request before response, registration order, remove at runtime, constructor config), and custom logger integration.
+- **Stream methods** (`streamMethods.test.ts`) — 71 tests verifying all `stream*()` methods across 19 domain clients delegate correctly to `BaseEsiClient.streamEndpoint()` with the right endpoint name and arguments.
+- **Pagination branches** (`paginationBranches.test.ts`) — Edge case branches in `PaginationHandler` (no rate limiter, non-Error thrown values, null page data), `CursorPaginationHandler` (pageFetch delegate, non-abort errors, invalid JSON, body passthrough), `resolveRateLimiter` error path, and `handleOffsetPagination` generic error wrapping.
+- **Coverage branches** (`coverageBranches.test.ts`) — `BaseEsiClient.withSafeMode()` and `withMetadata()` memoization, `EsiClient.batch()` and `batchPost()` delegation, `EsiApiFactory` static factory config branches, and `CustomEsiClient` constructor config branches.
 
 ### Tier 2: BDD Behavioral Tests
 
@@ -860,7 +870,7 @@ npm run generate:types
 | `jest.integration.config.cjs`                  | Integration test config (30s timeout)             |
 | `jest.contract.config.cjs`                     | Contract test config (60s timeout)                |
 | `jest.fuzz.config.cjs`                         | Fuzz test config (30s timeout)                    |
-| `tests/tdd/`                                   | 85 TDD test files                                 |
+| `tests/tdd/`                                   | 99 TDD test files                                 |
 | `tests/tdd/helpers/clientErrorTests.ts`        | Shared HTTP error test generator (5 status codes) |
 | `tests/tdd/core/apiSurfaceSnapshots.test.ts`   | API export & shape snapshot tests (5 tests)       |
 | `tests/tdd/core/concurrency.test.ts`           | Async scheduling correctness (11 tests)           |

--- a/tests/tdd/clients/streamMethods.test.ts
+++ b/tests/tdd/clients/streamMethods.test.ts
@@ -1,0 +1,565 @@
+import { ApiClient } from '../../../src/core/ApiClient';
+import { BaseEsiClient } from '../../../src/clients/BaseEsiClient';
+import { RateLimiter } from '../../../src/core/rateLimiter/RateLimiter';
+
+import { AllianceClient } from '../../../src/clients/AllianceClient';
+import { AssetsClient } from '../../../src/clients/AssetsClient';
+import { CalendarClient } from '../../../src/clients/CalendarClient';
+import { CharacterClient } from '../../../src/clients/CharacterClient';
+import { ClonesClient } from '../../../src/clients/ClonesClient';
+import { ContactsClient } from '../../../src/clients/ContactsClient';
+import { ContractsClient } from '../../../src/clients/ContractsClient';
+import { CorporationsClient } from '../../../src/clients/CorporationsClient';
+import { FittingsClient } from '../../../src/clients/FittingsClient';
+import { FleetClient } from '../../../src/clients/FleetClient';
+import { IndustryClient } from '../../../src/clients/IndustryClient';
+import { KillmailsClient } from '../../../src/clients/KillmailsClient';
+import { LoyaltyClient } from '../../../src/clients/LoyaltyClient';
+import { MailClient } from '../../../src/clients/MailClient';
+import { MarketClient } from '../../../src/clients/MarketClient';
+import { PiClient } from '../../../src/clients/PiClient';
+import { CharacterSkillsClient } from '../../../src/clients/SkillsClient';
+import { WalletClient } from '../../../src/clients/WalletClient';
+import { WarsClient } from '../../../src/clients/WarsClient';
+
+let apiClient: ApiClient;
+let streamSpy: jest.SpyInstance;
+
+function mockAsyncGenerator() {
+  return (async function* () {
+    yield { data: [], page: 1, totalPages: 1 };
+  })();
+}
+
+beforeEach(() => {
+  const rateLimiter = new RateLimiter();
+  rateLimiter.setTestMode(true);
+  apiClient = new ApiClient('test', 'https://esi.evetech.net', 'token');
+  apiClient.setRateLimiter(rateLimiter);
+
+  streamSpy = jest
+    .spyOn(BaseEsiClient.prototype as any, 'streamEndpoint')
+    .mockImplementation(() => mockAsyncGenerator());
+});
+
+afterEach(() => {
+  streamSpy.mockRestore();
+});
+
+describe('AllianceClient stream methods', () => {
+  let client: AllianceClient;
+  beforeEach(() => {
+    client = new AllianceClient(apiClient);
+  });
+
+  it('streamAlliances', () => {
+    client.streamAlliances();
+    expect(streamSpy).toHaveBeenCalledWith('getAlliances');
+  });
+
+  it('streamCorporations', () => {
+    client.streamCorporations(99005338);
+    expect(streamSpy).toHaveBeenCalledWith('getCorporations', 99005338);
+  });
+});
+
+describe('AssetsClient stream methods', () => {
+  let client: AssetsClient;
+  beforeEach(() => {
+    client = new AssetsClient(apiClient);
+  });
+
+  it('streamCharacterAssets', () => {
+    client.streamCharacterAssets(123);
+    expect(streamSpy).toHaveBeenCalledWith('getCharacterAssets', 123);
+  });
+
+  it('streamCorporationAssets', () => {
+    client.streamCorporationAssets(456);
+    expect(streamSpy).toHaveBeenCalledWith('getCorporationAssets', 456);
+  });
+});
+
+describe('CalendarClient stream methods', () => {
+  let client: CalendarClient;
+  beforeEach(() => {
+    client = new CalendarClient(apiClient);
+  });
+
+  it('streamCalendarEvents', () => {
+    client.streamCalendarEvents(123);
+    expect(streamSpy).toHaveBeenCalledWith('getCalendarEvents', 123);
+  });
+
+  it('streamEventAttendees', () => {
+    client.streamEventAttendees(123, 456);
+    expect(streamSpy).toHaveBeenCalledWith('getEventAttendees', 123, 456);
+  });
+});
+
+describe('CharacterClient stream methods', () => {
+  let client: CharacterClient;
+  beforeEach(() => {
+    client = new CharacterClient(apiClient);
+  });
+
+  it('streamCharacterAgentsResearch', () => {
+    client.streamCharacterAgentsResearch(123);
+    expect(streamSpy).toHaveBeenCalledWith('getAgentsResearch', 123);
+  });
+
+  it('streamCharacterBlueprints', () => {
+    client.streamCharacterBlueprints(123);
+    expect(streamSpy).toHaveBeenCalledWith('getBlueprints', 123);
+  });
+
+  it('streamCharacterCorporationHistory', () => {
+    client.streamCharacterCorporationHistory(123);
+    expect(streamSpy).toHaveBeenCalledWith('getCorporationHistory', 123);
+  });
+
+  it('streamCharacterMedals', () => {
+    client.streamCharacterMedals(123);
+    expect(streamSpy).toHaveBeenCalledWith('getMedals', 123);
+  });
+
+  it('streamCharacterNotifications', () => {
+    client.streamCharacterNotifications(123);
+    expect(streamSpy).toHaveBeenCalledWith('getNotifications', 123);
+  });
+
+  it('streamCharacterNotificationsContacts', () => {
+    client.streamCharacterNotificationsContacts(123);
+    expect(streamSpy).toHaveBeenCalledWith('getContactNotifications', 123);
+  });
+
+  it('streamCharacterStandings', () => {
+    client.streamCharacterStandings(123);
+    expect(streamSpy).toHaveBeenCalledWith('getStandings', 123);
+  });
+
+  it('streamCharacterTitles', () => {
+    client.streamCharacterTitles(123);
+    expect(streamSpy).toHaveBeenCalledWith('getTitles', 123);
+  });
+});
+
+describe('ClonesClient stream methods', () => {
+  let client: ClonesClient;
+  beforeEach(() => {
+    client = new ClonesClient(apiClient);
+  });
+
+  it('streamImplants', () => {
+    client.streamImplants(123);
+    expect(streamSpy).toHaveBeenCalledWith('getImplants', 123);
+  });
+});
+
+describe('ContactsClient stream methods', () => {
+  let client: ContactsClient;
+  beforeEach(() => {
+    client = new ContactsClient(apiClient);
+  });
+
+  it('streamAllianceContacts', () => {
+    client.streamAllianceContacts(99005338);
+    expect(streamSpy).toHaveBeenCalledWith('getAllianceContacts', 99005338);
+  });
+
+  it('streamAllianceContactLabels', () => {
+    client.streamAllianceContactLabels(99005338);
+    expect(streamSpy).toHaveBeenCalledWith(
+      'getAllianceContactLabels',
+      99005338,
+    );
+  });
+
+  it('streamCharacterContacts', () => {
+    client.streamCharacterContacts(123);
+    expect(streamSpy).toHaveBeenCalledWith('getCharacterContacts', 123);
+  });
+
+  it('streamCharacterContactLabels', () => {
+    client.streamCharacterContactLabels(123);
+    expect(streamSpy).toHaveBeenCalledWith('getCharacterContactLabels', 123);
+  });
+
+  it('streamCorporationContacts', () => {
+    client.streamCorporationContacts(456);
+    expect(streamSpy).toHaveBeenCalledWith('getCorporationContacts', 456);
+  });
+
+  it('streamCorporationContactLabels', () => {
+    client.streamCorporationContactLabels(456);
+    expect(streamSpy).toHaveBeenCalledWith('getCorporationContactLabels', 456);
+  });
+});
+
+describe('ContractsClient stream methods', () => {
+  let client: ContractsClient;
+  beforeEach(() => {
+    client = new ContractsClient(apiClient);
+  });
+
+  it('streamPublicContracts', () => {
+    client.streamPublicContracts(10000002);
+    expect(streamSpy).toHaveBeenCalledWith('getPublicContracts', 10000002);
+  });
+
+  it('streamCharacterContracts', () => {
+    client.streamCharacterContracts(123);
+    expect(streamSpy).toHaveBeenCalledWith('getCharacterContracts', 123);
+  });
+
+  it('streamCorporationContracts', () => {
+    client.streamCorporationContracts(456);
+    expect(streamSpy).toHaveBeenCalledWith('getCorporationContracts', 456);
+  });
+});
+
+describe('CorporationsClient stream methods', () => {
+  let client: CorporationsClient;
+  beforeEach(() => {
+    client = new CorporationsClient(apiClient);
+  });
+
+  it('streamCorporationAllianceHistory', () => {
+    client.streamCorporationAllianceHistory(456);
+    expect(streamSpy).toHaveBeenCalledWith(
+      'getCorporationAllianceHistory',
+      456,
+    );
+  });
+
+  it('streamCorporationBlueprints', () => {
+    client.streamCorporationBlueprints(456);
+    expect(streamSpy).toHaveBeenCalledWith('getCorporationBlueprints', 456);
+  });
+
+  it('streamCorporationAlscLogs', () => {
+    client.streamCorporationAlscLogs(456);
+    expect(streamSpy).toHaveBeenCalledWith('getCorporationAlscLogs', 456);
+  });
+
+  it('streamCorporationFacilities', () => {
+    client.streamCorporationFacilities(456);
+    expect(streamSpy).toHaveBeenCalledWith('getCorporationFacilities', 456);
+  });
+
+  it('streamCorporationMedals', () => {
+    client.streamCorporationMedals(456);
+    expect(streamSpy).toHaveBeenCalledWith('getCorporationMedals', 456);
+  });
+
+  it('streamCorporationIssuedMedals', () => {
+    client.streamCorporationIssuedMedals(456);
+    expect(streamSpy).toHaveBeenCalledWith('getCorporationIssuedMedals', 456);
+  });
+
+  it('streamCorporationMembers', () => {
+    client.streamCorporationMembers(456);
+    expect(streamSpy).toHaveBeenCalledWith('getCorporationMembers', 456);
+  });
+
+  it('streamCorporationMemberTitles', () => {
+    client.streamCorporationMemberTitles(456);
+    expect(streamSpy).toHaveBeenCalledWith('getCorporationMembersTitles', 456);
+  });
+
+  it('streamCorporationMemberTracking', () => {
+    client.streamCorporationMemberTracking(456);
+    expect(streamSpy).toHaveBeenCalledWith('getCorporationMemberTracking', 456);
+  });
+
+  it('streamCorporationRoles', () => {
+    client.streamCorporationRoles(456);
+    expect(streamSpy).toHaveBeenCalledWith('getCorporationMemberRoles', 456);
+  });
+
+  it('streamCorporationRolesHistory', () => {
+    client.streamCorporationRolesHistory(456);
+    expect(streamSpy).toHaveBeenCalledWith(
+      'getCorporationMemberRolesHistory',
+      456,
+    );
+  });
+
+  it('streamCorporationShareholders', () => {
+    client.streamCorporationShareholders(456);
+    expect(streamSpy).toHaveBeenCalledWith('getCorporationShareholders', 456);
+  });
+
+  it('streamCorporationStandings', () => {
+    client.streamCorporationStandings(456);
+    expect(streamSpy).toHaveBeenCalledWith('getCorporationStandings', 456);
+  });
+
+  it('streamCorporationStarbases', () => {
+    client.streamCorporationStarbases(456);
+    expect(streamSpy).toHaveBeenCalledWith('getCorporationStarbases', 456);
+  });
+
+  it('streamCorporationStructures', () => {
+    client.streamCorporationStructures(456);
+    expect(streamSpy).toHaveBeenCalledWith('getCorporationStructures', 456);
+  });
+
+  it('streamCorporationTitles', () => {
+    client.streamCorporationTitles(456);
+    expect(streamSpy).toHaveBeenCalledWith('getCorporationTitles', 456);
+  });
+
+  it('streamNpcCorporations', () => {
+    client.streamNpcCorporations();
+    expect(streamSpy).toHaveBeenCalledWith('getNpcCorporations');
+  });
+});
+
+describe('FittingsClient stream methods', () => {
+  let client: FittingsClient;
+  beforeEach(() => {
+    client = new FittingsClient(apiClient);
+  });
+
+  it('streamFittings', () => {
+    client.streamFittings(123);
+    expect(streamSpy).toHaveBeenCalledWith('getFittings', 123);
+  });
+});
+
+describe('FleetClient stream methods', () => {
+  let client: FleetClient;
+  beforeEach(() => {
+    client = new FleetClient(apiClient);
+  });
+
+  it('streamFleetMembers', () => {
+    client.streamFleetMembers(123);
+    expect(streamSpy).toHaveBeenCalledWith('getFleetMembers', 123);
+  });
+
+  it('streamFleetWings', () => {
+    client.streamFleetWings(123);
+    expect(streamSpy).toHaveBeenCalledWith('getFleetWings', 123);
+  });
+});
+
+describe('IndustryClient stream methods', () => {
+  let client: IndustryClient;
+  beforeEach(() => {
+    client = new IndustryClient(apiClient);
+  });
+
+  it('streamCharacterIndustryJobs', () => {
+    client.streamCharacterIndustryJobs(123);
+    expect(streamSpy).toHaveBeenCalledWith('getCharacterIndustryJobs', 123);
+  });
+
+  it('streamCharacterMiningLedger', () => {
+    client.streamCharacterMiningLedger(123);
+    expect(streamSpy).toHaveBeenCalledWith('getCharacterMiningLedger', 123);
+  });
+
+  it('streamCorporationIndustryJobs', () => {
+    client.streamCorporationIndustryJobs(456);
+    expect(streamSpy).toHaveBeenCalledWith('getCorporationIndustryJobs', 456);
+  });
+
+  it('streamMoonExtractionTimers', () => {
+    client.streamMoonExtractionTimers(456);
+    expect(streamSpy).toHaveBeenCalledWith('getMoonExtractionTimers', 456);
+  });
+
+  it('streamCorporationMiningObservers', () => {
+    client.streamCorporationMiningObservers(456);
+    expect(streamSpy).toHaveBeenCalledWith(
+      'getCorporationMiningObservers',
+      456,
+    );
+  });
+
+  it('streamCorporationMiningObserver', () => {
+    client.streamCorporationMiningObserver(456, 789);
+    expect(streamSpy).toHaveBeenCalledWith(
+      'getCorporationMiningObserver',
+      456,
+      789,
+    );
+  });
+
+  it('streamIndustryFacilities', () => {
+    client.streamIndustryFacilities();
+    expect(streamSpy).toHaveBeenCalledWith('getIndustryFacilities');
+  });
+
+  it('streamIndustrySystems', () => {
+    client.streamIndustrySystems();
+    expect(streamSpy).toHaveBeenCalledWith('getIndustrySystems');
+  });
+});
+
+describe('KillmailsClient stream methods', () => {
+  let client: KillmailsClient;
+  beforeEach(() => {
+    client = new KillmailsClient(apiClient);
+  });
+
+  it('streamCharacterRecentKillmails', () => {
+    client.streamCharacterRecentKillmails(123);
+    expect(streamSpy).toHaveBeenCalledWith('getCharacterRecentKillmails', 123);
+  });
+
+  it('streamCorporationRecentKillmails', () => {
+    client.streamCorporationRecentKillmails(456);
+    expect(streamSpy).toHaveBeenCalledWith(
+      'getCorporationRecentKillmails',
+      456,
+    );
+  });
+});
+
+describe('LoyaltyClient stream methods', () => {
+  let client: LoyaltyClient;
+  beforeEach(() => {
+    client = new LoyaltyClient(apiClient);
+  });
+
+  it('streamLoyaltyPoints', () => {
+    client.streamLoyaltyPoints(123);
+    expect(streamSpy).toHaveBeenCalledWith('getLoyaltyPoints', 123);
+  });
+
+  it('streamLoyaltyStoreOffers', () => {
+    client.streamLoyaltyStoreOffers(456);
+    expect(streamSpy).toHaveBeenCalledWith('getLoyaltyStoreOffers', 456);
+  });
+});
+
+describe('MailClient stream methods', () => {
+  let client: MailClient;
+  beforeEach(() => {
+    client = new MailClient(apiClient);
+  });
+
+  it('streamMailHeaders', () => {
+    client.streamMailHeaders(123);
+    expect(streamSpy).toHaveBeenCalledWith('getCharacterMailHeaders', 123);
+  });
+
+  it('streamMailingLists', () => {
+    client.streamMailingLists(123);
+    expect(streamSpy).toHaveBeenCalledWith('getMailingLists', 123);
+  });
+});
+
+describe('MarketClient stream methods', () => {
+  let client: MarketClient;
+  beforeEach(() => {
+    client = new MarketClient(apiClient);
+  });
+
+  it('streamMarketTypes', () => {
+    client.streamMarketTypes(10000002);
+    expect(streamSpy).toHaveBeenCalledWith('getMarketTypes', 10000002);
+  });
+
+  it('streamCharacterOrderHistory', () => {
+    client.streamCharacterOrderHistory(123);
+    expect(streamSpy).toHaveBeenCalledWith('getCharacterOrderHistory', 123);
+  });
+
+  it('streamCorporationOrders', () => {
+    client.streamCorporationOrders(456);
+    expect(streamSpy).toHaveBeenCalledWith('getCorporationOrders', 456);
+  });
+
+  it('streamCorporationOrderHistory', () => {
+    client.streamCorporationOrderHistory(456);
+    expect(streamSpy).toHaveBeenCalledWith('getCorporationOrderHistory', 456);
+  });
+});
+
+describe('PiClient stream methods', () => {
+  let client: PiClient;
+  beforeEach(() => {
+    client = new PiClient(apiClient);
+  });
+
+  it('streamColonies', () => {
+    client.streamColonies(123);
+    expect(streamSpy).toHaveBeenCalledWith('getColonies', 123);
+  });
+
+  it('streamCorporationCustomsOffices', () => {
+    client.streamCorporationCustomsOffices(456);
+    expect(streamSpy).toHaveBeenCalledWith('getCorporationCustomsOffices', 456);
+  });
+});
+
+describe('CharacterSkillsClient stream methods', () => {
+  let client: CharacterSkillsClient;
+  beforeEach(() => {
+    client = new CharacterSkillsClient(apiClient);
+  });
+
+  it('streamCharacterSkillQueue', () => {
+    client.streamCharacterSkillQueue(123);
+    expect(streamSpy).toHaveBeenCalledWith('getCharacterSkillQueue', 123);
+  });
+});
+
+describe('WalletClient stream methods', () => {
+  let client: WalletClient;
+  beforeEach(() => {
+    client = new WalletClient(apiClient);
+  });
+
+  it('streamCharacterWalletJournal', () => {
+    client.streamCharacterWalletJournal(123);
+    expect(streamSpy).toHaveBeenCalledWith('getCharacterWalletJournal', 123);
+  });
+
+  it('streamCorporationWalletJournal', () => {
+    client.streamCorporationWalletJournal(456, 1);
+    expect(streamSpy).toHaveBeenCalledWith(
+      'getCorporationWalletJournal',
+      456,
+      1,
+    );
+  });
+
+  it('streamCharacterWalletTransactions', () => {
+    client.streamCharacterWalletTransactions(123);
+    expect(streamSpy).toHaveBeenCalledWith(
+      'getCharacterWalletTransactions',
+      123,
+    );
+  });
+
+  it('streamCorporationWalletTransactions', () => {
+    client.streamCorporationWalletTransactions(456, 1);
+    expect(streamSpy).toHaveBeenCalledWith(
+      'getCorporationWalletTransactions',
+      456,
+      1,
+    );
+  });
+});
+
+describe('WarsClient stream methods', () => {
+  let client: WarsClient;
+  beforeEach(() => {
+    client = new WarsClient(apiClient);
+  });
+
+  it('streamWars', () => {
+    client.streamWars();
+    expect(streamSpy).toHaveBeenCalledWith('getWars');
+  });
+
+  it('streamWarKillmails', () => {
+    client.streamWarKillmails(123);
+    expect(streamSpy).toHaveBeenCalledWith('getWarKillmails', 123);
+  });
+});

--- a/tests/tdd/core/coverageBranches.test.ts
+++ b/tests/tdd/core/coverageBranches.test.ts
@@ -1,0 +1,144 @@
+import { ApiClient } from '../../../src/core/ApiClient';
+import { BaseEsiClient } from '../../../src/clients/BaseEsiClient';
+import { EndpointMap } from '../../../src/core/endpoints/EndpointDefinition';
+import { RateLimiter } from '../../../src/core/rateLimiter/RateLimiter';
+import { EsiClient } from '../../../src/EsiClient';
+import { CustomEsiClient, EsiApiFactory } from '../../../src/EsiClientBuilder';
+import fetchMock from 'jest-fetch-mock';
+
+fetchMock.enableMocks();
+
+const testEndpoints = {
+  getItems: {
+    path: 'test/items/',
+    method: 'GET',
+    requiresAuth: false,
+  },
+} as const satisfies EndpointMap;
+
+class TestClient extends BaseEsiClient<typeof testEndpoints> {
+  constructor(client: ApiClient) {
+    super(client, testEndpoints);
+  }
+}
+
+describe('BaseEsiClient branch coverage', () => {
+  let apiClient: ApiClient;
+
+  beforeEach(() => {
+    fetchMock.resetMocks();
+    const rateLimiter = new RateLimiter();
+    rateLimiter.setTestMode(true);
+    apiClient = new ApiClient('test', 'https://esi.evetech.net', 'token');
+    apiClient.setRateLimiter(rateLimiter);
+  });
+
+  it('withSafeMode should return cached instance on second call', () => {
+    const client = new TestClient(apiClient);
+    const safe1 = client.withSafeMode();
+    const safe2 = client.withSafeMode();
+    expect(safe1).toBe(safe2);
+  });
+
+  it('withMetadata should return cached instance on second call', () => {
+    const client = new TestClient(apiClient);
+    const meta1 = client.withMetadata();
+    const meta2 = client.withMetadata();
+    expect(meta1).toBe(meta2);
+  });
+});
+
+describe('EsiClient batch methods', () => {
+  let client: EsiClient;
+
+  beforeEach(() => {
+    fetchMock.resetMocks();
+    client = new EsiClient();
+  });
+
+  afterEach(() => {
+    client.shutdown();
+  });
+
+  it('batch should delegate to batchFetch', async () => {
+    const fetcher = jest.fn().mockResolvedValue('result');
+    const result = await client.batch([1, 2], fetcher);
+    expect(result.results.size).toBe(2);
+  });
+
+  it('batchPost should delegate to batchPost utility', async () => {
+    const poster = jest.fn().mockResolvedValue([{ id: 1 }]);
+    const result = await client.batchPost([1], poster);
+    expect(result).toEqual([{ id: 1 }]);
+  });
+});
+
+describe('EsiApiFactory branch coverage', () => {
+  it('should create client without optional config fields', () => {
+    const client = EsiApiFactory.createAllianceClient();
+    expect(client).toBeDefined();
+  });
+
+  it('should create client with language config', () => {
+    const client = EsiApiFactory.createAllianceClient({ language: 'de' });
+    expect(client).toBeDefined();
+  });
+
+  it('should create client with datasource config', () => {
+    const client = EsiApiFactory.createAllianceClient({
+      datasource: 'singularity',
+    });
+    expect(client).toBeDefined();
+  });
+
+  it('should create client with onTokenRefresh config', () => {
+    const client = EsiApiFactory.createAllianceClient({
+      onTokenRefresh: async () => 'new-token',
+    });
+    expect(client).toBeDefined();
+  });
+
+  it('should create client with all optional config fields', () => {
+    const client = EsiApiFactory.createAllianceClient({
+      language: 'fr',
+      datasource: 'singularity',
+      onTokenRefresh: async () => 'token',
+    });
+    expect(client).toBeDefined();
+  });
+});
+
+describe('CustomEsiClient branch coverage', () => {
+  it('should build without optional config fields', () => {
+    const client = new CustomEsiClient({ clients: ['alliance'] });
+    expect(client).toBeDefined();
+    client.shutdown();
+  });
+
+  it('should build with language config', () => {
+    const client = new CustomEsiClient({
+      clients: ['alliance'],
+      language: 'de',
+    });
+    expect(client).toBeDefined();
+    client.shutdown();
+  });
+
+  it('should build with datasource config', () => {
+    const client = new CustomEsiClient({
+      clients: ['alliance'],
+      datasource: 'singularity',
+    });
+    expect(client).toBeDefined();
+    client.shutdown();
+  });
+
+  it('should build with onTokenRefresh config', () => {
+    const client = new CustomEsiClient({
+      clients: ['alliance'],
+      onTokenRefresh: async () => 'new-token',
+    });
+    expect(client).toBeDefined();
+    client.shutdown();
+  });
+});

--- a/tests/tdd/core/paginationBranches.test.ts
+++ b/tests/tdd/core/paginationBranches.test.ts
@@ -1,0 +1,295 @@
+import { PaginationHandler } from '../../../src/core/pagination/PaginationHandler';
+import { CursorPaginationHandler } from '../../../src/core/pagination/CursorPaginationHandler';
+import { ApiClient } from '../../../src/core/ApiClient';
+import { RateLimiter } from '../../../src/core/rateLimiter/RateLimiter';
+import { handleOffsetPagination } from '../../../src/core/requestPipeline/paginationOrchestration';
+import { resolveRateLimiter } from '../../../src/core/requestPipeline/dependencies';
+import { ParsedHeaders } from '../../../src/core/util/headersUtil';
+import fetchMock from 'jest-fetch-mock';
+
+fetchMock.enableMocks();
+
+describe('PaginationHandler branch coverage', () => {
+  let client: ApiClient;
+  let pageFetch: jest.Mock;
+
+  beforeEach(() => {
+    const rateLimiter = new RateLimiter();
+    rateLimiter.reset();
+    rateLimiter.setTestMode(true);
+    client = new ApiClient('test', 'https://esi.evetech.net', undefined);
+    client.setRateLimiter(rateLimiter);
+    pageFetch = jest.fn();
+  });
+
+  it('should work without a rate limiter', async () => {
+    const noRlClient = new ApiClient(
+      'test',
+      'https://esi.evetech.net',
+      undefined,
+    );
+    pageFetch.mockResolvedValueOnce([{ id: 2 }]);
+
+    const result = await PaginationHandler.fetchRemainingPages(
+      noRlClient,
+      'alliances',
+      'GET',
+      false,
+      [{ id: 1 }],
+      2,
+      undefined,
+      {},
+      pageFetch,
+    );
+
+    expect(result).toEqual([{ id: 1 }, { id: 2 }]);
+  });
+
+  it('should pass templatePath to rate limiter', async () => {
+    pageFetch.mockResolvedValueOnce([{ id: 2 }]);
+
+    const result = await PaginationHandler.fetchRemainingPages(
+      client,
+      'alliances',
+      'GET',
+      false,
+      [{ id: 1 }],
+      2,
+      undefined,
+      {},
+      pageFetch,
+      'alliances/',
+    );
+
+    expect(result).toEqual([{ id: 1 }, { id: 2 }]);
+  });
+
+  it('should wrap non-Error thrown values in Error', async () => {
+    pageFetch.mockRejectedValue('string error');
+
+    await expect(
+      PaginationHandler.fetchRemainingPages(
+        client,
+        'alliances',
+        'GET',
+        false,
+        [{ id: 1 }],
+        2,
+        undefined,
+        { maxRetries: 1, retryDelayMs: 1 },
+        pageFetch,
+      ),
+    ).rejects.toThrow('Failed to fetch page 2: string error');
+  });
+
+  it('should stop when stopOnEmptyPage is true and page returns null', async () => {
+    pageFetch.mockResolvedValueOnce(null as unknown as unknown[]);
+
+    const result = await PaginationHandler.fetchRemainingPages(
+      client,
+      'alliances',
+      'GET',
+      false,
+      [{ id: 1 }],
+      3,
+      undefined,
+      { stopOnEmptyPage: true },
+      pageFetch,
+    );
+
+    expect(result).toEqual([{ id: 1 }]);
+  });
+});
+
+function cursorResponse(
+  data: unknown[],
+  before: string | null,
+  after: string | null,
+  status = 200,
+) {
+  const headers: Record<string, string> = {};
+  if (before) headers['x-cursor-before'] = before;
+  if (after) headers['x-cursor-after'] = after;
+  return { status, headers, body: JSON.stringify(data) };
+}
+
+describe('CursorPaginationHandler branch coverage', () => {
+  let client: ApiClient;
+
+  beforeEach(() => {
+    fetchMock.resetMocks();
+    const rateLimiter = new RateLimiter();
+    rateLimiter.reset();
+    rateLimiter.setTestMode(true);
+    client = new ApiClient('test', 'https://esi.evetech.net', undefined);
+    client.setRateLimiter(rateLimiter);
+  });
+
+  it('should delegate to pageFetch when provided', async () => {
+    const mockPageFetch = jest.fn().mockResolvedValue({
+      data: [{ id: 1 }],
+      cursors: { before: null, after: null },
+    });
+
+    const result = await CursorPaginationHandler.fetchPage(
+      client,
+      'corps/123/projects',
+      'GET',
+      false,
+      undefined,
+      undefined,
+      mockPageFetch,
+    );
+
+    expect(result.data).toEqual([{ id: 1 }]);
+    expect(mockPageFetch).toHaveBeenCalledWith('corps/123/projects', undefined);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('should rethrow non-abort errors from fetch', async () => {
+    const networkError = new Error('Network failure');
+    fetchMock.mockRejectOnce(networkError);
+
+    await expect(
+      CursorPaginationHandler.fetchPage(client, 'some/endpoint', 'GET', false),
+    ).rejects.toThrow('Network failure');
+  });
+
+  it('should throw on invalid JSON response', async () => {
+    fetchMock.mockResponseOnce('not json{{{', { status: 200 });
+
+    await expect(
+      CursorPaginationHandler.fetchPage(client, 'some/endpoint', 'GET', false),
+    ).rejects.toThrow('Invalid JSON response');
+  });
+
+  it('should send body as JSON when provided', async () => {
+    const resp = cursorResponse([{ id: 1 }], null, null);
+    fetchMock.mockResponseOnce(resp.body, {
+      status: resp.status,
+      headers: resp.headers,
+    });
+
+    await CursorPaginationHandler.fetchPage(
+      client,
+      'some/endpoint',
+      'POST',
+      false,
+      undefined,
+      { ids: [1, 2, 3] },
+    );
+
+    const fetchOptions = fetchMock.mock.calls[0][1];
+    expect(fetchOptions?.body).toBe(JSON.stringify({ ids: [1, 2, 3] }));
+  });
+
+  it('fetchAll should use pageFetch delegate for subsequent pages', async () => {
+    const mockPageFetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        data: [{ id: 2 }],
+        cursors: { before: null, after: 'c2' },
+      })
+      .mockResolvedValueOnce({
+        data: [],
+        cursors: { before: null, after: null },
+      });
+
+    const result = await CursorPaginationHandler.fetchAll(
+      client,
+      'corps/123/projects',
+      'GET',
+      false,
+      [{ id: 1 }],
+      { before: null, after: 'c1' },
+      undefined,
+      {},
+      mockPageFetch,
+    );
+
+    expect(result).toEqual([{ id: 1 }, { id: 2 }]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('fetchAll should work without a rate limiter', async () => {
+    const noRlClient = new ApiClient(
+      'test',
+      'https://esi.evetech.net',
+      undefined,
+    );
+
+    const resp = cursorResponse([], null, null);
+    fetchMock.mockResponseOnce(resp.body, {
+      status: resp.status,
+      headers: resp.headers,
+    });
+
+    const result = await CursorPaginationHandler.fetchAll(
+      noRlClient,
+      'corps/123/projects',
+      'GET',
+      false,
+      [{ id: 1 }],
+      { before: null, after: 'c1' },
+    );
+
+    expect(result).toEqual([{ id: 1 }]);
+  });
+});
+
+describe('resolveRateLimiter', () => {
+  it('should throw when no rate limiter is configured', () => {
+    const noRlClient = new ApiClient(
+      'test',
+      'https://esi.evetech.net',
+      undefined,
+    );
+
+    expect(() => resolveRateLimiter(noRlClient)).toThrow(
+      'No rate limiter configured',
+    );
+  });
+});
+
+describe('handleOffsetPagination branch coverage', () => {
+  let client: ApiClient;
+
+  beforeEach(() => {
+    fetchMock.resetMocks();
+    const rateLimiter = new RateLimiter();
+    rateLimiter.reset();
+    rateLimiter.setTestMode(true);
+    client = new ApiClient('test', 'https://esi.evetech.net', undefined);
+    client.setRateLimiter(rateLimiter);
+  });
+
+  it('should wrap generic errors in PAGINATION_INCOMPLETE', async () => {
+    const pageFetch = jest
+      .fn()
+      .mockRejectedValue(new TypeError('fetch failed'));
+
+    const parsed = {
+      raw: {},
+      xPages: 3,
+      hasCursorPagination: false,
+      cursorBefore: null,
+      cursorAfter: null,
+    } as unknown as ParsedHeaders;
+
+    await expect(
+      handleOffsetPagination(
+        client,
+        'alliances',
+        'GET',
+        false,
+        parsed,
+        [{ id: 1 }],
+        undefined,
+        'https://esi.evetech.net/alliances',
+        false,
+        pageFetch,
+        () => null,
+      ),
+    ).rejects.toThrow('Pagination incomplete');
+  });
+});


### PR DESCRIPTION
## Summary

- Add 96 tests across 3 new test files to close branch and function coverage gaps
- **streamMethods.test.ts** (71 tests): covers all `stream*()` methods across 19 domain clients
- **paginationBranches.test.ts** (12 tests): pagination handler edge cases (no rate limiter, non-Error throws, null pages, cursor delegation, JSON parse errors)
- **coverageBranches.test.ts** (13 tests): BaseEsiClient memoization, EsiClient batch delegation, EsiApiFactory/CustomEsiClient config branches

Coverage after: stmts 98.47%, branches 90.10%, functions 97.54%, lines 98.59% — all metrics now above 90%.

## Test plan

- [x] All 96 new tests pass (`npx jest --config jest.unit.config.cjs`)
- [x] No existing tests broken
- [x] Coverage thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)