### PR TITLE
chore(ci): bump codeql-action to v4.37.8 and group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,3 +40,7 @@ updates:
       prefix: 'chore(ci):'
     labels:
       - dependencies
+    groups:
+      codeql:
+        patterns:
+          - 'github/codeql-action'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,14 +29,14 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
+        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
+        uses: github/codeql-action/autobuild@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
+        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4
         with:
           category: '/language:${{ matrix.language }}'


### PR DESCRIPTION
## Summary
- Bump all three `github/codeql-action` sub-actions (init, autobuild, analyze) atomically from v4.37.7 to v4.37.8
- Add dependabot group for `github/codeql-action` to prevent future version-mismatch CI failures

**Root cause:** Dependabot created separate PRs for each sub-action (#201, #204, #206), but CodeQL requires all three to use the same SHA — version mismatch causes the "Analyze" step to fail.

Closes #201, closes #204, closes #206.

## Test plan
- [ ] CI "Analyze (javascript-typescript)" check passes (was failing on all three individual PRs)
- [ ] All other CI checks remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)