### PR TITLE
test: improve branch and function coverage to mid-90s

### DIFF
--- a/tests/tdd/core/ApiRequestHandler.test.ts
+++ b/tests/tdd/core/ApiRequestHandler.test.ts
@@ -1,5 +1,8 @@
 import { ApiClient } from '../../../src/core/ApiClient';
-import { handleRequest } from '../../../src/core/ApiRequestHandler';
+import {
+  handleRequest,
+  handleSinglePageRequest,
+} from '../../../src/core/ApiRequestHandler';
 import { RateLimiter } from '../../../src/core/rateLimiter/RateLimiter';
 import { ETagCacheManager } from '../../../src/core/cache/ETagCacheManager';
 import { CircuitBreaker } from '../../../src/core/circuitBreaker/CircuitBreaker';
@@ -175,6 +178,80 @@ describe('ApiRequestHandler', () => {
       await expect(
         handleRequest(client, 'v1/characters/123/', 'GET'),
       ).rejects.toThrow(EsiError);
+    });
+  });
+
+  describe('handleSinglePageRequest', () => {
+    it('should fetch a single page and return data', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify([{ id: 1 }, { id: 2 }]));
+
+      const result = await handleSinglePageRequest(
+        client,
+        'v1/alliances/',
+        'GET',
+      );
+
+      expect(result.body).toEqual([{ id: 1 }, { id: 2 }]);
+      expect(result.headers).toBeDefined();
+    });
+
+    it('should include auth header when requiresAuth is true', async () => {
+      client.setAccessToken('single-page-token');
+      fetchMock.mockResponseOnce(JSON.stringify({ name: 'Test' }));
+
+      await handleSinglePageRequest(
+        client,
+        'v1/characters/123/',
+        'GET',
+        undefined,
+        true,
+      );
+
+      const headers = fetchMock.mock.calls[0]?.[1]?.headers as Record<
+        string,
+        string
+      >;
+      expect(headers['Authorization']).toBe('Bearer single-page-token');
+    });
+
+    it('should throw EsiError on HTTP error', async () => {
+      fetchMock.mockResponseOnce('Internal Server Error', { status: 500 });
+
+      await expect(
+        handleSinglePageRequest(client, 'v1/status/', 'GET'),
+      ).rejects.toThrow(EsiError);
+    });
+
+    it('should pass templatePath and requestTimeout', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ status: 'ok' }));
+
+      const result = await handleSinglePageRequest(
+        client,
+        'v1/status/',
+        'GET',
+        undefined,
+        false,
+        'v1/status/',
+        5000,
+      );
+
+      expect(result.body).toEqual({ status: 'ok' });
+    });
+
+    it('should pass refreshToken when client has token provider', async () => {
+      client.setAccessToken('test-token');
+      client.setTokenProvider(async () => 'refreshed-token');
+      fetchMock.mockResponseOnce(JSON.stringify({ name: 'Test' }));
+
+      const result = await handleSinglePageRequest(
+        client,
+        'v1/characters/123/',
+        'GET',
+        undefined,
+        true,
+      );
+
+      expect(result.body).toEqual({ name: 'Test' });
     });
   });
 

--- a/tests/tdd/core/CursorPaginationHandler.test.ts
+++ b/tests/tdd/core/CursorPaginationHandler.test.ts
@@ -267,6 +267,56 @@ describe('CursorPaginationHandler', () => {
 
       expect(result.data).toEqual([{ id: 1, name: 'single' }]);
     });
+
+    it('should return empty array when response data is null', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(null));
+
+      const result = await CursorPaginationHandler.fetchPage(
+        client,
+        'some/endpoint',
+        'GET',
+        false,
+      );
+
+      expect(result.data).toEqual([]);
+    });
+
+    it('should delegate to pageFetch callback when provided', async () => {
+      const pageFetch = jest.fn().mockResolvedValue({
+        data: [{ id: 1 }],
+        cursors: { before: null, after: 'a1' },
+      });
+
+      const result = await CursorPaginationHandler.fetchPage(
+        client,
+        'some/endpoint',
+        'GET',
+        false,
+        { after: 'tok' },
+        undefined,
+        pageFetch,
+      );
+
+      expect(result.data).toEqual([{ id: 1 }]);
+      expect(pageFetch).toHaveBeenCalledWith('some/endpoint', { after: 'tok' });
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('should return endpoint unchanged when cursor has no before or after', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify([{ id: 1 }]));
+
+      await CursorPaginationHandler.fetchPage(
+        client,
+        'some/endpoint',
+        'GET',
+        false,
+        {},
+      );
+
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        'https://esi.evetech.net/some/endpoint',
+      );
+    });
   });
 
   describe('fetchAll', () => {
@@ -449,6 +499,35 @@ describe('CursorPaginationHandler', () => {
       );
 
       expect(result).toEqual([{ id: 1 }]);
+    });
+
+    it('should pass refreshToken when client has token provider', async () => {
+      const authedClient = new ApiClient(
+        'test',
+        'https://esi.evetech.net',
+        'my-token',
+      );
+      const rl = new RateLimiter();
+      rl.setTestMode(true);
+      authedClient.setRateLimiter(rl);
+      authedClient.setTokenProvider(async () => 'refreshed-token');
+
+      const resp = cursorResponse([{ id: 2 }], null, null);
+      fetchMock.mockResponseOnce(resp.body, {
+        status: resp.status,
+        headers: resp.headers,
+      });
+
+      const result = await CursorPaginationHandler.fetchAll(
+        authedClient,
+        'corporations/123/projects',
+        'GET',
+        true,
+        [{ id: 1 }],
+        { before: null, after: 'c1' },
+      );
+
+      expect(result).toEqual([{ id: 1 }, { id: 2 }]);
     });
 
     it('should handle duplicates across pages (per ESI spec)', async () => {

--- a/tests/tdd/core/PaginationHandler.test.ts
+++ b/tests/tdd/core/PaginationHandler.test.ts
@@ -303,5 +303,26 @@ describe('PaginationHandler', () => {
 
       expect(executeMock).toHaveBeenCalled();
     });
+
+    it('should pass refreshToken when client has token provider', async () => {
+      client.setAccessToken('test-token');
+      client.setTokenProvider(async () => 'refreshed-token');
+      const firstPageData = [{ id: 1 }];
+      pageFetch.mockResolvedValueOnce([{ id: 2 }]);
+
+      const result = await PaginationHandler.fetchRemainingPages(
+        client,
+        'alliances',
+        'GET',
+        true,
+        firstPageData,
+        2,
+        undefined,
+        {},
+        pageFetch,
+      );
+
+      expect(result).toEqual([{ id: 1 }, { id: 2 }]);
+    });
   });
 });

--- a/tests/tdd/core/RateLimiter.test.ts
+++ b/tests/tdd/core/RateLimiter.test.ts
@@ -781,6 +781,98 @@ describe('RateLimiter', () => {
     });
   });
 
