### PR TITLE
fix: realign Structures/Activities endpoints with ESI spec

### DIFF
--- a/examples/mercenary.ts
+++ b/examples/mercenary.ts
@@ -4,8 +4,8 @@
  * Fetches mercenary dens across New Eden and their spawned
  * tactical operations (MTOs), showing development and anarchy levels.
  *
- * Note: These endpoints may return 404 if CCP has not yet deployed
- * mercenary content to the current server version.
+ * Note: These endpoints require authentication and may return 404 if CCP
+ * has not yet deployed mercenary content to the current server version.
  *
  * Usage: npm run example:mercenary
  */
@@ -14,6 +14,13 @@ import { isNotFound } from '../src/core/util/error';
 
 async function main() {
   const client = new EsiClient();
+
+  // Character ID to query mercenary data for
+  const characterId = parseInt(process.env.CHARACTER_ID || '0', 10);
+  if (!characterId) {
+    console.error('Set CHARACTER_ID environment variable to your character ID.');
+    process.exit(1);
+  }
 
   try {
     console.log('Mercenary Dens & Tactical Operations\n');
@@ -25,8 +32,8 @@ async function main() {
 
     try {
       [dens, operations] = await Promise.all([
-        client.mercenary.getMercenaryDens(),
-        client.mercenary.getMercenaryTacticalOperations(),
+        client.mercenary.getMercenaryDens(characterId),
+        client.mercenary.getMercenaryTacticalOperations(characterId),
       ]);
     } catch (err) {
       if (isNotFound(err)) {

--- a/examples/skyhooks.ts
+++ b/examples/skyhooks.ts
@@ -4,8 +4,9 @@
  * Queries Upwell sovereignty structures — sovereignty hubs,
  * orbital skyhooks with silo levels, and currently raidable skyhooks.
  *
- * Note: These endpoints may return 404 if CCP has not yet deployed
- * skyhook content to the current server version.
+ * Note: Sovereignty hub and skyhook endpoints require authentication.
+ * The raidable skyhooks endpoint is public. Some endpoints may return 404
+ * if CCP has not yet deployed skyhook content to the current server version.
  *
  * Usage: npm run example:skyhooks
  */
@@ -14,6 +15,15 @@ import { isNotFound } from '../src/core/util/error';
 
 async function main() {
   const client = new EsiClient();
+
+  // Corporation ID to query sovereignty structures for
+  const corporationId = parseInt(process.env.CORPORATION_ID || '0', 10);
+  if (!corporationId) {
+    console.error(
+      'Set CORPORATION_ID environment variable to your corporation ID.',
+    );
+    process.exit(1);
+  }
 
   try {
     console.log('Skyhooks & Sovereignty Hubs\n');
@@ -28,8 +38,8 @@ async function main() {
 
     try {
       [hubs, skyhooks, raidable] = await Promise.all([
-        client.skyhooks.getSovereigntyHubs(),
-        client.skyhooks.getOrbitalSkyhooks(),
+        client.skyhooks.getSovereigntyHubs(corporationId),
+        client.skyhooks.getOrbitalSkyhooks(corporationId),
         client.skyhooks.getRaidableSkyhooks(),
       ]);
     } catch (err) {

--- a/src/clients/MercenaryClient.ts
+++ b/src/clients/MercenaryClient.ts
@@ -14,20 +14,24 @@ export class MercenaryClient extends BaseEsiClient<typeof mercenaryEndpoints> {
   /**
    * Retrieves all mercenary dens with their development and anarchy parameters.
    *
+   * @param characterId - The ID of the character to query mercenary dens for
    * @returns A list of mercenary dens
+   * @requires Authentication
    */
-  getMercenaryDens(): Promise<MercenaryDen[]> {
-    return this.api.getMercenaryDens() as Promise<MercenaryDen[]>;
+  getMercenaryDens(characterId: number): Promise<MercenaryDen[]> {
+    return this.api.getMercenaryDens(characterId);
   }
 
   /**
    * Retrieves all mercenary tactical operations (MTOs) spawned from mercenary dens.
    *
+   * @param characterId - The ID of the character to query tactical operations for
    * @returns A list of mercenary tactical operations
+   * @requires Authentication
    */
-  getMercenaryTacticalOperations(): Promise<MercenaryTacticalOperation[]> {
-    return this.api.getMercenaryTacticalOperations() as Promise<
-      MercenaryTacticalOperation[]
-    >;
+  getMercenaryTacticalOperations(
+    characterId: number,
+  ): Promise<MercenaryTacticalOperation[]> {
+    return this.api.getMercenaryTacticalOperations(characterId);
   }
 }

--- a/src/clients/SkyhooksClient.ts
+++ b/src/clients/SkyhooksClient.ts
@@ -15,19 +15,23 @@ export class SkyhooksClient extends BaseEsiClient<typeof skyhookEndpoints> {
   /**
    * Retrieves all sovereignty hubs exposed as Upwell structures, including online status and installed upgrades.
    *
+   * @param corporationId - The ID of the corporation to query sovereignty hubs for
    * @returns A list of sovereignty hubs
+   * @requires Authentication
    */
-  getSovereigntyHubs(): Promise<SovereigntyHub[]> {
-    return this.api.getSovereigntyHubs() as Promise<SovereigntyHub[]>;
+  getSovereigntyHubs(corporationId: number): Promise<SovereigntyHub[]> {
+    return this.api.getSovereigntyHubs(corporationId);
   }
 
   /**
    * Retrieves all orbital skyhooks with their silo capacity and levels.
    *
+   * @param corporationId - The ID of the corporation to query skyhooks for
    * @returns A list of orbital skyhooks
+   * @requires Authentication
    */
-  getOrbitalSkyhooks(): Promise<OrbitalSkyhook[]> {
-    return this.api.getOrbitalSkyhooks() as Promise<OrbitalSkyhook[]>;
+  getOrbitalSkyhooks(corporationId: number): Promise<OrbitalSkyhook[]> {
+    return this.api.getOrbitalSkyhooks(corporationId);
   }
 
   /**
@@ -36,6 +40,6 @@ export class SkyhooksClient extends BaseEsiClient<typeof skyhookEndpoints> {
    * @returns A list of raidable skyhooks
    */
   getRaidableSkyhooks(): Promise<RaidableSkyhook[]> {
-    return this.api.getRaidableSkyhooks() as Promise<RaidableSkyhook[]>;
+    return this.api.getRaidableSkyhooks();
   }
 }

--- a/src/core/endpoints/mercenaryEndpoints.ts
+++ b/src/core/endpoints/mercenaryEndpoints.ts
@@ -7,15 +7,17 @@ import {
 
 export const mercenaryEndpoints = {
   getMercenaryDens: {
-    path: 'mercenary/dens',
+    path: 'characters/{characterId}/structures/mercenary-dens',
     method: 'GET',
-    requiresAuth: false,
+    requiresAuth: true,
+    pathParams: ['characterId'],
     responseSchema: z.array(MercenaryDenSchema),
   },
   getMercenaryTacticalOperations: {
-    path: 'mercenary/operations',
+    path: 'characters/{characterId}/mercenary-tactical-operations',
     method: 'GET',
-    requiresAuth: false,
+    requiresAuth: true,
+    pathParams: ['characterId'],
     responseSchema: z.array(MercenaryTacticalOperationSchema),
   },
 } as const satisfies EndpointMap;

--- a/src/core/endpoints/skyhookEndpoints.ts
+++ b/src/core/endpoints/skyhookEndpoints.ts
@@ -8,19 +8,21 @@ import {
 
 export const skyhookEndpoints = {
   getSovereigntyHubs: {
-    path: 'sovereignty/hubs',
+    path: 'corporations/{corporationId}/structures/sovereignty-hubs',
     method: 'GET',
-    requiresAuth: false,
+    requiresAuth: true,
+    pathParams: ['corporationId'],
     responseSchema: z.array(SovereigntyHubSchema),
   },
   getOrbitalSkyhooks: {
-    path: 'sovereignty/skyhooks',
+    path: 'corporations/{corporationId}/structures/skyhooks',
     method: 'GET',
-    requiresAuth: false,
+    requiresAuth: true,
+    pathParams: ['corporationId'],
     responseSchema: z.array(OrbitalSkyhookSchema),
   },
   getRaidableSkyhooks: {
-    path: 'sovereignty/skyhooks/raidable',
+    path: 'skyhooks/raidable',
     method: 'GET',
     requiresAuth: false,
     responseSchema: z.array(RaidableSkyhookSchema),

--- a/tests/bdd/step-definitions/core/mercenary.steps.ts
+++ b/tests/bdd/step-definitions/core/mercenary.steps.ts
@@ -5,6 +5,8 @@ import { TestDataFactory } from '../../../../src/testing/TestDataFactory';
 
 const feature = loadFeature('tests/bdd/features/core/mercenary.feature');
 
+const TEST_CHARACTER_ID = 123456;
+
 defineFeature(feature, (test) => {
   let client: EsiClient;
 
@@ -50,7 +52,7 @@ defineFeature(feature, (test) => {
     });
 
     when('the client requests dens', async () => {
-      result = await client.mercenary.getMercenaryDens();
+      result = await client.mercenary.getMercenaryDens(TEST_CHARACTER_ID);
     });
 
     then('the client shall return development and anarchy parameters', () => {
@@ -75,7 +77,7 @@ defineFeature(feature, (test) => {
     });
 
     when('the client requests dens', async () => {
-      result = await client.mercenary.getMercenaryDens();
+      result = await client.mercenary.getMercenaryDens(TEST_CHARACTER_ID);
     });
 
     then('the client shall return an empty array', () => {
@@ -118,7 +120,10 @@ defineFeature(feature, (test) => {
     });
 
     when('the client requests operations', async () => {
-      result = await client.mercenary.getMercenaryTacticalOperations();
+      result =
+        await client.mercenary.getMercenaryTacticalOperations(
+          TEST_CHARACTER_ID,
+        );
     });
 
     then('the client shall return operation details with status', () => {
@@ -171,8 +176,8 @@ defineFeature(feature, (test) => {
 
     when('the client fetches both', async () => {
       [denResults, opResults] = await Promise.all([
-        client.mercenary.getMercenaryDens(),
-        client.mercenary.getMercenaryTacticalOperations(),
+        client.mercenary.getMercenaryDens(TEST_CHARACTER_ID),
+        client.mercenary.getMercenaryTacticalOperations(TEST_CHARACTER_ID),
       ]);
     });
 
@@ -197,7 +202,7 @@ defineFeature(feature, (test) => {
 
     when('the client requests mercenary data', async () => {
       try {
-        await client.mercenary.getMercenaryDens();
+        await client.mercenary.getMercenaryDens(TEST_CHARACTER_ID);
       } catch (e) {
         caughtError = e;
       }

--- a/tests/bdd/step-definitions/core/skyhooks.steps.ts
+++ b/tests/bdd/step-definitions/core/skyhooks.steps.ts
@@ -5,6 +5,8 @@ import { TestDataFactory } from '../../../../src/testing/TestDataFactory';
 
 const feature = loadFeature('tests/bdd/features/core/skyhooks.feature');
 
+const TEST_CORPORATION_ID = 98000002;
+
 defineFeature(feature, (test) => {
   let client: EsiClient;
 
@@ -50,7 +52,7 @@ defineFeature(feature, (test) => {
     });
 
     when('the client requests hubs', async () => {
-      result = await client.skyhooks.getSovereigntyHubs();
+      result = await client.skyhooks.getSovereigntyHubs(TEST_CORPORATION_ID);
     });
 
     then(
@@ -90,7 +92,7 @@ defineFeature(feature, (test) => {
     });
 
     when('the client requests skyhooks', async () => {
-      result = await client.skyhooks.getOrbitalSkyhooks();
+      result = await client.skyhooks.getOrbitalSkyhooks(TEST_CORPORATION_ID);
     });
 
     then('the client shall return silo capacity and levels', () => {
@@ -161,7 +163,7 @@ defineFeature(feature, (test) => {
 
     when('the client requests skyhook data', async () => {
       try {
-        await client.skyhooks.getSovereigntyHubs();
+        await client.skyhooks.getSovereigntyHubs(TEST_CORPORATION_ID);
       } catch (e) {
         caughtError = e;
       }

--- a/tests/tdd/mercenary/MercenaryClient.test.ts
+++ b/tests/tdd/mercenary/MercenaryClient.test.ts
@@ -1,22 +1,30 @@
 import { ApiClient } from '../../../src/core/ApiClient';
 import { MercenaryClient } from '../../../src/clients/MercenaryClient';
+import { ApiClientBuilder } from '../../../src/core/ApiClientBuilder';
+import { getConfig } from '../../../src/config/configManager';
 import { RateLimiter } from '../../../src/core/rateLimiter/RateLimiter';
 import fetchMock from 'jest-fetch-mock';
 import { describeClientErrors } from '../helpers/clientErrorTests';
 
 fetchMock.enableMocks();
 
-describe('MercenaryClient', () => {
-  let client: ApiClient;
-  let mercenaryClient: MercenaryClient;
+const config = getConfig();
 
+const rateLimiter = new RateLimiter();
+rateLimiter.setTestMode(true);
+
+const client = new ApiClientBuilder()
+  .setClientId(config.projectName)
+  .setLink(config.link)
+  .setAccessToken(process.env.ESI_ACCESS_TOKEN || 'test-token')
+  .setRateLimiter(rateLimiter)
+  .build();
+
+const mercenaryClient = new MercenaryClient(client);
+
+describe('MercenaryClient', () => {
   beforeEach(() => {
     fetchMock.resetMocks();
-    client = new ApiClient('dummy-client-id', 'https://esi.evetech.net');
-    const rateLimiter = new RateLimiter();
-    rateLimiter.setTestMode(true);
-    client.setRateLimiter(rateLimiter);
-    mercenaryClient = new MercenaryClient(client);
   });
 
   it('should get mercenary dens', async () => {
@@ -34,7 +42,9 @@ describe('MercenaryClient', () => {
 
     fetchMock.mockResponseOnce(JSON.stringify(mockResponse));
 
-    const result = await getBody(() => mercenaryClient.getMercenaryDens());
+    const result = await getBody(() =>
+      mercenaryClient.getMercenaryDens(123456),
+    );
     expect(Array.isArray(result)).toBe(true);
     result.forEach((den: any) => {
       expect(den).toHaveProperty('den_id');
@@ -42,7 +52,7 @@ describe('MercenaryClient', () => {
       expect(den).toHaveProperty('system_id');
     });
     expect(fetchMock.mock.calls[0][0]).toBe(
-      'https://esi.evetech.net/mercenary/dens',
+      'https://esi.evetech.net/latest/characters/123456/structures/mercenary-dens',
     );
   });
 
@@ -62,7 +72,7 @@ describe('MercenaryClient', () => {
     fetchMock.mockResponseOnce(JSON.stringify(mockResponse));
 
     const result = await getBody(() =>
-      mercenaryClient.getMercenaryTacticalOperations(),
+      mercenaryClient.getMercenaryTacticalOperations(123456),
     );
     expect(Array.isArray(result)).toBe(true);
     result.forEach((op: any) => {
@@ -71,11 +81,33 @@ describe('MercenaryClient', () => {
       expect(op).toHaveProperty('status');
     });
     expect(fetchMock.mock.calls[0][0]).toBe(
-      'https://esi.evetech.net/mercenary/operations',
+      'https://esi.evetech.net/latest/characters/123456/mercenary-tactical-operations',
     );
   });
 
+  it('should send auth headers for mercenary dens', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify([]));
+
+    await getBody(() => mercenaryClient.getMercenaryDens(123456));
+
+    const requestInit = fetchMock.mock.calls[0][1];
+    expect(requestInit?.headers).toBeDefined();
+    const headers = requestInit?.headers as Record<string, string>;
+    expect(headers['Authorization']).toMatch(/^Bearer /);
+  });
+
+  it('should send auth headers for mercenary tactical operations', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify([]));
+
+    await getBody(() => mercenaryClient.getMercenaryTacticalOperations(123456));
+
+    const requestInit = fetchMock.mock.calls[0][1];
+    expect(requestInit?.headers).toBeDefined();
+    const headers = requestInit?.headers as Record<string, string>;
+    expect(headers['Authorization']).toMatch(/^Bearer /);
+  });
+
   describeClientErrors('MercenaryClient', () =>
-    mercenaryClient.getMercenaryDens(),
+    mercenaryClient.getMercenaryDens(123456),
   );
 });

--- a/tests/tdd/skyhooks/SkyhooksClient.test.ts
+++ b/tests/tdd/skyhooks/SkyhooksClient.test.ts
@@ -1,22 +1,37 @@
 import { ApiClient } from '../../../src/core/ApiClient';
 import { SkyhooksClient } from '../../../src/clients/SkyhooksClient';
+import { ApiClientBuilder } from '../../../src/core/ApiClientBuilder';
+import { getConfig } from '../../../src/config/configManager';
 import { RateLimiter } from '../../../src/core/rateLimiter/RateLimiter';
 import fetchMock from 'jest-fetch-mock';
 import { describeClientErrors } from '../helpers/clientErrorTests';
 
 fetchMock.enableMocks();
 
-describe('SkyhooksClient', () => {
-  let client: ApiClient;
-  let skyhooksClient: SkyhooksClient;
+const config = getConfig();
 
+const rateLimiter = new RateLimiter();
+rateLimiter.setTestMode(true);
+
+const authClient = new ApiClientBuilder()
+  .setClientId(config.projectName)
+  .setLink(config.link)
+  .setAccessToken(process.env.ESI_ACCESS_TOKEN || 'test-token')
+  .setRateLimiter(rateLimiter)
+  .build();
+
+const unauthClient = new ApiClientBuilder()
+  .setClientId(config.projectName)
+  .setLink(config.link)
+  .setRateLimiter(rateLimiter)
+  .build();
+
+const authSkyhooksClient = new SkyhooksClient(authClient);
+const unauthSkyhooksClient = new SkyhooksClient(unauthClient);
+
+describe('SkyhooksClient', () => {
   beforeEach(() => {
     fetchMock.resetMocks();
-    client = new ApiClient('dummy-client-id', 'https://esi.evetech.net');
-    const rateLimiter = new RateLimiter();
-    rateLimiter.setTestMode(true);
-    client.setRateLimiter(rateLimiter);
-    skyhooksClient = new SkyhooksClient(client);
   });
 
   it('should get sovereignty hubs', async () => {
@@ -34,7 +49,9 @@ describe('SkyhooksClient', () => {
 
     fetchMock.mockResponseOnce(JSON.stringify(mockResponse));
 
-    const result = await getBody(() => skyhooksClient.getSovereigntyHubs());
+    const result = await getBody(() =>
+      authSkyhooksClient.getSovereigntyHubs(98000002),
+    );
     expect(Array.isArray(result)).toBe(true);
     result.forEach((hub: any) => {
       expect(hub).toHaveProperty('structure_id');
@@ -43,7 +60,7 @@ describe('SkyhooksClient', () => {
       expect(typeof hub.online).toBe('boolean');
     });
     expect(fetchMock.mock.calls[0][0]).toBe(
-      'https://esi.evetech.net/sovereignty/hubs',
+      'https://esi.evetech.net/latest/corporations/98000002/structures/sovereignty-hubs',
     );
   });
 
@@ -62,7 +79,9 @@ describe('SkyhooksClient', () => {
 
     fetchMock.mockResponseOnce(JSON.stringify(mockResponse));
 
-    const result = await getBody(() => skyhooksClient.getOrbitalSkyhooks());
+    const result = await getBody(() =>
+      authSkyhooksClient.getOrbitalSkyhooks(98000002),
+    );
     expect(Array.isArray(result)).toBe(true);
     result.forEach((skyhook: any) => {
       expect(skyhook).toHaveProperty('structure_id');
@@ -70,7 +89,7 @@ describe('SkyhooksClient', () => {
       expect(skyhook).toHaveProperty('online');
     });
     expect(fetchMock.mock.calls[0][0]).toBe(
-      'https://esi.evetech.net/sovereignty/skyhooks',
+      'https://esi.evetech.net/latest/corporations/98000002/structures/skyhooks',
     );
   });
 
@@ -88,7 +107,9 @@ describe('SkyhooksClient', () => {
 
     fetchMock.mockResponseOnce(JSON.stringify(mockResponse));
 
-    const result = await getBody(() => skyhooksClient.getRaidableSkyhooks());
+    const result = await getBody(() =>
+      unauthSkyhooksClient.getRaidableSkyhooks(),
+    );
     expect(Array.isArray(result)).toBe(true);
     result.forEach((skyhook: any) => {
       expect(skyhook).toHaveProperty('structure_id');
@@ -97,11 +118,33 @@ describe('SkyhooksClient', () => {
       expect(typeof skyhook.is_raidable).toBe('boolean');
     });
     expect(fetchMock.mock.calls[0][0]).toBe(
-      'https://esi.evetech.net/sovereignty/skyhooks/raidable',
+      'https://esi.evetech.net/latest/skyhooks/raidable',
     );
   });
 
+  it('should send auth headers for sovereignty hubs', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify([]));
+
+    await getBody(() => authSkyhooksClient.getSovereigntyHubs(98000002));
+
+    const requestInit = fetchMock.mock.calls[0][1];
+    expect(requestInit?.headers).toBeDefined();
+    const headers = requestInit?.headers as Record<string, string>;
+    expect(headers['Authorization']).toMatch(/^Bearer /);
+  });
+
+  it('should send auth headers for orbital skyhooks', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify([]));
+
+    await getBody(() => authSkyhooksClient.getOrbitalSkyhooks(98000002));
+
+    const requestInit = fetchMock.mock.calls[0][1];
+    expect(requestInit?.headers).toBeDefined();
+    const headers = requestInit?.headers as Record<string, string>;
+    expect(headers['Authorization']).toMatch(/^Bearer /);
+  });
+
   describeClientErrors('SkyhooksClient', () =>
-    skyhooksClient.getSovereigntyHubs(),
+    authSkyhooksClient.getSovereigntyHubs(98000002),
   );
 });


### PR DESCRIPTION
## Summary

Updates mercenary and skyhook endpoint paths to match the ESI spec (compatibility date `2026-05-19`):

| Old Path | New Spec Path | Auth |
|----------|---------------|------|
| `mercenary/dens` | `characters/{characterId}/structures/mercenary-dens` | Yes |
| `mercenary/operations` | `characters/{characterId}/mercenary-tactical-operations` | Yes |
| `sovereignty/hubs` | `corporations/{corporationId}/structures/sovereignty-hubs` | Yes |
| `sovereignty/skyhooks` | `corporations/{corporationId}/structures/skyhooks` | Yes |
| `sovereignty/skyhooks/raidable` | `skyhooks/raidable` | No |

## Files Changed

| Layer | Changes |
|-------|---------|
| Endpoints | `mercenaryEndpoints.ts`, `skyhookEndpoints.ts` — path + auth updates |
| Clients | `MercenaryClient.ts`, `SkyhooksClient.ts` — added characterId/corporationId params |
| Unit Tests | Updated URLs, auth headers, separate auth/unauth clients |
| BDD Steps | Updated method call signatures |
| Examples | `mercenary.ts`, `skyhooks.ts` — pass ID params |

## Test plan

- [x] `npm run typecheck` — passes
- [x] All tests pass (28 tests, 4 suites)
- [x] `npm run lint` — clean

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)