### PR TITLE
fix(ci): scope workflow token permissions to least privilege

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   pr-info:
@@ -150,6 +149,9 @@ jobs:
     name: Test Coverage
     runs-on: ubuntu-latest
     needs: lint-and-build
+    permissions:
+      contents: read
+      pull-requests: write # post/update the coverage comment
 
     steps:
       - name: Checkout code

--- a/.github/workflows/nightly-audit.yml
+++ b/.github/workflows/nightly-audit.yml
@@ -7,12 +7,14 @@ on:
 
 permissions:
   contents: read
-  issues: write
 
 jobs:
   audit:
     name: npm Security Audit
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write # create/label the security-audit issue
 
     steps:
       - name: Checkout code

--- a/.github/workflows/nightly-spec-drift.yml
+++ b/.github/workflows/nightly-spec-drift.yml
@@ -7,12 +7,14 @@ on:
 
 permissions:
   contents: read
-  issues: write
 
 jobs:
   check-spec-drift:
     name: Check ESI Spec Drift
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write # create/update the spec-drift issue
 
     steps:
       - name: Checkout code

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,13 +5,15 @@ on:
     branches: [master]
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   release-please:
     name: Release Please
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # create release commits/tags
+      pull-requests: write # open/update the release PR
 
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
## Summary

Addresses the **Token-Permissions** check in the OpenSSF Scorecard, currently **0/10** (reason: *"detected GitHub workflow tokens with excessive permissions"*). This is one of the five 0-scoring checks tracked in beads epic *Improve OpenSSF Scorecard* (`esi-jxu`).

All workflows already had `permissions:` blocks, but four granted **write** scopes at the **top level**, giving every job in the workflow more access than it needs. Scorecard wants top-level permissions read-only, with write scopes granted only to the specific job that needs them.

## Changes

| Workflow | Was (top-level) | Now |
| --- | --- | --- |
| `ci.yml` | `pull-requests: write` | top-level `contents: read`; `pull-requests: write` on **coverage** job (coverage comment) |
| `nightly-audit.yml` | `issues: write` | top-level `contents: read`; `issues: write` on **audit** job |
| `nightly-spec-drift.yml` | `issues: write` | top-level `contents: read`; `issues: write` on **check-spec-drift** job |
| `release-please.yml` | `contents: write`, `pull-requests: write` | top-level `contents: read`; both on **release-please** job |

Each job's write scope was verified against what the job actually does (coverage comment via `MishaKav/jest-coverage-comment`; `gh issue`/`gh label` calls; release-please commit/PR creation).

## Verification

- All four workflow files parse as valid YAML.
- Re-audited every workflow: no remaining top-level write scopes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)