+  describe('checkRateLimit blocked retry budget exhaustion', () => {
+    let sleepSpy: jest.SpyInstance;
+    let dateNowSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      sleepSpy = jest.spyOn(sleepModule, 'sleep').mockResolvedValue(undefined);
+    });
+
+    afterEach(() => {
+      sleepSpy.mockRestore();
+      if (dateNowSpy) dateNowSpy.mockRestore();
+    });
+
+    it('should throw EsiError when block is re-extended past retry budget', async () => {
+      const baseTime = Date.now();
+      let currentTime = baseTime;
+      dateNowSpy = jest
+        .spyOn(Date, 'now')
+        .mockImplementation(() => currentTime);
+
+      limiter.updateFromResponse({ 'retry-after': '5' }, 429);
+
+      sleepSpy.mockImplementation(async () => {
+        currentTime += 100;
+        limiter.updateFromResponse({ 'retry-after': '5' }, 429);
+      });
+
+      await expect(limiter.checkRateLimit()).rejects.toThrow(/still blocked/);
+    });
+  });
+
+  describe('isBlocked with fallback bucket', () => {
+    it('should return true when fallback bucket is blocked', () => {
+      limiter.updateFromResponse({ 'retry-after': '30' }, 429);
+      expect(limiter.isBlocked()).toBe(true);
+    });
+  });
+
+  describe('getStatus with user buckets', () => {
+    it('should check user bucket groups in getStatus', () => {
+      const userLimiter = new RateLimiter({
+        userKeyExtractor: (headers) => headers['authorization'] ?? 'anon',
+      });
+      userLimiter.setTestMode(false);
+
+      userLimiter.updateFromResponse(
+        {
+          'x-ratelimit-remaining': '3',
+          'x-ratelimit-limit': '15',
+          'x-ratelimit-used': '12',
+          'x-ratelimit-group': 'char-notification',
+        },
+        200,
+        'characters/{characterId}/notifications',
+        'GET',
+        { authorization: 'Bearer user-a' },
+      );
+
+      const status = userLimiter.getStatus();
+      expect(status.remaining).toBe(3);
+      expect(status.group).toBe('char-notification');
+
+      userLimiter.setTestMode(true);
+    });
+  });
+
+  describe('cleanup stale users', () => {
+    let sleepSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      sleepSpy = jest.spyOn(sleepModule, 'sleep').mockResolvedValue(undefined);
+    });
+
+    afterEach(() => {
+      sleepSpy.mockRestore();
+    });
+
+    it('should skip cleanup when interval has not elapsed', async () => {
+      const userLimiter = new RateLimiter({
+        userKeyExtractor: (headers) => headers['authorization'] ?? 'anon',
+      });
+
+      await userLimiter.checkRateLimit(undefined, undefined, {
+        authorization: 'Bearer user-a',
+      });
+      await userLimiter.checkRateLimit(undefined, undefined, {
+        authorization: 'Bearer user-a',
+      });
+      userLimiter.setTestMode(true);
+    });
+  });
+
   describe('response group header is authoritative', () => {
     it('should use x-ratelimit-group from response over spec lookup', () => {
       limiter.updateFromResponse(

--- a/tests/tdd/core/requestPipeline/fetchExecution.test.ts
+++ b/tests/tdd/core/requestPipeline/fetchExecution.test.ts
@@ -1,0 +1,142 @@
+import { executeSingleFetch } from '../../../../src/core/requestPipeline/fetchExecution';
+import { ApiClient } from '../../../../src/core/ApiClient';
+import { RateLimiter } from '../../../../src/core/rateLimiter/RateLimiter';
+import { ICache } from '../../../../src/core/cache/ICache';
+import { IRateLimiter } from '../../../../src/core/rateLimiter/IRateLimiter';
+import { ICircuitBreaker } from '../../../../src/core/circuitBreaker/ICircuitBreaker';
+import fetchMock from 'jest-fetch-mock';
+
+fetchMock.enableMocks();
+
+const BASE_URL = 'https://esi.evetech.net';
+
+describe('requestPipeline/fetchExecution branch coverage', () => {
+  let client: ApiClient;
+  let rateLimiter: RateLimiter;
+  const resolveCache = (_c: ApiClient): ICache | null => null;
+  const resolveRl = (_c: ApiClient): IRateLimiter => rateLimiter;
+
+  beforeEach(() => {
+    fetchMock.resetMocks();
+    rateLimiter = new RateLimiter();
+    rateLimiter.setTestMode(true);
+    client = new ApiClient('test', BASE_URL);
+    client.setRateLimiter(rateLimiter);
+  });
+
+  describe('fetch throws non-AbortError without circuit breaker', () => {
+    it('should re-throw the error when no circuit breaker is present', async () => {
+      const networkErr = new Error('ECONNREFUSED');
+      fetchMock.mockRejectOnce(networkErr);
+
+      const resolveCb = (_c: ApiClient): ICircuitBreaker | null => null;
+
+      await expect(
+        executeSingleFetch(
+          client,
+          'v1/status/',
+          'GET',
+          undefined,
+          false,
+          false,
+          resolveCache,
+          resolveRl,
+          resolveCb,
+        ),
+      ).rejects.toThrow('ECONNREFUSED');
+    });
+  });
+
+  describe('finally records failure when cb exists but no path recorded', () => {
+    it('should record failure in finally when rate limiter throws before fetch', async () => {
+      const recordFailureMock = jest.fn();
+      const mockCb: ICircuitBreaker = {
+        checkCircuit: jest.fn(),
+        recordSuccess: jest.fn(),
+        recordFailure: recordFailureMock,
+        getState: jest.fn().mockReturnValue('closed'),
+        getStats: jest.fn().mockReturnValue({}),
+        shutdown: jest.fn(),
+        reset: jest.fn(),
+        cleanup: jest.fn().mockReturnValue(0),
+      };
+
+      const resolveCb = (_c: ApiClient): ICircuitBreaker | null => mockCb;
+      const throwingRl: IRateLimiter = {
+        checkRateLimit: jest
+          .fn()
+          .mockRejectedValue(new Error('rate limit error')),
+        updateFromResponse: jest.fn(),
+        getStatus: jest.fn().mockReturnValue({
+          remaining: 100,
+          limit: 100,
+          used: 0,
+          group: null,
+          errorLimitRemain: 100,
+          errorLimitReset: 0,
+          retryAfter: null,
+          blockedUntil: 0,
+        }),
+        isBlocked: jest.fn().mockReturnValue(false),
+        reset: jest.fn(),
+        getGroupStatus: jest.fn(),
+        getAllGroupStatuses: jest.fn().mockReturnValue(new Map()),
+      };
+      const resolveThrowingRl = (_c: ApiClient): IRateLimiter => throwingRl;
+
+      await expect(
+        executeSingleFetch(
+          client,
+          'v1/status/',
+          'GET',
+          undefined,
+          false,
+          false,
+          resolveCache,
+          resolveThrowingRl,
+          resolveCb,
+        ),
+      ).rejects.toThrow('rate limit error');
+
+      expect(recordFailureMock).toHaveBeenCalledWith('v1/status/', 0);
+    });
+  });
+
+  describe('circuit breaker with template key strategy', () => {
+    it('should use templatePath as cbKey when cb.getKeyStrategy returns template', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ players: 100 }));
+      const recordSuccessMock = jest.fn();
+      const mockCb: ICircuitBreaker = {
+        checkCircuit: jest.fn(),
+        recordSuccess: recordSuccessMock,
+        recordFailure: jest.fn(),
+        getState: jest.fn().mockReturnValue('closed'),
+        getStats: jest.fn().mockReturnValue({}),
+        shutdown: jest.fn(),
+        reset: jest.fn(),
+        cleanup: jest.fn().mockReturnValue(0),
+        getKeyStrategy: jest.fn().mockReturnValue('template'),
+      };
+
+      const resolveCb = (_c: ApiClient): ICircuitBreaker | null => mockCb;
+
+      await executeSingleFetch(
+        client,
+        'v1/characters/123/assets/',
+        'GET',
+        undefined,
+        false,
+        false,
+        resolveCache,
+        resolveRl,
+        resolveCb,
+        undefined,
+        'characters/{characterId}/assets',
+      );
+
+      expect(recordSuccessMock).toHaveBeenCalledWith(
+        'characters/{characterId}/assets',
+      );
+    });
+  });
+});

--- a/tests/tdd/core/requestPipeline/middlewareBridge.test.ts
+++ b/tests/tdd/core/requestPipeline/middlewareBridge.test.ts
@@ -1,0 +1,139 @@
+import {
+  applyRequestMiddleware,
+  applyResponseInterceptors,
+} from '../../../../src/core/requestPipeline/middlewareBridge';
+import { ApiClient } from '../../../../src/core/ApiClient';
+import type { EsiHandlerResponse } from '../../../../src/core/requestPipeline/cachePolicy';
+
+const BASE_URL = 'https://esi.evetech.net';
+
+describe('requestPipeline/middlewareBridge', () => {
+  let client: ApiClient;
+
+  beforeEach(() => {
+    client = new ApiClient('test', BASE_URL);
+  });
+
+  describe('applyRequestMiddleware', () => {
+    it('should pass through unchanged when no interceptors', async () => {
+      const result = await applyRequestMiddleware(
+        client,
+        `${BASE_URL}/v1/status/`,
+        'v1/status/',
+        'GET',
+        { Accept: 'application/json' },
+        undefined,
+      );
+
+      expect(result.url).toBe(`${BASE_URL}/v1/status/`);
+      expect(result.headers).toEqual({ Accept: 'application/json' });
+      expect(result.body).toBeUndefined();
+    });
+
+    it('should apply request interceptors when present', async () => {
+      client.addRequestInterceptor((ctx) => ({
+        ...ctx,
+        headers: { ...ctx.headers, 'X-Custom': 'test' },
+      }));
+
+      const result = await applyRequestMiddleware(
+        client,
+        `${BASE_URL}/v1/status/`,
+        'v1/status/',
+        'GET',
+        { Accept: 'application/json' },
+        undefined,
+      );
+
+      expect(result.headers['X-Custom']).toBe('test');
+    });
+  });
+
+  describe('applyResponseInterceptors', () => {
+    it('should pass through unchanged when no interceptors', async () => {
+      const handlerResult: EsiHandlerResponse = {
+        headers: { 'content-type': 'application/json' },
+        body: { players: 100 },
+        status: 200,
+      };
+
+      const result = await applyResponseInterceptors(
+        client,
+        handlerResult,
+        `${BASE_URL}/v1/status/`,
+        'v1/status/',
+        'GET',
+        Date.now(),
+      );
+
+      expect(result).toBe(handlerResult);
+    });
+
+    it('should default to status 200 when result.status is undefined', async () => {
+      client.addResponseInterceptor((ctx) => {
+        expect(ctx.status).toBe(200);
+        return ctx;
+      });
+
+      const handlerResult: EsiHandlerResponse = {
+        headers: { 'content-type': 'application/json' },
+        body: { players: 100 },
+      };
+
+      await applyResponseInterceptors(
+        client,
+        handlerResult,
+        `${BASE_URL}/v1/status/`,
+        'v1/status/',
+        'GET',
+        Date.now(),
+      );
+    });
+
+    it('should default fromCache to false when not set', async () => {
+      client.addResponseInterceptor((ctx) => {
+        expect(ctx.fromCache).toBe(false);
+        return ctx;
+      });
+
+      const handlerResult: EsiHandlerResponse = {
+        headers: {},
+        body: null,
+        status: 200,
+      };
+
+      await applyResponseInterceptors(
+        client,
+        handlerResult,
+        `${BASE_URL}/v1/status/`,
+        'v1/status/',
+        'GET',
+        Date.now(),
+      );
+    });
+
+    it('should apply response interceptors and return modified result', async () => {
+      client.addResponseInterceptor((ctx) => ({
+        ...ctx,
+        body: { modified: true },
+      }));
+
+      const handlerResult: EsiHandlerResponse = {
+        headers: { 'content-type': 'application/json' },
+        body: { players: 100 },
+        status: 200,
+      };
+
+      const result = await applyResponseInterceptors(
+        client,
+        handlerResult,
+        `${BASE_URL}/v1/status/`,
+        'v1/status/',
+        'GET',
+        Date.now(),
+      );
+
+      expect(result.body).toEqual({ modified: true });
+    });
+  });
+});

--- a/tests/tdd/core/requestPipeline/paginationOrchestration.test.ts
+++ b/tests/tdd/core/requestPipeline/paginationOrchestration.test.ts
@@ -1,0 +1,206 @@
+import {
+  handleCursorPagination,
+  handleOffsetPagination,
+} from '../../../../src/core/requestPipeline/paginationOrchestration';
+import { ApiClient } from '../../../../src/core/ApiClient';
+import { RateLimiter } from '../../../../src/core/rateLimiter/RateLimiter';
+import { EsiError } from '../../../../src/core/util/error';
+import { CircuitOpenError } from '../../../../src/core/circuitBreaker/CircuitBreaker';
+import { ParsedHeaders } from '../../../../src/core/util/headersUtil';
+import { ICache } from '../../../../src/core/cache/ICache';
+
+const BASE_URL = 'https://esi.evetech.net';
+
+describe('requestPipeline/paginationOrchestration', () => {
+  describe('handleCursorPagination', () => {
+    it('should return null when no cursor pagination headers present', () => {
+      const parsed = {
+        raw: {},
+        hasCursorPagination: false,
+        cursorBefore: null,
+        cursorAfter: null,
+      } as unknown as ParsedHeaders;
+
+      expect(handleCursorPagination(parsed, [{ id: 1 }])).toBeNull();
+    });
+
+    it('should return response with cursors when cursor headers are present', () => {
+      const parsed = {
+        raw: { 'x-cursor-before': 'b1', 'x-cursor-after': 'a1' },
+        hasCursorPagination: true,
+        cursorBefore: 'b1',
+        cursorAfter: 'a1',
+      } as unknown as ParsedHeaders;
+
+      const result = handleCursorPagination(parsed, [{ id: 1 }]);
+      expect(result).not.toBeNull();
+      expect(result!.status).toBe(200);
+      expect(result!.cursors).toEqual({ before: 'b1', after: 'a1' });
+      expect(result!.body).toEqual([{ id: 1 }]);
+    });
+  });
+
+  describe('handleOffsetPagination', () => {
+    let client: ApiClient;
+    const resolveCache = (_c: ApiClient): ICache | null => null;
+
+    beforeEach(() => {
+      const rateLimiter = new RateLimiter();
+      rateLimiter.setTestMode(true);
+      client = new ApiClient('test', BASE_URL);
+      client.setRateLimiter(rateLimiter);
+      client.setRetryConfig({ maxRetries: 0, baseDelayMs: 1, maxDelayMs: 10 });
+    });
+
+    it('should return data directly when totalPages <= 1', async () => {
+      const parsed = {
+        raw: {},
+        xPages: 1,
+      } as unknown as ParsedHeaders;
+      const pageFetch = jest.fn();
+
+      const result = await handleOffsetPagination(
+        client,
+        'alliances',
+        'GET',
+        false,
+        parsed,
+        [{ id: 1 }],
+        undefined,
+        `${BASE_URL}/alliances`,
+        true,
+        pageFetch,
+        resolveCache,
+      );
+
+      expect(result.status).toBe(200);
+      expect(result.body).toEqual([{ id: 1 }]);
+      expect(pageFetch).not.toHaveBeenCalled();
+    });
+
+    it('should wrap non-array data in an array for first page', async () => {
+      const parsed = {
+        raw: {},
+        xPages: 2,
+      } as unknown as ParsedHeaders;
+      const pageFetch = jest.fn().mockResolvedValue([{ id: 2 }]);
+
+      const result = await handleOffsetPagination(
+        client,
+        'alliances',
+        'GET',
+        false,
+        parsed,
+        { id: 1 } as unknown,
+        undefined,
+        `${BASE_URL}/alliances`,
+        true,
+        pageFetch,
+        resolveCache,
+      );
+
+      expect(result.status).toBe(200);
+      expect(result.body).toEqual([{ id: 1 }, { id: 2 }]);
+    });
+
+    it('should re-throw EsiError from pagination failure', async () => {
+      const parsed = {
+        raw: {},
+        xPages: 3,
+      } as unknown as ParsedHeaders;
+      const esiErr = new EsiError(502, 'Bad Gateway');
+      const pageFetch = jest.fn().mockRejectedValue(esiErr);
+
+      await expect(
+        handleOffsetPagination(
+          client,
+          'alliances',
+          'GET',
+          false,
+          parsed,
+          [{ id: 1 }],
+          undefined,
+          `${BASE_URL}/alliances`,
+          true,
+          pageFetch,
+          resolveCache,
+        ),
+      ).rejects.toThrow(esiErr);
+    });
+
+    it('should re-throw CircuitOpenError from pagination failure', async () => {
+      const parsed = {
+        raw: {},
+        xPages: 3,
+      } as unknown as ParsedHeaders;
+      const cbErr = new CircuitOpenError('alliances', 5, 30000);
+      const pageFetch = jest.fn().mockRejectedValue(cbErr);
+
+      await expect(
+        handleOffsetPagination(
+          client,
+          'alliances',
+          'GET',
+          false,
+          parsed,
+          [{ id: 1 }],
+          undefined,
+          `${BASE_URL}/alliances`,
+          true,
+          pageFetch,
+          resolveCache,
+        ),
+      ).rejects.toThrow(CircuitOpenError);
+    });
+
+    it('should stringify non-Error pagination failures', async () => {
+      const parsed = {
+        raw: {},
+        xPages: 3,
+      } as unknown as ParsedHeaders;
+      const pageFetch = jest.fn().mockRejectedValue('string error');
+
+      await expect(
+        handleOffsetPagination(
+          client,
+          'alliances',
+          'GET',
+          false,
+          parsed,
+          [{ id: 1 }],
+          undefined,
+          `${BASE_URL}/alliances`,
+          true,
+          pageFetch,
+          resolveCache,
+        ),
+      ).rejects.toThrow('Pagination incomplete');
+    });
+
+    it('should wrap generic Error as PAGINATION_INCOMPLETE', async () => {
+      const parsed = {
+        raw: {},
+        xPages: 3,
+      } as unknown as ParsedHeaders;
+      const pageFetch = jest
+        .fn()
+        .mockRejectedValue(new Error('network failure'));
+
+      await expect(
+        handleOffsetPagination(
+          client,
+          'alliances',
+          'GET',
+          false,
+          parsed,
+          [{ id: 1 }],
+          undefined,
+          `${BASE_URL}/alliances`,
+          true,
+          pageFetch,
+          resolveCache,
+        ),
+      ).rejects.toThrow('Pagination incomplete');
+    });
+  });
+});

--- a/tests/tdd/sde/MemorySdeProvider.test.ts
+++ b/tests/tdd/sde/MemorySdeProvider.test.ts
@@ -104,4 +104,708 @@ describe('MemorySdeProvider', () => {
       expect(v1).not.toBe(v2);
     });
   });
