### PR TITLE
feat: add --compatibility-date and --latest flags to ESI scripts

### DIFF
--- a/scripts/generate-esi-types.ts
+++ b/scripts/generate-esi-types.ts
@@ -12,6 +12,8 @@
  * scripts/generate-schema-drift-report.ts (no generated Zod schemas needed).
  *
  * Usage: npx ts-node scripts/generate-esi-types.ts
+ *        npx ts-node scripts/generate-esi-types.ts --compatibility-date=2026-08-04
+ *        npx ts-node scripts/generate-esi-types.ts --latest
  *        npm run generate:types
  */
 
@@ -19,8 +21,43 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as crypto from 'crypto';
 
-const ESI_OPENAPI_URL =
-  'https://esi.evetech.net/meta/openapi.json?compatibility_date=2025-12-16';
+const DEFAULT_COMPATIBILITY_DATE = '2025-12-16';
+const ESI_OPENAPI_BASE = 'https://esi.evetech.net/meta/openapi.json';
+const ESI_COMPATIBILITY_DATES_URL =
+  'https://esi.evetech.net/meta/compatibility-dates';
+
+function parseCompatibilityDate(): string | 'latest' {
+  for (const arg of process.argv.slice(2)) {
+    if (arg === '--latest') return 'latest';
+    const match = arg.match(/^--compatibility-date=(\d{4}-\d{2}-\d{2})$/);
+    if (match) return match[1]!;
+  }
+  return DEFAULT_COMPATIBILITY_DATE;
+}
+
+async function resolveCompatibilityDate(
+  requested: string | 'latest',
+): Promise<string> {
+  if (requested !== 'latest') return requested;
+  const response = await fetch(ESI_COMPATIBILITY_DATES_URL);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch compatibility dates: HTTP ${response.status}`,
+    );
+  }
+  const data = (await response.json()) as {
+    compatibility_dates: string[];
+  };
+  const dates = data.compatibility_dates;
+  if (!dates || dates.length === 0) {
+    throw new Error('No compatibility dates returned from ESI');
+  }
+  return dates[0]!;
+}
+
+function buildSpecUrl(compatibilityDate: string): string {
+  return `${ESI_OPENAPI_BASE}?compatibility_date=${compatibilityDate}`;
+}
 const TYPES_OUTPUT = path.resolve(
   __dirname,
   '../src/types/generated/esi-spec.generated.ts',
@@ -564,11 +601,16 @@ function writeScopesFile(
 // --- Main ---
 
 async function main(): Promise<void> {
-  console.log(`Fetching ESI OpenAPI spec from ${ESI_OPENAPI_URL}...`);
+  const requested = parseCompatibilityDate();
+  const compatibilityDate = await resolveCompatibilityDate(requested);
+  const specUrl = buildSpecUrl(compatibilityDate);
+
+  console.log(`Compatibility date: ${compatibilityDate}`);
+  console.log(`Fetching ESI OpenAPI spec from ${specUrl}...`);
 
   let spec: OpenApiSpec;
   try {
-    const response = await fetch(ESI_OPENAPI_URL);
+    const response = await fetch(specUrl);
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}: ${response.statusText}`);
     }

--- a/scripts/validate-esi-endpoints.ts
+++ b/scripts/validate-esi-endpoints.ts
@@ -6,14 +6,51 @@
  * missing coverage, and deprecated endpoints.
  *
  * Usage: npx ts-node scripts/validate-esi-endpoints.ts
+ *        npx ts-node scripts/validate-esi-endpoints.ts --compatibility-date=2026-08-04
+ *        npx ts-node scripts/validate-esi-endpoints.ts --latest
  *        npm run validate:esi
  */
 
 import * as fs from 'fs';
 import * as path from 'path';
 
-const ESI_OPENAPI_URL =
-  'https://esi.evetech.net/meta/openapi.json?compatibility_date=2025-12-16';
+const DEFAULT_COMPATIBILITY_DATE = '2025-12-16';
+const ESI_OPENAPI_BASE = 'https://esi.evetech.net/meta/openapi.json';
+const ESI_COMPATIBILITY_DATES_URL =
+  'https://esi.evetech.net/meta/compatibility-dates';
+
+function parseCompatibilityDate(): string | 'latest' {
+  for (const arg of process.argv.slice(2)) {
+    if (arg === '--latest') return 'latest';
+    const match = arg.match(/^--compatibility-date=(\d{4}-\d{2}-\d{2})$/);
+    if (match) return match[1]!;
+  }
+  return DEFAULT_COMPATIBILITY_DATE;
+}
+
+async function resolveCompatibilityDate(
+  requested: string | 'latest',
+): Promise<string> {
+  if (requested !== 'latest') return requested;
+  const response = await fetch(ESI_COMPATIBILITY_DATES_URL);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch compatibility dates: HTTP ${response.status}`,
+    );
+  }
+  const data = (await response.json()) as {
+    compatibility_dates: string[];
+  };
+  const dates = data.compatibility_dates;
+  if (!dates || dates.length === 0) {
+    throw new Error('No compatibility dates returned from ESI');
+  }
+  return dates[0]!;
+}
+
+function buildSpecUrl(compatibilityDate: string): string {
+  return `${ESI_OPENAPI_BASE}?compatibility_date=${compatibilityDate}`;
+}
 const ENDPOINTS_DIR = path.resolve(__dirname, '../src/core/endpoints');
 const TYPES_DIR = path.resolve(__dirname, '../src/types');
 const GENERATED_TYPES_FILE = path.resolve(
@@ -481,11 +518,16 @@ function printTypeDriftReport(drift: TypeDriftResult): void {
 }
 
 async function main(): Promise<void> {
-  console.log(`Fetching ESI OpenAPI spec from ${ESI_OPENAPI_URL}...`);
+  const requested = parseCompatibilityDate();
+  const compatibilityDate = await resolveCompatibilityDate(requested);
+  const specUrl = buildSpecUrl(compatibilityDate);
+
+  console.log(`Compatibility date: ${compatibilityDate}`);
+  console.log(`Fetching ESI OpenAPI spec from ${specUrl}...`);
 
   let spec: OpenApiSpec;
   try {
-    const response = await fetch(ESI_OPENAPI_URL);
+    const response = await fetch(specUrl);
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}: ${response.statusText}`);
     }


### PR DESCRIPTION
## Summary

- Adds `--compatibility-date=YYYY-MM-DD` and `--latest` CLI flags to `validate-esi-endpoints.ts` and `generate-esi-types.ts`
- `--latest` auto-resolves the newest date from the ESI `/meta/compatibility-dates` API
- Default remains `2025-12-16` so CI behavior is unchanged

## Motivation

The ESI spec uses compatibility dates to version breaking changes. New endpoints like Military Campaigns (2026-08-04) aren't visible unless the scripts request the correct date. This change enables checking against any spec version without editing source code.

## Usage

```bash
# Default (existing behavior)
npm run validate:esi

# Specific date
npx ts-node scripts/validate-esi-endpoints.ts --compatibility-date=2026-08-04

# Auto-detect latest
npx ts-node scripts/validate-esi-endpoints.ts --latest
npx ts-node scripts/generate-esi-types.ts --latest
```

## Test plan

- [x] Verified `--latest` resolves to `2026-08-04` and shows Military Campaigns as missing
- [x] Verified default (no flag) still uses `2025-12-16` for backwards compatibility
- [x] Verified `--compatibility-date=2026-08-04` works identically to `--latest`

Closes #155 partially (enables detection; implementation tracked separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)