### PR TITLE
ci: move mutation testing to nightly schedule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,36 +278,6 @@ jobs:
             exit 1
           fi
 
-  mutation-testing:
-    name: Mutation Testing
-    runs-on: ubuntu-latest
-    needs: lint-and-build
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v7
-        with:
-          node-version: '20'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Run mutation testing
-        run: npm run mutation
-        timeout-minutes: 150
-
-      - name: Upload mutation report
-        uses: actions/upload-artifact@v7
-        if: always()
-        with:
-          name: mutation-report
-          path: reports/mutation/
-          retention-days: 30
-
   schemathesis:
     name: Schemathesis API Fuzz
     runs-on: ubuntu-latest
@@ -382,7 +352,6 @@ jobs:
         static-analysis,
         contract-tests,
         fuzz-tests,
-        mutation-testing,
       ]
     if: always()
 
@@ -396,7 +365,6 @@ jobs:
           echo "Static Analysis: ${{ needs.static-analysis.result }}"
           echo "Contract Tests: ${{ needs.contract-tests.result }}"
           echo "Fuzz Tests: ${{ needs.fuzz-tests.result }}"
-          echo "Mutation Testing: ${{ needs.mutation-testing.result }}"
 
       - name: Quality Gate
         if: >-
@@ -406,8 +374,7 @@ jobs:
           needs.coverage.result != 'success' ||
           needs.static-analysis.result != 'success' ||
           needs.contract-tests.result != 'success' ||
-          needs.fuzz-tests.result != 'success' ||
-          needs.mutation-testing.result != 'success'
+          needs.fuzz-tests.result != 'success'
         run: |
           echo "Quality gate failed!"
           exit 1
@@ -420,6 +387,5 @@ jobs:
           needs.coverage.result == 'success' &&
           needs.static-analysis.result == 'success' &&
           needs.contract-tests.result == 'success' &&
-          needs.fuzz-tests.result == 'success' &&
-          needs.mutation-testing.result == 'success'
+          needs.fuzz-tests.result == 'success'
         run: echo "All quality checks passed!"

--- a/.github/workflows/nightly-mutation.yml
+++ b/.github/workflows/nightly-mutation.yml
@@ -1,0 +1,49 @@
+name: Nightly Mutation Testing
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  mutation-testing:
+    name: Mutation Testing
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run mutation testing
+        run: npm run mutation
+
+      - name: Upload mutation report
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: mutation-report
+          path: reports/mutation/
+          retention-days: 30
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "## Nightly Mutation Testing" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Date:** $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_STEP_SUMMARY
+          if [ -f reports/mutation/mutation.html ]; then
+            echo "- **Report:** uploaded as artifact" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,8 @@ Key middleware in the pipeline:
 ### CI Workflows
 
 - **ci-fast.yml** — runs on all pushes: lint, format, build, typecheck, unit tests (Node 20)
-- **ci.yml** — runs on PRs to master: full matrix (Node 18/20/22), BDD, contract, fuzz, mutation testing, coverage with PR comment, quality gate
+- **ci.yml** — runs on PRs to master: full matrix (Node 18/20/22), BDD, contract, fuzz, coverage with PR comment, quality gate
+- **nightly-mutation.yml** — runs nightly: mutation testing (Stryker) with 4-hour timeout
 
 ## Do Not Edit
 


### PR DESCRIPTION
## Summary

- Removed mutation testing job from the PR CI pipeline (`ci.yml`) and its quality gate dependency
- Created `nightly-mutation.yml` workflow running at 02:00 UTC daily with a 4-hour timeout
- Mutation testing is still available on-demand via `workflow_dispatch`

## Motivation

Mutation testing (Stryker) takes exceptionally long to run and doesn't need to gate every PR. Moving it to a nightly schedule keeps PR feedback fast while still catching mutation score regressions daily.

## Test plan

- [x] Verify `ci.yml` no longer references `mutation-testing` job
- [x] Verify `nightly-mutation.yml` is valid (trigger manually via `workflow_dispatch`)
- [x] Confirm PR quality gate still passes without mutation testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)