+
+  describe('extended lookups', () => {
+    const extendedData = {
+      ...SdeTestDataFactory.createHierarchicalTestData(),
+      dogmaAttributeCategories: [
+        { attributeCategoryId: 1, description: 'Fitting', name: 'Fitting' },
+        { attributeCategoryId: 2, description: 'Shield', name: 'Shield' },
+      ],
+      dogmaUnits: [
+        {
+          unitId: 1,
+          description: 'Duration in ms',
+          displayName: 'ms',
+          name: 'Milliseconds',
+        },
+        {
+          unitId: 2,
+          description: 'Modifier percent',
+          displayName: '%',
+          name: 'Percentage',
+        },
+      ],
+      industryActivities: [
+        {
+          industryActivityId: 1,
+          description: 'Manufacturing',
+          name: 'Manufacturing',
+        },
+        { industryActivityId: 8, description: 'Invention', name: 'Invention' },
+      ],
+      agentTypes: [
+        { agentTypeId: 1, name: 'NonAgent' },
+        { agentTypeId: 2, name: 'BasicAgent' },
+      ],
+      agentsInSpace: [
+        {
+          characterId: 3019000,
+          dungeonId: 100,
+          solarSystemId: 30000142,
+          spawnPointId: 1,
+          typeId: 3856,
+        },
+        {
+          characterId: 3019001,
+          dungeonId: 101,
+          solarSystemId: 30000144,
+          spawnPointId: 2,
+          typeId: 3857,
+        },
+      ],
+      certificates: [
+        {
+          certificateId: 1,
+          description: 'Basic Spaceship',
+          groupId: 18,
+          name: 'Spaceship Command Basic',
+          recommendedFor: null,
+          skillTypes: null,
+        },
+      ],
+      characterAttributes: [
+        {
+          attributeId: 164,
+          description: 'Charisma',
+          iconId: 1383,
+          name: 'Charisma',
+          notes: 'Social attribute',
+          shortDescription: 'Cha',
+        },
+      ],
+      npcCharacters: [
+        {
+          characterId: 3004451,
+          bloodlineId: 1,
+          ceo: true,
+          corporationId: 1000035,
+          gender: 1,
+          locationId: 60003760,
+          name: 'Caldari Navy Commander',
+          raceId: 1,
+          startDate: '2003-01-01',
+          uniqueName: true,
+          skills: null,
+          ancestryId: null,
+          careerId: null,
+          schoolId: null,
+          specialityId: null,
+        },
+        {
+          characterId: 3004452,
+          bloodlineId: 2,
+          ceo: false,
+          corporationId: 1000035,
+          gender: 0,
+          locationId: 60003761,
+          name: 'Navy Recruiter',
+          raceId: 1,
+          startDate: '2003-06-01',
+          uniqueName: false,
+          skills: null,
+          ancestryId: 1,
+          careerId: null,
+          schoolId: null,
+          specialityId: null,
+        },
+      ],
+      cloneGrades: [
+        { cloneGradeId: 1, name: 'Alpha', skills: null },
+        { cloneGradeId: 2, name: 'Omega', skills: null },
+      ],
+      corporationActivities: [
+        { corporationActivityId: 1, name: 'Manufacturing' },
+        { corporationActivityId: 2, name: 'Warrior' },
+      ],
+      npcCorporationDivisions: [
+        {
+          npcCorporationDivisionId: 1,
+          displayName: 'Accounting',
+          internalName: 'accounting',
+          leaderTypeName: 'CFO',
+          name: 'Accounting',
+          description: null,
+        },
+        {
+          npcCorporationDivisionId: 2,
+          displayName: 'Security',
+          internalName: 'security',
+          leaderTypeName: 'CSO',
+          name: 'Security',
+          description: 'Corp security',
+        },
+      ],
+      landmarks: [
+        {
+          landmarkId: 1,
+          description: 'The Eve Gate',
+          name: 'Eve Gate',
+          position: { x: 1e16, y: 0, z: 0 },
+          iconId: 10,
+          locationId: 30000001,
+        },
+      ],
+      notificationTypes: [
+        {
+          notificationTypeId: 1,
+          displayName: 'War Declared',
+          internalName: 'AllWarDeclaredMsg',
+        },
+      ],
+      schools: [
+        {
+          schoolId: 1,
+          careerAgents: null,
+          careerId: 1,
+          characterDescription: 'Test desc',
+          corporationId: 1000035,
+          description: 'Science Academy',
+          iconId: 100,
+          name: 'Science and Trade Institute',
+          raceId: 1,
+          startingStations: null,
+          title: 'School of Science',
+          isStarterSpaceSchool: null,
+        },
+      ],
+      secondarySuns: [
+        {
+          secondarySunId: 40100001,
+          effectBeaconTypeId: 100,
+          position: { x: 1e12, y: 2e12, z: 3e12 },
+          solarSystemId: 30000142,
+          typeId: 995,
+        },
+        {
+          secondarySunId: 40100002,
+          effectBeaconTypeId: 101,
+          position: { x: 4e12, y: 5e12, z: 6e12 },
+          solarSystemId: 30000144,
+          typeId: 996,
+        },
+      ],
+      skins: [
+        {
+          skinId: 100,
+          allowCCPDevs: false,
+          internalName: 'TestSkin',
+          skinMaterialId: 200,
+          types: null,
+          visibleSerenity: true,
+          visibleTranquility: true,
+          isStructureSkin: null,
+        },
+      ],
+      skinLicenses: [
+        { duration: 0, licenseTypeId: 5001, skinId: 100 },
+        { duration: 30, licenseTypeId: 5002, skinId: 100 },
+        { duration: 0, licenseTypeId: 5003, skinId: 999 },
+      ],
+      stationOperations: [
+        {
+          stationOperationId: 1,
+          activityId: 1,
+          border: 1,
+          corridor: 1,
+          description: 'Manufacturing Hub',
+          fringe: 0,
+          hub: 1,
+          manufacturingFactor: 1.0,
+          operationName: 'Manufacturing',
+          ratio: 1,
+          researchFactor: 1.0,
+          services: null,
+          stationTypes: null,
+        },
+      ],
+      stationServices: [
+        {
+          stationServiceId: 1,
+          serviceName: 'Market',
+          description: 'Trade goods',
+        },
+        {
+          stationServiceId: 2,
+          serviceName: 'Reprocessing',
+          description: null,
+        },
+      ],
+      typeDogma: [
+        { typeId: 34, dogmaAttributes: [{ attributeId: 9 }], dogmaEffects: [] },
+      ],
+      typeMaterials: [
+        { typeId: 34, materials: [{ typeId: 35, quantity: 100 }] },
+      ],
+      typeBonuses: [
+        { typeId: 17918, roleBonuses: [{ bonus: 5 }], types: null },
+      ],
+      missions: [
+        {
+          missionId: 1,
+          hasStandingRewards: true,
+          killMission: null,
+          messages: null,
+          name: 'Worlds Collide',
+          expirationTime: null,
+          factionId: 500001,
+        },
+      ],
+      dungeons: [
+        {
+          dungeonId: 100,
+          allowedShipsList: null,
+          archetypeId: 1,
+          description: 'A combat site',
+          factionId: 500001,
+          name: 'Serpentis Hideaway',
+        },
+      ],
+      epicArcs: [
+        {
+          epicArcId: 1,
+          arcRestartInterval: 90,
+          factionId: 500001,
+          iconId: 10,
+          missions: null,
+          name: 'The Blood-Stained Stars',
+        },
+        {
+          epicArcId: 2,
+          arcRestartInterval: 90,
+          factionId: 500002,
+          iconId: 11,
+          missions: null,
+          name: 'Penumbra',
+        },
+      ],
+    };
+
+    let provider: MemorySdeProvider;
+
+    beforeEach(() => {
+      provider = new MemorySdeProvider(extendedData);
+    });
+
+    afterEach(() => {
+      provider.close();
+    });
+
+    describe('dogma extended', () => {
+      it('should look up dogma attribute category by ID', () => {
+        const cat = provider.getDogmaAttributeCategory(1);
+        expect(cat).not.toBeNull();
+        expect(cat!.name).toBe('Fitting');
+      });
+
+      it('should return null for unknown dogma attribute category', () => {
+        expect(provider.getDogmaAttributeCategory(999)).toBeNull();
+      });
+
+      it('should list all dogma attribute categories', () => {
+        const cats = provider.getAllDogmaAttributeCategories();
+        expect(cats).toHaveLength(2);
+      });
+
+      it('should look up dogma unit by ID', () => {
+        const unit = provider.getDogmaUnit(1);
+        expect(unit).not.toBeNull();
+        expect(unit!.name).toBe('Milliseconds');
+      });
+
+      it('should return null for unknown dogma unit', () => {
+        expect(provider.getDogmaUnit(999)).toBeNull();
+      });
+
+      it('should list all dogma units', () => {
+        expect(provider.getAllDogmaUnits()).toHaveLength(2);
+      });
+    });
+
+    describe('industry extended', () => {
+      it('should look up industry activity by ID', () => {
+        const act = provider.getIndustryActivity(1);
+        expect(act).not.toBeNull();
+        expect(act!.name).toBe('Manufacturing');
+      });
+
+      it('should return null for unknown industry activity', () => {
+        expect(provider.getIndustryActivity(999)).toBeNull();
+      });
+
+      it('should list all industry activities', () => {
+        expect(provider.getAllIndustryActivities()).toHaveLength(2);
+      });
+    });
+
+    describe('agent system', () => {
+      it('should look up agent type by ID', () => {
+        const at = provider.getAgentType(1);
+        expect(at).not.toBeNull();
+        expect(at!.name).toBe('NonAgent');
+      });
+
+      it('should return null for unknown agent type', () => {
+        expect(provider.getAgentType(999)).toBeNull();
+      });
+
+      it('should list all agent types', () => {
+        expect(provider.getAllAgentTypes()).toHaveLength(2);
+      });
+
+      it('should look up agent in space by character ID', () => {
+        const agent = provider.getAgentInSpace(3019000);
+        expect(agent).not.toBeNull();
+        expect(agent!.solarSystemId).toBe(30000142);
+      });
+
+      it('should return null for unknown agent in space', () => {
+        expect(provider.getAgentInSpace(999)).toBeNull();
+      });
+
+      it('should find agents in space by system', () => {
+        const agents = provider.getAgentsInSpaceBySystem(30000142);
+        expect(agents).toHaveLength(1);
+        expect(agents[0]!.characterId).toBe(3019000);
+      });
+
+      it('should return empty for agents in unknown system', () => {
+        expect(provider.getAgentsInSpaceBySystem(999)).toEqual([]);
+      });
+    });
+
+    describe('certificates', () => {
+      it('should look up certificate by ID', () => {
+        const cert = provider.getCertificate(1);
+        expect(cert).not.toBeNull();
+        expect(cert!.name).toBe('Spaceship Command Basic');
+      });
+
+      it('should return null for unknown certificate', () => {
+        expect(provider.getCertificate(999)).toBeNull();
+      });
+
+      it('should list all certificates', () => {
+        expect(provider.getAllCertificates()).toHaveLength(1);
+      });
+    });
+
+    describe('character attributes', () => {
+      it('should look up character attribute by ID', () => {
+        const attr = provider.getCharacterAttribute(164);
+        expect(attr).not.toBeNull();
+        expect(attr!.name).toBe('Charisma');
+      });
+
+      it('should return null for unknown character attribute', () => {
+        expect(provider.getCharacterAttribute(999)).toBeNull();
+      });
+
+      it('should list all character attributes', () => {
+        expect(provider.getAllCharacterAttributes()).toHaveLength(1);
+      });
+    });
+
+    describe('NPC characters', () => {
+      it('should look up NPC character by ID', () => {
+        const npc = provider.getNpcCharacter(3004451);
+        expect(npc).not.toBeNull();
+        expect(npc!.name).toBe('Caldari Navy Commander');
+      });
+
+      it('should return null for unknown NPC character', () => {
+        expect(provider.getNpcCharacter(999)).toBeNull();
+      });
+
+      it('should find NPC characters by corporation', () => {
+        const npcs = provider.getNpcCharactersByCorporation(1000035);
+        expect(npcs).toHaveLength(2);
+      });
+
+      it('should return empty for NPCs in unknown corporation', () => {
+        expect(provider.getNpcCharactersByCorporation(999)).toEqual([]);
+      });
+
+      it('should search NPC characters by name', () => {
+        const results = provider.searchNpcCharactersByName('Commander');
+        expect(results).toHaveLength(1);
+        expect(results[0]!.characterId).toBe(3004451);
+      });
+
+      it('should return empty for non-matching NPC name search', () => {
+        expect(provider.searchNpcCharactersByName('zzzzz')).toEqual([]);
+      });
+
+      it('should respect search limit for NPC characters', () => {
+        const results = provider.searchNpcCharactersByName('', 1);
+        expect(results).toHaveLength(1);
+      });
+    });
+
+    describe('clone grades', () => {
+      it('should look up clone grade by ID', () => {
+        const grade = provider.getCloneGrade(1);
+        expect(grade).not.toBeNull();
+        expect(grade!.name).toBe('Alpha');
+      });
+
+      it('should return null for unknown clone grade', () => {
+        expect(provider.getCloneGrade(999)).toBeNull();
+      });
+
+      it('should list all clone grades', () => {
+        expect(provider.getAllCloneGrades()).toHaveLength(2);
+      });
+    });
+
+    describe('corporation reference', () => {
+      it('should look up corporation activity by ID', () => {
+        const act = provider.getCorporationActivity(1);
+        expect(act).not.toBeNull();
+        expect(act!.name).toBe('Manufacturing');
+      });
+
+      it('should return null for unknown corporation activity', () => {
+        expect(provider.getCorporationActivity(999)).toBeNull();
+      });
+
+      it('should list all corporation activities', () => {
+        expect(provider.getAllCorporationActivities()).toHaveLength(2);
+      });
+
+      it('should look up NPC corporation division by ID', () => {
+        const div = provider.getNpcCorporationDivision(1);
+        expect(div).not.toBeNull();
+        expect(div!.name).toBe('Accounting');
+      });
+
+      it('should return null for unknown NPC corporation division', () => {
+        expect(provider.getNpcCorporationDivision(999)).toBeNull();
+      });
+
+      it('should list all NPC corporation divisions', () => {
+        expect(provider.getAllNpcCorporationDivisions()).toHaveLength(2);
+      });
+    });
+
+    describe('landmarks', () => {
+      it('should look up landmark by ID', () => {
+        const lm = provider.getLandmark(1);
+        expect(lm).not.toBeNull();
+        expect(lm!.name).toBe('Eve Gate');
+      });
+
+      it('should return null for unknown landmark', () => {
+        expect(provider.getLandmark(999)).toBeNull();
+      });
+
+      it('should list all landmarks', () => {
+        expect(provider.getAllLandmarks()).toHaveLength(1);
+      });
+    });
+
+    describe('notifications', () => {
+      it('should look up notification type by ID', () => {
+        const nt = provider.getNotificationType(1);
+        expect(nt).not.toBeNull();
+        expect(nt!.displayName).toBe('War Declared');
+      });
+
+      it('should return null for unknown notification type', () => {
+        expect(provider.getNotificationType(999)).toBeNull();
+      });
+    });
+
+    describe('schools', () => {
+      it('should look up school by ID', () => {
+        const school = provider.getSchool(1);
+        expect(school).not.toBeNull();
+        expect(school!.name).toBe('Science and Trade Institute');
+      });
+
+      it('should return null for unknown school', () => {
+        expect(provider.getSchool(999)).toBeNull();
+      });
+
+      it('should list all schools', () => {
+        expect(provider.getAllSchools()).toHaveLength(1);
+      });
+    });
+
+    describe('secondary suns', () => {
+      it('should look up secondary sun by ID', () => {
+        const sun = provider.getSecondarySun(40100001);
+        expect(sun).not.toBeNull();
+        expect(sun!.solarSystemId).toBe(30000142);
+      });
+
+      it('should return null for unknown secondary sun', () => {
+        expect(provider.getSecondarySun(999)).toBeNull();
+      });
+
+      it('should find secondary suns by system', () => {
+        const suns = provider.getSecondarySunsBySystem(30000142);
+        expect(suns).toHaveLength(1);
+        expect(suns[0]!.secondarySunId).toBe(40100001);
+      });
+
+      it('should return empty for suns in unknown system', () => {
+        expect(provider.getSecondarySunsBySystem(999)).toEqual([]);
+      });
+    });
+
+    describe('skins', () => {
+      it('should look up skin by ID', () => {
+        const skin = provider.getSkin(100);
+        expect(skin).not.toBeNull();
+        expect(skin!.internalName).toBe('TestSkin');
+      });
+
+      it('should return null for unknown skin', () => {
+        expect(provider.getSkin(999)).toBeNull();
+      });
+
+      it('should look up skin license by license type ID', () => {
+        const lic = provider.getSkinLicense(5001);
+        expect(lic).not.toBeNull();
+        expect(lic!.skinId).toBe(100);
+      });
+
+      it('should return null for unknown skin license', () => {
+        expect(provider.getSkinLicense(999)).toBeNull();
+      });
+
+      it('should find skin licenses by skin ID', () => {
+        const licenses = provider.getSkinLicensesBySkin(100);
+        expect(licenses).toHaveLength(2);
+      });
+
+      it('should return empty for licenses of unknown skin', () => {
+        expect(provider.getSkinLicensesBySkin(888)).toEqual([]);
+      });
+    });
+
+    describe('station operations and services', () => {
+      it('should look up station operation by ID', () => {
+        const op = provider.getStationOperation(1);
+        expect(op).not.toBeNull();
+        expect(op!.operationName).toBe('Manufacturing');
+      });
+
+      it('should return null for unknown station operation', () => {
+        expect(provider.getStationOperation(999)).toBeNull();
+      });
+
+      it('should list all station operations', () => {
+        expect(provider.getAllStationOperations()).toHaveLength(1);
+      });
+
+      it('should look up station service by ID', () => {
+        const svc = provider.getStationService(1);
+        expect(svc).not.toBeNull();
+        expect(svc!.serviceName).toBe('Market');
+      });
+
+      it('should return null for unknown station service', () => {
+        expect(provider.getStationService(999)).toBeNull();
+      });
+
+      it('should list all station services', () => {
+        expect(provider.getAllStationServices()).toHaveLength(2);
+      });
+    });
+
+    describe('type extensions', () => {
+      it('should look up type dogma by type ID', () => {
+        const td = provider.getTypeDogma(34);
+        expect(td).not.toBeNull();
+        expect(td!.dogmaAttributes).toEqual([{ attributeId: 9 }]);
+      });
+
+      it('should return null for unknown type dogma', () => {
+        expect(provider.getTypeDogma(999)).toBeNull();
+      });
+
+      it('should look up type material by type ID', () => {
+        const tm = provider.getTypeMaterial(34);
+        expect(tm).not.toBeNull();
+        expect(tm!.materials).toEqual([{ typeId: 35, quantity: 100 }]);
+      });
+
+      it('should return null for unknown type material', () => {
+        expect(provider.getTypeMaterial(999)).toBeNull();
+      });
+
+      it('should look up type bonus by type ID', () => {
+        const tb = provider.getTypeBonus(17918);
+        expect(tb).not.toBeNull();
+        expect(tb!.roleBonuses).toEqual([{ bonus: 5 }]);
+      });
+
+      it('should return null for unknown type bonus', () => {
+        expect(provider.getTypeBonus(999)).toBeNull();
+      });
+    });
+
+    describe('missions and content', () => {
+      it('should look up mission by ID', () => {
+        const m = provider.getMission(1);
+        expect(m).not.toBeNull();
+        expect(m!.name).toBe('Worlds Collide');
+      });
+
+      it('should return null for unknown mission', () => {
+        expect(provider.getMission(999)).toBeNull();
+      });
+
+      it('should look up dungeon by ID', () => {
+        const d = provider.getDungeon(100);
+        expect(d).not.toBeNull();
+        expect(d!.name).toBe('Serpentis Hideaway');
+      });
+
+      it('should return null for unknown dungeon', () => {
+        expect(provider.getDungeon(999)).toBeNull();
+      });
+
+      it('should look up epic arc by ID', () => {
+        const ea = provider.getEpicArc(1);
+        expect(ea).not.toBeNull();
+        expect(ea!.name).toBe('The Blood-Stained Stars');
+      });
+
+      it('should return null for unknown epic arc', () => {
+        expect(provider.getEpicArc(999)).toBeNull();
+      });
+
+      it('should list all epic arcs', () => {
+        expect(provider.getAllEpicArcs()).toHaveLength(2);
+      });
+    });
+
+    describe('generic accessors', () => {
+      it('should get entity by table name and ID', () => {
+        const type = provider.getEntity('eve_types', 34);
+        expect(type).not.toBeNull();
+        expect((type as { name: string }).name).toBe('Tritanium');
+      });
+
+      it('should return null for unknown entity', () => {
+        expect(provider.getEntity('eve_types', 999999)).toBeNull();
+      });
+
+      it('should return null for unknown table', () => {
+        expect(provider.getEntity('nonexistent_table', 1)).toBeNull();
+      });
+
+      it('should get all entities from a table', () => {
+        const allTypes = provider.getAllEntities('eve_types');
+        expect(allTypes.length).toBeGreaterThanOrEqual(3);
+      });
+
+      it('should return empty for unknown table in getAllEntities', () => {
+        expect(provider.getAllEntities('nonexistent_table')).toEqual([]);
+      });
+    });
+  });
 });

--- a/tests/tdd/sde/ingestion/SdeDatabaseBuilder.test.ts
+++ b/tests/tdd/sde/ingestion/SdeDatabaseBuilder.test.ts
@@ -211,4 +211,56 @@ function createParsedFile(
     expect(row.name).toBe('Material');
     db.close();
   });
+
+  it('should call onProgress at 1000-record intervals and at end', () => {
+    const progress = jest.fn();
+    const records: Record<number, Record<string, unknown>> = {};
+    for (let i = 1; i <= 1001; i++) {
+      records[i] = { name: { en: `Type ${i}` }, published: true };
+    }
+    const parsedFiles = [createParsedFile('categories.yaml', records)];
+
+    builder.build({
+      outputPath: dbPath,
+      parsedFiles,
+      sdeVersion: '12345',
+      buildDate: '2026-01-15',
+      onProgress: progress,
+    });
+
+    const calls = progress.mock.calls as Array<[string, number, number]>;
+    const intervalCall = calls.find(([, inserted]) => inserted === 1000);
+    expect(intervalCall).toBeDefined();
+    expect(intervalCall![0]).toBe('eve_categories');
+    const finalCall = calls[calls.length - 1]!;
+    expect(finalCall[0]).toBe('eve_categories');
+    expect(finalCall[1]).toBe(1001);
+  });
+});
+
+describe('SdeDatabaseBuilder (no better-sqlite3)', () => {
+  it('should throw SdeError when better-sqlite3 is not available', () => {
+    const origRequire = jest.requireActual;
+    jest.doMock('better-sqlite3', () => {
+      throw new Error('Cannot find module');
+    });
+
+    jest.resetModules();
+    const {
+      SdeDatabaseBuilder: FreshBuilder,
+    } = require('../../../../src/sde/ingestion/SdeDatabaseBuilder');
+
+    const freshBuilder = new FreshBuilder();
+    expect(() =>
+      freshBuilder.build({
+        outputPath: '/tmp/test.db',
+        parsedFiles: [],
+        sdeVersion: '1',
+        buildDate: '2026-01-01',
+      }),
+    ).toThrow('better-sqlite3 is required');
+
+    jest.dontMock('better-sqlite3');
+    jest.resetModules();
+  });
 });

--- a/tests/tdd/sde/ingestion/SdeDownloader.test.ts
+++ b/tests/tdd/sde/ingestion/SdeDownloader.test.ts
@@ -97,6 +97,34 @@ describe('SdeDownloader', () => {
       await expect(downloader.getLatestBuild()).rejects.toThrow(SdeError);
       await expect(downloader.getLatestBuild()).rejects.toThrow('read error');
     });
+
+    it('should stringify non-Error fetch rejection', async () => {
+      mockFetch(async () => {
+        throw 'string rejection';
+      });
+
+      await expect(downloader.getLatestBuild()).rejects.toThrow(SdeError);
+      await expect(downloader.getLatestBuild()).rejects.toThrow(
+        'string rejection',
+      );
+    });
+
+    it('should stringify non-Error text() rejection', async () => {
+      mockFetch(async () => {
+        const response = new Response('ok', { status: 200 });
+        jest.spyOn(response, 'text').mockRejectedValue('text failure');
+        return response;
+      });
+
+      await expect(downloader.getLatestBuild()).rejects.toThrow(SdeError);
+      await expect(downloader.getLatestBuild()).rejects.toThrow('text failure');
+    });
+
+    it('should stringify non-Error parse rejection', async () => {
+      mockFetch(async () => new Response('not valid json\n', { status: 200 }));
+
+      await expect(downloader.getLatestBuild()).rejects.toThrow(SdeError);
+    });
   });
 
   describe('download', () => {
@@ -116,6 +144,19 @@ describe('SdeDownloader', () => {
       await expect(
         downloader.download({ outputPath: '/tmp/sde.zip' }),
       ).rejects.toThrow(SdeError);
+    });
+
+    it('should stringify non-Error download rejection', async () => {
+      mockFetch(async () => {
+        throw 'download failed string';
+      });
+
+      await expect(
+        downloader.download({ outputPath: '/tmp/sde.zip' }),
+      ).rejects.toThrow(SdeError);
+      await expect(
+        downloader.download({ outputPath: '/tmp/sde.zip' }),
+      ).rejects.toThrow('download failed string');
     });
 
     it('should throw SdeError when response body is null', async () => {
@@ -186,6 +227,78 @@ describe('SdeDownloader', () => {
           outputPath: '/nonexistent/path/that/does/not/exist/sde.zip',
         }),
       ).rejects.toThrow(SdeError);
+    });
+
+    it('should handle missing content-length header', async () => {
+      const zipContent = Buffer.from('PK\x03\x04fakecontent');
+
+      mockFetch(async () => {
+        return new Response(zipContent, {
+          status: 200,
+        });
+      });
+
+      const outputPath = path.join(
+        os.tmpdir(),
+        `sde-dl-nolen-${Date.now()}.zip`,
+      );
+
+      try {
+        const result = await downloader.download({
+          outputPath,
+          onProgress: () => {},
+        });
+
+        expect(result).toBe(outputPath);
+        expect(fs.existsSync(outputPath)).toBe(true);
+      } finally {
+        if (fs.existsSync(outputPath)) fs.unlinkSync(outputPath);
+      }
+    });
+
+    it('should skip onProgress when totalBytes is 0', async () => {
+      const zipContent = Buffer.from('PK\x03\x04fakecontent');
+
+      mockFetch(async () => {
+        return new Response(zipContent, { status: 200 });
+      });
+
+      const outputPath = path.join(
+        os.tmpdir(),
+        `sde-dl-noprog-${Date.now()}.zip`,
+      );
+      const progress = jest.fn();
+
+      try {
+        await downloader.download({ outputPath, onProgress: progress });
+        expect(progress).not.toHaveBeenCalled();
+      } finally {
+        if (fs.existsSync(outputPath)) fs.unlinkSync(outputPath);
+      }
+    });
+
+    it('should download without onProgress callback', async () => {
+      const zipContent = Buffer.from('PK\x03\x04fakecontent');
+
+      mockFetch(async () => {
+        return new Response(zipContent, {
+          status: 200,
+          headers: { 'content-length': String(zipContent.length) },
+        });
+      });
+
+      const outputPath = path.join(
+        os.tmpdir(),
+        `sde-dl-nocb-${Date.now()}.zip`,
+      );
+
+      try {
+        const result = await downloader.download({ outputPath });
+        expect(result).toBe(outputPath);
+        expect(fs.existsSync(outputPath)).toBe(true);
+      } finally {
+        if (fs.existsSync(outputPath)) fs.unlinkSync(outputPath);
+      }
     });
   });
 });

--- a/tests/tdd/sde/ingestion/SdeExtractor.test.ts
+++ b/tests/tdd/sde/ingestion/SdeExtractor.test.ts
@@ -54,6 +54,31 @@ describe('SdeExtractor', () => {
 
       expect(() => extractor.readMetadata(zipPath)).toThrow(SdeError);
     });
+
+    it('should return empty strings when metadata fields are non-string/number', () => {
+      const zipPath = createTestZip({
+        '_sde.yaml': { buildNumber: true, releaseDate: null },
+      });
+      tempFiles.push(zipPath);
+
+      const metadata = extractor.readMetadata(zipPath);
+      expect(metadata.buildNumber).toBe('');
+      expect(metadata.releaseDate).toBe('');
+    });
+
+    it('should handle string buildNumber and releaseDate', () => {
+      const zipPath = createTestZip({
+        '_sde.yaml': {
+          buildNumber: '2026-01-15.1',
+          releaseDate: '2026-01-15',
+        },
+      });
+      tempFiles.push(zipPath);
+
+      const metadata = extractor.readMetadata(zipPath);
+      expect(metadata.buildNumber).toBe('2026-01-15.1');
+      expect(metadata.releaseDate).toBe('2026-01-15');
+    });
   });
 
   describe('parseFile', () => {
@@ -136,6 +161,30 @@ describe('SdeExtractor', () => {
     });
   });
 
+  describe('extractAll', () => {
+    it('should extract all entries to the output directory', () => {
+      const zipPath = createTestZip({
+        'types.yaml': { 34: { name: { en: 'Tritanium' } } },
+        'groups.yaml': { 18: { name: { en: 'Mineral' } } },
+      });
+      tempFiles.push(zipPath);
+
+      const outputDir = path.join(
+        os.tmpdir(),
+        `sde-extract-test-${Date.now()}`,
+      );
+
+      try {
+        extractor.extractAll(zipPath, outputDir);
+        expect(fs.existsSync(outputDir)).toBe(true);
+        expect(fs.existsSync(path.join(outputDir, 'types.yaml'))).toBe(true);
+        expect(fs.existsSync(path.join(outputDir, 'groups.yaml'))).toBe(true);
+      } finally {
+        fs.rmSync(outputDir, { recursive: true, force: true });
+      }
+    });
+  });
+
   describe('listFiles', () => {
     it('should list all YAML files in the zip', () => {
       const zipPath = createTestZip({
@@ -149,6 +198,89 @@ describe('SdeExtractor', () => {
       expect(files).toContain('types.yaml');
       expect(files).toContain('groups.yaml');
       expect(files).toContain('_sde.yaml');
+    });
+
+    it('should exclude non-YAML files and directories', () => {
+      const zip = new AdmZip();
+      zip.addFile('types.yaml', Buffer.from(yaml.dump({ 34: {} })));
+      zip.addFile('readme.txt', Buffer.from('hello'));
+      zip.addFile('subdir/', Buffer.alloc(0));
+      const zipPath = path.join(
+        os.tmpdir(),
+        `sde-list-filter-${Date.now()}.zip`,
+      );
+      zip.writeZip(zipPath);
+      tempFiles.push(zipPath);
+
+      const files = extractor.listFiles(zipPath);
+      expect(files).toContain('types.yaml');
+      expect(files).not.toContain('readme.txt');
+      expect(files).not.toContain('subdir/');
+    });
+  });
+
+  describe('findEntry with directory entries', () => {
+    it('should skip directory entries when searching', () => {
+      const zip = new AdmZip();
+      zip.addFile('categories/', Buffer.alloc(0));
+      zip.addFile(
+        'categories.yaml',
+        Buffer.from(yaml.dump({ 4: { name: { en: 'Material' } } })),
+      );
+      const zipPath = path.join(os.tmpdir(), `sde-dir-entry-${Date.now()}.zip`);
+      zip.writeZip(zipPath);
+      tempFiles.push(zipPath);
+
+      const result = extractor.parseFile(zipPath, 'categories.yaml');
+      expect(result.records.size).toBe(1);
+    });
+  });
+
+  describe('findEntry fallback matching', () => {
+    it('should find entry by exact full path', () => {
+      const zip = new AdmZip();
+      zip.addFile(
+        'sde/categories.yaml',
+        Buffer.from(yaml.dump({ 4: { name: { en: 'Material' } } })),
+      );
+      const zipPath = path.join(os.tmpdir(), `sde-fullpath-${Date.now()}.zip`);
+      zip.writeZip(zipPath);
+      tempFiles.push(zipPath);
+
+      const result = extractor.parseFile(zipPath, 'sde/categories.yaml');
+      expect(result.records.size).toBe(1);
+      expect(result.records.get(4)).toBeDefined();
+    });
+
+    it('should find entry by basename when stored under sde/ prefix', () => {
+      const zip = new AdmZip();
+      zip.addFile(
+        'sde/types.yaml',
+        Buffer.from(yaml.dump({ 34: { name: { en: 'Tritanium' } } })),
+      );
+      const zipPath = path.join(os.tmpdir(), `sde-basename-${Date.now()}.zip`);
+      zip.writeZip(zipPath);
+      tempFiles.push(zipPath);
+
+      const result = extractor.parseFile(zipPath, 'types.yaml');
+      expect(result.records.size).toBe(1);
+    });
+
+    it('should read metadata from sde/ prefixed entry', () => {
+      const zip = new AdmZip();
+      zip.addFile(
+        'sde/_sde.yaml',
+        Buffer.from(yaml.dump({ buildNumber: 99, releaseDate: '2026-06-01' })),
+      );
+      const zipPath = path.join(
+        os.tmpdir(),
+        `sde-meta-prefix-${Date.now()}.zip`,
+      );
+      zip.writeZip(zipPath);
+      tempFiles.push(zipPath);
+
+      const metadata = extractor.readMetadata(zipPath);
+      expect(metadata.buildNumber).toBe('99');
     });
   });
 });

--- a/tests/tdd/testing/TestDataFactory.test.ts
+++ b/tests/tdd/testing/TestDataFactory.test.ts
@@ -1,6 +1,518 @@
 import { TestDataFactory } from '../../../src/testing/TestDataFactory';
 
 describe('TestDataFactory', () => {
+  describe('Alliance factories', () => {
+    it('should create alliance info with defaults', () => {
+      const info = TestDataFactory.createAllianceInfo();
+      expect(info.alliance_id).toBe(99005338);
+      expect(info.name).toBe('Goonswarm Federation');
+      expect(info.ticker).toBe('CONDI');
+    });
+
+    it('should create alliance info with overrides', () => {
+      const info = TestDataFactory.createAllianceInfo({ name: 'Test' });
+      expect(info.name).toBe('Test');
+      expect(info.alliance_id).toBe(99005338);
+    });
+
+    it('should create alliance contact with defaults', () => {
+      const contact = TestDataFactory.createAllianceContact();
+      expect(contact.contact_id).toBe(1689391488);
+      expect(contact.standing).toBe(10.0);
+    });
+
+    it('should create alliance contact with overrides', () => {
+      const contact = TestDataFactory.createAllianceContact({ standing: -5 });
+      expect(contact.standing).toBe(-5);
+    });
+
+    it('should create alliance contact label with defaults', () => {
+      const label = TestDataFactory.createAllianceContactLabel();
+      expect(label.label_id).toBe(1);
+      expect(label.label_name).toBe('Friendly');
+    });
+
+    it('should create alliance contact label with overrides', () => {
+      const label = TestDataFactory.createAllianceContactLabel({
+        label_name: 'Hostile',
+      });
+      expect(label.label_name).toBe('Hostile');
+    });
+  });
+
+  describe('Character factories', () => {
+    it('should create character info with defaults', () => {
+      const info = TestDataFactory.createCharacterInfo();
+      expect(info.character_id).toBe(1689391488);
+      expect(info.name).toBe('Test Character');
+    });
+
+    it('should create character info with overrides', () => {
+      const info = TestDataFactory.createCharacterInfo({ name: 'Other' });
+      expect(info.name).toBe('Other');
+    });
+
+    it('should create character portrait with default id', () => {
+      const portrait = TestDataFactory.createCharacterPortrait();
+      expect(portrait.px64x64).toContain('1689391488');
+    });
+
+    it('should create character portrait with custom id', () => {
+      const portrait = TestDataFactory.createCharacterPortrait(999);
+      expect(portrait.px64x64).toContain('999');
+    });
+
+    it('should create character attributes with defaults', () => {
+      const attrs = TestDataFactory.createCharacterAttributes();
+      expect(attrs.charisma).toBe(20);
+      expect(attrs.intelligence).toBe(24);
+    });
+
+    it('should create character attributes with overrides', () => {
+      const attrs = TestDataFactory.createCharacterAttributes({ charisma: 30 });
+      expect(attrs.charisma).toBe(30);
+    });
+
+    it('should create character skill with defaults', () => {
+      const skill = TestDataFactory.createCharacterSkill();
+      expect(skill.skill_id).toBe(3300);
+      expect(skill.trained_skill_level).toBe(5);
+    });
+
+    it('should create character skill with overrides', () => {
+      const skill = TestDataFactory.createCharacterSkill({
+        trained_skill_level: 3,
+      });
+      expect(skill.trained_skill_level).toBe(3);
+    });
+
+    it('should create character roles with defaults', () => {
+      const roles = TestDataFactory.createCharacterRoles();
+      expect(roles.roles).toContain('Director');
+    });
+
+    it('should create character roles with overrides', () => {
+      const roles = TestDataFactory.createCharacterRoles({
+        roles: ['Accountant'],
+      });
+      expect(roles.roles).toContain('Accountant');
+    });
+
+    it('should create corporation history entry with defaults', () => {
+      const entry = TestDataFactory.createCorporationHistoryEntry();
+      expect(entry.corporation_id).toBe(1344654522);
+    });
+
+    it('should create corporation history entry with overrides', () => {
+      const entry = TestDataFactory.createCorporationHistoryEntry({
+        corporation_id: 999,
+      });
+      expect(entry.corporation_id).toBe(999);
+    });
+
+    it('should create character medal with defaults', () => {
+      const medal = TestDataFactory.createCharacterMedal();
+      expect(medal.medal_id).toBe(1);
+      expect(medal.title).toBe('Test Medal');
+    });
+
+    it('should create character medal with overrides', () => {
+      const medal = TestDataFactory.createCharacterMedal({ title: 'Custom' });
+      expect(medal.title).toBe('Custom');
+    });
+
+    it('should create character notification with defaults', () => {
+      const notif = TestDataFactory.createCharacterNotification();
+      expect(notif.notification_id).toBe(1000001);
+      expect(notif.is_read).toBe(false);
+    });
+
+    it('should create character notification with overrides', () => {
+      const notif = TestDataFactory.createCharacterNotification({
+        is_read: true,
+      });
+      expect(notif.is_read).toBe(true);
+    });
+
+    it('should create character location with defaults', () => {
+      const loc = TestDataFactory.createCharacterLocation();
+      expect(loc.solar_system_id).toBe(30000142);
+    });
+
+    it('should create character location with overrides', () => {
+      const loc = TestDataFactory.createCharacterLocation({
+        solar_system_id: 99,
+      });
+      expect(loc.solar_system_id).toBe(99);
+    });
+
+    it('should create character skills with defaults', () => {
+      const skills = TestDataFactory.createCharacterSkills();
+      expect(skills.total_sp).toBe(384000);
+      expect(skills.skills).toHaveLength(2);
+    });
+
+    it('should create character skills with overrides', () => {
+      const skills = TestDataFactory.createCharacterSkills({ total_sp: 0 });
+      expect(skills.total_sp).toBe(0);
+    });
+
+    it('should create character asset with defaults', () => {
+      const asset = TestDataFactory.createCharacterAsset();
+      expect(asset.type_id).toBe(34);
+      expect(asset.quantity).toBe(1000000);
+    });
+
+    it('should create character asset with overrides', () => {
+      const asset = TestDataFactory.createCharacterAsset({ quantity: 1 });
+      expect(asset.quantity).toBe(1);
+    });
+  });
+
+  describe('Market factories', () => {
+    it('should create market price with defaults', () => {
+      const price = TestDataFactory.createMarketPrice();
+      expect(price.type_id).toBe(34);
+      expect(price.average_price).toBe(4.5);
+    });
+
+    it('should create market price with overrides', () => {
+      const price = TestDataFactory.createMarketPrice({ average_price: 10 });
+      expect(price.average_price).toBe(10);
+    });
+
+    it('should create market history with defaults', () => {
+      const hist = TestDataFactory.createMarketHistory();
+      expect(hist.volume).toBe(1000000000);
+    });
+
+    it('should create market history with overrides', () => {
+      const hist = TestDataFactory.createMarketHistory({ volume: 0 });
+      expect(hist.volume).toBe(0);
+    });
+
+    it('should create character market order with defaults', () => {
+      const order = TestDataFactory.createCharacterMarketOrder();
+      expect(order.order_id).toBe(5000000001);
+      expect(order.is_buy_order).toBe(true);
+    });
+
+    it('should create character market order with overrides', () => {
+      const order = TestDataFactory.createCharacterMarketOrder({
+        is_buy_order: false,
+      });
+      expect(order.is_buy_order).toBe(false);
+    });
+
+    it('should create character order history with defaults', () => {
+      const order = TestDataFactory.createCharacterOrderHistory();
+      expect(order.state).toBe('expired');
+    });
+
+    it('should create character order history with overrides', () => {
+      const order = TestDataFactory.createCharacterOrderHistory({
+        state: 'cancelled',
+      });
+      expect(order.state).toBe('cancelled');
+    });
+
+    it('should create market order with defaults', () => {
+      const order = TestDataFactory.createMarketOrder();
+      expect(order.order_id).toBe(123456789);
+      expect(order.type_id).toBe(34);
+    });
+
+    it('should create market order with overrides', () => {
+      const order = TestDataFactory.createMarketOrder({ price: 99 });
+      expect(order.price).toBe(99);
+    });
+  });
+
+  describe('Universe factories', () => {
+    it('should create solar system with defaults', () => {
+      const system = TestDataFactory.createSolarSystem();
+      expect(system.system_id).toBe(30000142);
+      expect(system.name).toBe('Jita');
+    });
+
+    it('should create solar system with overrides', () => {
+      const system = TestDataFactory.createSolarSystem({ name: 'Amarr' });
+      expect(system.name).toBe('Amarr');
+    });
+
+    it('should create station with defaults', () => {
+      const station = TestDataFactory.createStation();
+      expect(station.station_id).toBe(60003760);
+    });
+
+    it('should create station with overrides', () => {
+      const station = TestDataFactory.createStation({ station_id: 1 });
+      expect(station.station_id).toBe(1);
+    });
+
+    it('should create structure with defaults', () => {
+      const structure = TestDataFactory.createStructure();
+      expect(structure.name).toBe('Test Citadel');
+    });
+
+    it('should create structure with overrides', () => {
+      const structure = TestDataFactory.createStructure({ name: 'Keepstar' });
+      expect(structure.name).toBe('Keepstar');
+    });
+
+    it('should create item type with defaults', () => {
+      const type = TestDataFactory.createItemType();
+      expect(type.type_id).toBe(34);
+      expect(type.name).toBe('Tritanium');
+    });
+
+    it('should create item type with overrides', () => {
+      const type = TestDataFactory.createItemType({ name: 'Pyerite' });
+      expect(type.name).toBe('Pyerite');
+    });
+
+    it('should create item group with defaults', () => {
+      const group = TestDataFactory.createItemGroup();
+      expect(group.group_id).toBe(18);
+      expect(group.name).toBe('Mineral');
+    });
+
+    it('should create item group with overrides', () => {
+      const group = TestDataFactory.createItemGroup({ name: 'Ship' });
+      expect(group.name).toBe('Ship');
+    });
+
+    it('should create star with defaults', () => {
+      const star = TestDataFactory.createStar();
+      expect(star.star_id).toBe(40000001);
+    });
+
+    it('should create star with overrides', () => {
+      const star = TestDataFactory.createStar({ temperature: 9999 });
+      expect(star.temperature).toBe(9999);
+    });
+
+    it('should create planet with defaults', () => {
+      const planet = TestDataFactory.createPlanet();
+      expect(planet.planet_id).toBe(40000004);
+    });
+
+    it('should create planet with overrides', () => {
+      const planet = TestDataFactory.createPlanet({ name: 'Mars' });
+      expect(planet.name).toBe('Mars');
+    });
+
+    it('should create search results with defaults', () => {
+      const results = TestDataFactory.createSearchResults();
+      expect(results.systems).toEqual([]);
+      expect(results.characters).toEqual([]);
+    });
+
+    it('should create search results with overrides', () => {
+      const results = TestDataFactory.createSearchResults({
+        systems: [30000142],
+      });
+      expect(results.systems).toEqual([30000142]);
+    });
+
+    it('should create entity name with defaults', () => {
+      const name = TestDataFactory.createEntityName();
+      expect(name.id).toBe(30000142);
+      expect(name.category).toBe('solar_system');
+    });
+
+    it('should create entity name with overrides', () => {
+      const name = TestDataFactory.createEntityName({ name: 'Amarr' });
+      expect(name.name).toBe('Amarr');
+    });
+  });
+
+  describe('Corporation factories', () => {
+    it('should create corporation info with defaults', () => {
+      const info = TestDataFactory.createCorporationInfo();
+      expect(info.corporation_id).toBe(1344654522);
+      expect(info.name).toBe('GoonWaffe');
+    });
+
+    it('should create corporation info with overrides', () => {
+      const info = TestDataFactory.createCorporationInfo({ name: 'Test' });
+      expect(info.name).toBe('Test');
+    });
+
+    it('should create corporation member roles with defaults', () => {
+      const roles = TestDataFactory.createCorporationMemberRoles();
+      expect(roles.character_id).toBe(1689391488);
+      expect(roles.roles).toContain('Director');
+    });
+
+    it('should create corporation member roles with overrides', () => {
+      const roles = TestDataFactory.createCorporationMemberRoles({
+        character_id: 999,
+      });
+      expect(roles.character_id).toBe(999);
+    });
+
+    it('should create corporation asset with defaults', () => {
+      const asset = TestDataFactory.createCorporationAsset();
+      expect(asset.type_id).toBe(587);
+    });
+
+    it('should create corporation asset with overrides', () => {
+      const asset = TestDataFactory.createCorporationAsset({ type_id: 34 });
+      expect(asset.type_id).toBe(34);
+    });
+
+    it('should create corporation structure with defaults', () => {
+      const structure = TestDataFactory.createCorporationStructure();
+      expect(structure.type_id).toBe(35832);
+      expect(structure.state).toBe('shield_vulnerable');
+    });
+
+    it('should create corporation structure with overrides', () => {
+      const structure = TestDataFactory.createCorporationStructure({
+        state: 'anchoring',
+      });
+      expect(structure.state).toBe('anchoring');
+    });
+
+    it('should create corporation wallet with defaults', () => {
+      const wallet = TestDataFactory.createCorporationWallet();
+      expect(wallet.division).toBe(1);
+      expect(wallet.balance).toBe(1000000000.0);
+    });
+
+    it('should create corporation wallet with overrides', () => {
+      const wallet = TestDataFactory.createCorporationWallet({ division: 7 });
+      expect(wallet.division).toBe(7);
+    });
+
+    it('should create wallet journal entry with defaults', () => {
+      const entry = TestDataFactory.createWalletJournalEntry();
+      expect(entry.ref_type).toBe('market_transaction');
+    });
+
+    it('should create wallet journal entry with overrides', () => {
+      const entry = TestDataFactory.createWalletJournalEntry({
+        ref_type: 'bounty_prizes',
+      });
+      expect(entry.ref_type).toBe('bounty_prizes');
+    });
+  });
+
+  describe('Fleet factories', () => {
+    it('should create fleet info with defaults', () => {
+      const fleet = TestDataFactory.createFleetInfo();
+      expect(fleet.fleet_id).toBe(1234567890);
+      expect(fleet.is_free_move).toBe(false);
+    });
+
+    it('should create fleet info with overrides', () => {
+      const fleet = TestDataFactory.createFleetInfo({ is_free_move: true });
+      expect(fleet.is_free_move).toBe(true);
+    });
+
+    it('should create fleet member with defaults', () => {
+      const member = TestDataFactory.createFleetMember();
+      expect(member.role).toBe('fleet_commander');
+    });
+
+    it('should create fleet member with overrides', () => {
+      const member = TestDataFactory.createFleetMember({
+        role: 'squad_member',
+      });
+      expect(member.role).toBe('squad_member');
+    });
+
+    it('should create fleet wing with defaults', () => {
+      const wing = TestDataFactory.createFleetWing();
+      expect(wing.wing_id).toBe(987654321);
+      expect(wing.squads).toHaveLength(1);
+    });
+
+    it('should create fleet wing with overrides', () => {
+      const wing = TestDataFactory.createFleetWing({ name: 'Wing 2' });
+      expect(wing.name).toBe('Wing 2');
+    });
+  });
+
+  describe('Industry factories', () => {
+    it('should create industry job with defaults', () => {
+      const job = TestDataFactory.createIndustryJob();
+      expect(job.job_id).toBe(1000001);
+      expect(job.status).toBe('active');
+    });
+
+    it('should create industry job with overrides', () => {
+      const job = TestDataFactory.createIndustryJob({ status: 'delivered' });
+      expect(job.status).toBe('delivered');
+    });
+
+    it('should create blueprint with defaults', () => {
+      const bp = TestDataFactory.createBlueprint();
+      expect(bp.type_id).toBe(17918);
+      expect(bp.runs).toBe(100);
+    });
+
+    it('should create blueprint with overrides', () => {
+      const bp = TestDataFactory.createBlueprint({ runs: 0 });
+      expect(bp.runs).toBe(0);
+    });
+  });
+
+  describe('Wallet factories', () => {
+    it('should create wallet transaction with defaults', () => {
+      const tx = TestDataFactory.createWalletTransaction();
+      expect(tx.transaction_id).toBe(123456789);
+      expect(tx.is_buy).toBe(false);
+    });
+
+    it('should create wallet transaction with overrides', () => {
+      const tx = TestDataFactory.createWalletTransaction({ is_buy: true });
+      expect(tx.is_buy).toBe(true);
+    });
+  });
+
+  describe('Contract factories', () => {
+    it('should create contract with defaults', () => {
+      const contract = TestDataFactory.createContract();
+      expect(contract.contract_id).toBe(123456789);
+      expect(contract.type).toBe('courier');
+    });
+
+    it('should create contract with overrides', () => {
+      const contract = TestDataFactory.createContract({
+        type: 'item_exchange',
+      });
+      expect(contract.type).toBe('item_exchange');
+    });
+  });
+
+  describe('Error factories', () => {
+    it('should create error with default message for known status', () => {
+      const err = TestDataFactory.createError(404);
+      expect(err.statusCode).toBe(404);
+      expect(err.message).toBe('Resource not found');
+    });
+
+    it('should create error with custom message', () => {
+      const err = TestDataFactory.createError(500, 'Custom error');
+      expect(err.message).toBe('Custom error');
+    });
+
+    it('should create error with fallback message for unknown status', () => {
+      const err = TestDataFactory.createError(418);
+      expect(err.message).toBe('Unknown error');
+    });
+
+    it('should create errors for all known status codes', () => {
+      for (const code of [400, 401, 403, 404, 429, 500, 503]) {
+        const err = TestDataFactory.createError(code);
+        expect(err.statusCode).toBe(code);
+        expect(err.message).not.toBe('Unknown error');
+      }
+    });
+  });
+
   describe('Sovereignty/Equinox factories', () => {
     it('should create a sovereignty system with defaults', () => {
       const system = TestDataFactory.createSovereigntySystem();
@@ -153,6 +665,13 @@ describe('TestDataFactory', () => {
   });
 
   describe('createPerformanceTestData', () => {
+    it('should default to medium dataset', () => {
+      const data = TestDataFactory.createPerformanceTestData();
+      expect(data.alliances).toHaveLength(20);
+      expect(data.characters).toHaveLength(100);
+      expect(data.corporations).toHaveLength(50);
+    });
+
     it('should generate small dataset', () => {
       const data = TestDataFactory.createPerformanceTestData('small');
       expect(data.alliances).toHaveLength(5);


### PR DESCRIPTION
## Summary
- Boost **branch coverage** from 89.78% → **95.14%** and **function coverage** from 90.27% → **96.09%**
- Add 215+ new tests across 12 test files (3 new, 9 modified), bringing total from 4,742 → 4,957
- All source files untouched — test-only changes

## Coverage breakdown

| Area | Changes | Impact |
|------|---------|--------|
| MemorySdeProvider | 73 new tests for extended SDE methods (dogma, agents, certs, skins, missions, etc.) | +42 functions |
| TestDataFactory | 82 new tests exercising all factory default param branches | +30 branches |
| ApiRequestHandler | 5 new tests for `handleSinglePageRequest` + token provider | +5 functions |
| Request pipeline | 3 new test files for paginationOrchestration, middlewareBridge, fetchExecution | +12 branches |
| RateLimiter | 4 new tests for blocked retry, stale cleanup, user bucket scanning | +4 branches |
| SDE ingestion | Tests for error paths in DatabaseBuilder, Downloader, Extractor | +10 branches |
| Pagination handlers | Token provider, null data, empty cursor edge cases | +6 branches |

## Test plan
- [x] All 4,957 tests pass
- [x] Coverage thresholds met: stmts 98.37%, branches 95.14%, functions 96.09%, lines 98.17%
- [x] No source code changes — test-only PR
- [x] Pre-commit hooks pass (prettier)

🤖 Generated with [Claude Code](https://claude.com/claude-code)