### PR TITLE
feat: add fetchAll pagination API and per-endpoint rate limits

### DIFF
--- a/etc/esi.ts.api.md
+++ b/etc/esi.ts.api.md
@@ -65,6 +65,10 @@ const AgentResearchSchema: z.ZodObject<{
 // @public (undocumented)
 export class AllianceClient extends BaseEsiClient<typeof allianceEndpoints> {
     constructor(client: ApiClient);
+    // (undocumented)
+    fetchAllAlliances(concurrency?: number): Promise<number[]>;
+    // (undocumented)
+    fetchAllCorporations(allianceId: number, concurrency?: number): Promise<number[]>;
     getAllianceById(allianceId: number): Promise<AllianceInfo>;
     getAlliances(): Promise<number[]>;
     // @deprecated
@@ -320,6 +324,10 @@ const AssetNameSchema: z.ZodObject<{
 // @public (undocumented)
 export class AssetsClient extends BaseEsiClient<typeof assetEndpoints> {
     constructor(client: ApiClient);
+    // (undocumented)
+    fetchAllCharacterAssets(characterId: number, concurrency?: number): Promise<CharacterAsset[]>;
+    // (undocumented)
+    fetchAllCorporationAssets(corporationId: number, concurrency?: number): Promise<CharacterAsset[]>;
     getCharacterAssets(characterId: number): Promise<CharacterAsset[]>;
     getCorporationAssets(corporationId: number): Promise<CharacterAsset[]>;
     postCharacterAssetLocations(characterId: number, itemIds: number[]): Promise<AssetLocation[]>;
@@ -359,6 +367,8 @@ export abstract class BaseEsiClient<T extends EndpointMap> {
     protected _client: ApiClient;
     // (undocumented)
     protected _endpoints: T;
+    // (undocumented)
+    fetchAllEndpoint<R>(endpointName: string & keyof T, args: unknown[], concurrency?: number): Promise<R[]>;
     // (undocumented)
     streamEndpoint<R>(endpointName: string & keyof T, ...args: unknown[]): AsyncGenerator<PageResult<R>, void, undefined>;
     // (undocumented)
@@ -501,6 +511,10 @@ export interface CacheStats {
 // @public (undocumented)
 export class CalendarClient extends BaseEsiClient<typeof calendarEndpoints> {
     constructor(client: ApiClient);
+    // (undocumented)
+    fetchAllCalendarEvents(characterId: number, concurrency?: number): Promise<CalendarEvent[]>;
+    // (undocumented)
+    fetchAllEventAttendees(characterId: number, eventId: number, concurrency?: number): Promise<CalendarEventAttendee[]>;
     getCalendarEventById(characterId: number, eventId: number): Promise<CalendarEventDetail>;
     getCalendarEvents(characterId: number): Promise<CalendarEvent[]>;
     getEventAttendees(characterId: number, eventId: number): Promise<CalendarEventAttendee[]>;
@@ -595,6 +609,22 @@ const CharacterAttributesSchema: z.ZodObject<{
 // @public (undocumented)
 export class CharacterClient extends BaseEsiClient<typeof characterEndpoints> {
     constructor(client: ApiClient);
+    // (undocumented)
+    fetchAllCharacterAgentsResearch(characterId: number, concurrency?: number): Promise<AgentResearch[]>;
+    // (undocumented)
+    fetchAllCharacterBlueprints(characterId: number, concurrency?: number): Promise<Blueprint[]>;
+    // (undocumented)
+    fetchAllCharacterCorporationHistory(characterId: number, concurrency?: number): Promise<CorporationHistory[]>;
+    // (undocumented)
+    fetchAllCharacterMedals(characterId: number, concurrency?: number): Promise<Medal[]>;
+    // (undocumented)
+    fetchAllCharacterNotifications(characterId: number, concurrency?: number): Promise<Notification_2[]>;
+    // (undocumented)
+    fetchAllCharacterNotificationsContacts(characterId: number, concurrency?: number): Promise<Notification_2[]>;
+    // (undocumented)
+    fetchAllCharacterStandings(characterId: number, concurrency?: number): Promise<Standing[]>;
+    // (undocumented)
+    fetchAllCharacterTitles(characterId: number, concurrency?: number): Promise<CharacterTitle[]>;
     getCharacterAgentsResearch(characterId: number): Promise<AgentResearch[]>;
     getCharacterBlueprints(characterId: number): Promise<Blueprint[]>;
     getCharacterCorporationHistory(characterId: number): Promise<CorporationHistory[]>;
@@ -1668,6 +1698,8 @@ const CharacterSkillSchema: z.ZodObject<{
 // @public (undocumented)
 export class CharacterSkillsClient extends BaseEsiClient<typeof skillEndpoints> {
     constructor(client: ApiClient);
+    // (undocumented)
+    fetchAllCharacterSkillQueue(characterId: number, concurrency?: number): Promise<SkillQueue[]>;
     getCharacterAttributes(characterId: number): Promise<CharacterAttributes>;
     getCharacterSkillQueue(characterId: number): Promise<SkillQueue[]>;
     getCharacterSkills(characterId: number): Promise<{
@@ -1892,6 +1924,8 @@ const CloneInfoSchema: z.ZodObject<{
 // @public (undocumented)
 export class ClonesClient extends BaseEsiClient<typeof cloneEndpoints> {
     constructor(client: ApiClient);
+    // (undocumented)
+    fetchAllImplants(characterId: number, concurrency?: number): Promise<number[]>;
     getClones(characterId: number): Promise<CloneInfo>;
     getImplants(characterId: number): Promise<number[]>;
     // (undocumented)
@@ -2008,6 +2042,18 @@ const ContactSchema: z.ZodObject<{
 export class ContactsClient extends BaseEsiClient<typeof contactEndpoints> {
     constructor(client: ApiClient);
     deleteCharacterContacts(characterId: number, contactIds: number[]): Promise<void>;
+    // (undocumented)
+    fetchAllAllianceContactLabels(allianceId: number, concurrency?: number): Promise<ContactLabel[]>;
+    // (undocumented)
+    fetchAllAllianceContacts(allianceId: number, concurrency?: number): Promise<Contact[]>;
+    // (undocumented)
+    fetchAllCharacterContactLabels(characterId: number, concurrency?: number): Promise<ContactLabel[]>;
+    // (undocumented)
+    fetchAllCharacterContacts(characterId: number, concurrency?: number): Promise<Contact[]>;
+    // (undocumented)
+    fetchAllCorporationContactLabels(corporationId: number, concurrency?: number): Promise<ContactLabel[]>;
+    // (undocumented)
+    fetchAllCorporationContacts(corporationId: number, concurrency?: number): Promise<Contact[]>;
     getAllianceContactLabels(allianceId: number): Promise<ContactLabel[]>;
     getAllianceContacts(allianceId: number): Promise<Contact[]>;
     getCharacterContactLabels(characterId: number): Promise<ContactLabel[]>;
@@ -2111,6 +2157,12 @@ const ContractSchema: z.ZodObject<{
 // @public (undocumented)
 export class ContractsClient extends BaseEsiClient<typeof contractEndpoints> {
     constructor(client: ApiClient);
+    // (undocumented)
+    fetchAllCharacterContracts(characterId: number, concurrency?: number): Promise<Contract[]>;
+    // (undocumented)
+    fetchAllCorporationContracts(corporationId: number, concurrency?: number): Promise<Contract[]>;
+    // (undocumented)
+    fetchAllPublicContracts(regionId: number, concurrency?: number): Promise<Contract[]>;
     getCharacterContractBids(characterId: number, contractId: number): Promise<ContractBid[]>;
     getCharacterContractItems(characterId: number, contractId: number): Promise<ContractItem[]>;
     getCharacterContracts(characterId: number): Promise<Contract[]>;
@@ -2512,6 +2564,40 @@ const CorporationRoleHistorySchema: z.ZodObject<{
 // @public (undocumented)
 export class CorporationsClient extends BaseEsiClient<typeof corporationEndpoints> {
     constructor(client: ApiClient);
+    // (undocumented)
+    fetchAllCorporationAllianceHistory(corporationId: number, concurrency?: number): Promise<CorporationAllianceHistory[]>;
+    // (undocumented)
+    fetchAllCorporationAlscLogs(corporationId: number, concurrency?: number): Promise<ContainerLog[]>;
+    // (undocumented)
+    fetchAllCorporationBlueprints(corporationId: number, concurrency?: number): Promise<Blueprint[]>;
+    // (undocumented)
+    fetchAllCorporationFacilities(corporationId: number, concurrency?: number): Promise<CorporationFacility[]>;
+    // (undocumented)
+    fetchAllCorporationIssuedMedals(corporationId: number, concurrency?: number): Promise<CorporationIssuedMedal[]>;
+    // (undocumented)
+    fetchAllCorporationMedals(corporationId: number, concurrency?: number): Promise<CorporationMedal[]>;
+    // (undocumented)
+    fetchAllCorporationMembers(corporationId: number, concurrency?: number): Promise<number[]>;
+    // (undocumented)
+    fetchAllCorporationMemberTitles(corporationId: number, concurrency?: number): Promise<CorporationMemberTitle[]>;
+    // (undocumented)
+    fetchAllCorporationMemberTracking(corporationId: number, concurrency?: number): Promise<CorporationMemberTracking[]>;
+    // (undocumented)
+    fetchAllCorporationRoles(corporationId: number, concurrency?: number): Promise<CorporationMemberRole[]>;
+    // (undocumented)
+    fetchAllCorporationRolesHistory(corporationId: number, concurrency?: number): Promise<CorporationRoleHistory[]>;
+    // (undocumented)
+    fetchAllCorporationShareholders(corporationId: number, concurrency?: number): Promise<CorporationShareholder[]>;
+    // (undocumented)
+    fetchAllCorporationStandings(corporationId: number, concurrency?: number): Promise<Standing[]>;
+    // (undocumented)
+    fetchAllCorporationStarbases(corporationId: number, concurrency?: number): Promise<CorporationStarbase[]>;
+    // (undocumented)
+    fetchAllCorporationStructures(corporationId: number, concurrency?: number): Promise<CorporationStructure[]>;
+    // (undocumented)
+    fetchAllCorporationTitles(corporationId: number, concurrency?: number): Promise<CorporationTitle[]>;
+    // (undocumented)
+    fetchAllNpcCorporations(concurrency?: number): Promise<number[]>;
     getCorporationAllianceHistory(corporationId: number): Promise<CorporationAllianceHistory[]>;
     getCorporationAlscLogs(corporationId: number): Promise<ContainerLog[]>;
     getCorporationBlueprints(corporationId: number): Promise<Blueprint[]>;
@@ -4920,11 +5006,14 @@ export function fetchAllCursorPages<TResponse, TItem = unknown>(fetcher: (before
     after?: string | null;
 }): Promise<TItem[]>;
 
+// Warning: (ae-forgotten-export) The symbol "ResponseSchema" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export function fetchAllPages<T = unknown>(client: ApiClient, endpoint: string, method: string, requiresAuth?: boolean, body?: unknown, templatePath?: string, responseSchema?: ResponseSchema, concurrency?: number): Promise<T[]>;
+
 // @public (undocumented)
 export type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
 
-// Warning: (ae-forgotten-export) The symbol "ResponseSchema" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
 export function fetchPages<T = unknown>(client: ApiClient, endpoint: string, method: string, requiresAuth?: boolean, body?: unknown, templatePath?: string, responseSchema?: ResponseSchema): AsyncGenerator<PageResult<T>, void, undefined>;
 
@@ -4953,6 +5042,8 @@ export class FittingsClient extends BaseEsiClient<typeof fittingEndpoints> {
         fitting_id: number;
     }>;
     deleteFitting(characterId: number, fittingId: number): Promise<void>;
+    // (undocumented)
+    fetchAllFittings(characterId: number, concurrency?: number): Promise<Fitting[]>;
     getFittings(characterId: number): Promise<Fitting[]>;
     // (undocumented)
     streamFittings(characterId: number): AsyncGenerator<PageResult<Fitting>, void, undefined>;
@@ -4972,6 +5063,10 @@ export class FleetClient extends BaseEsiClient<typeof fleetEndpoints> {
     }>;
     deleteFleetSquad(fleetId: number, squadId: number): Promise<void>;
     deleteFleetWing(fleetId: number, wingId: number): Promise<void>;
+    // (undocumented)
+    fetchAllFleetMembers(fleetId: number, concurrency?: number): Promise<FleetMember[]>;
+    // (undocumented)
+    fetchAllFleetWings(fleetId: number, concurrency?: number): Promise<FleetWing[]>;
     getCharacterFleetInfo(characterId: number): Promise<CharacterFleetInfo>;
     getFleetInformation(fleetId: number): Promise<FleetInfo>;
     getFleetMembers(fleetId: number): Promise<FleetMember[]>;
@@ -5600,6 +5695,22 @@ interface IncursionsGet {
 // @public (undocumented)
 export class IndustryClient extends BaseEsiClient<typeof industryEndpoints> {
     constructor(client: ApiClient);
+    // (undocumented)
+    fetchAllCharacterIndustryJobs(characterId: number, concurrency?: number): Promise<IndustryJob[]>;
+    // (undocumented)
+    fetchAllCharacterMiningLedger(characterId: number, concurrency?: number): Promise<MiningLedgerEntry[]>;
+    // (undocumented)
+    fetchAllCorporationIndustryJobs(corporationId: number, concurrency?: number): Promise<IndustryJob[]>;
+    // (undocumented)
+    fetchAllCorporationMiningObserver(corporationId: number, observerId: number, concurrency?: number): Promise<MiningObserverEntry[]>;
+    // (undocumented)
+    fetchAllCorporationMiningObservers(corporationId: number, concurrency?: number): Promise<MiningObserver[]>;
+    // (undocumented)
+    fetchAllIndustryFacilities(concurrency?: number): Promise<IndustryFacility[]>;
+    // (undocumented)
+    fetchAllIndustrySystems(concurrency?: number): Promise<IndustrySystem[]>;
+    // (undocumented)
+    fetchAllMoonExtractionTimers(corporationId: number, concurrency?: number): Promise<MoonExtractionTimer[]>;
     getCharacterIndustryJobs(characterId: number): Promise<IndustryJob[]>;
     getCharacterMiningLedger(characterId: number): Promise<MiningLedgerEntry[]>;
     getCorporationIndustryJobs(corporationId: number): Promise<IndustryJob[]>;
@@ -5890,6 +6001,10 @@ const KillmailSchema: z.ZodObject<{
 // @public (undocumented)
 export class KillmailsClient extends BaseEsiClient<typeof killmailEndpoints> {
     constructor(client: ApiClient);
+    // (undocumented)
+    fetchAllCharacterRecentKillmails(characterId: number, concurrency?: number): Promise<KillmailSummary[]>;
+    // (undocumented)
+    fetchAllCorporationRecentKillmails(corporationId: number, concurrency?: number): Promise<KillmailSummary[]>;
     getCharacterRecentKillmails(characterId: number): Promise<KillmailSummary[]>;
     getCorporationRecentKillmails(corporationId: number): Promise<KillmailSummary[]>;
     getKillmail(killmailId: number, killmailHash: string): Promise<Killmail>;
@@ -5977,6 +6092,10 @@ export class LocationClient extends BaseEsiClient<typeof locationEndpoints> {
 // @public (undocumented)
 export class LoyaltyClient extends BaseEsiClient<typeof loyaltyEndpoints> {
     constructor(client: ApiClient);
+    // (undocumented)
+    fetchAllLoyaltyPoints(characterId: number, concurrency?: number): Promise<LoyaltyPoints[]>;
+    // (undocumented)
+    fetchAllLoyaltyStoreOffers(corporationId: number, concurrency?: number): Promise<LoyaltyStoreOffer[]>;
     getLoyaltyPoints(characterId: number): Promise<LoyaltyPoints[]>;
     getLoyaltyStoreOffers(corporationId: number): Promise<LoyaltyStoreOffer[]>;
     // (undocumented)
@@ -6040,6 +6159,13 @@ export class MailClient extends BaseEsiClient<typeof mailEndpoints> {
     createMailLabel(characterId: number, body: object): Promise<number>;
     deleteMail(characterId: number, mailId: number): Promise<void>;
     deleteMailLabel(characterId: number, labelId: number): Promise<void>;
+    // (undocumented)
+    fetchAllMailHeaders(characterId: number, concurrency?: number): Promise<MailMessage[]>;
+    // (undocumented)
+    fetchAllMailingLists(characterId: number, concurrency?: number): Promise<{
+        mailing_list_id: number;
+        name: string;
+    }[]>;
     getMail(characterId: number, mailId: number): Promise<MailMessage>;
     getMailHeaders(characterId: number): Promise<MailMessage[]>;
     getMailingLists(characterId: number): Promise<{
@@ -6112,6 +6238,18 @@ const MailMessageSchema: z.ZodObject<{
 // @public (undocumented)
 export class MarketClient extends BaseEsiClient<typeof marketEndpoints> {
     constructor(client: ApiClient);
+    // (undocumented)
+    fetchAllCharacterOrderHistory(characterId: number, concurrency?: number): Promise<CharacterMarketOrderHistory[]>;
+    // (undocumented)
+    fetchAllCorporationOrderHistory(corporationId: number, concurrency?: number): Promise<CorporationMarketOrderHistory[]>;
+    // (undocumented)
+    fetchAllCorporationOrders(corporationId: number, concurrency?: number): Promise<CorporationMarketOrder[]>;
+    // (undocumented)
+    fetchAllMarketOrders(regionId: number, concurrency?: number): Promise<MarketOrder[]>;
+    // (undocumented)
+    fetchAllMarketOrdersInStructure(structureId: number, concurrency?: number): Promise<StructureMarketOrder[]>;
+    // (undocumented)
+    fetchAllMarketTypes(regionId: number, concurrency?: number): Promise<number[]>;
     getCharacterOrderHistory(characterId: number): Promise<CharacterMarketOrderHistory[]>;
     getCharacterOrders(characterId: number): Promise<CharacterMarketOrder[]>;
     getCorporationOrderHistory(corporationId: number): Promise<CorporationMarketOrderHistory[]>;
@@ -6798,6 +6936,10 @@ const ParagonHubSkinrTargetSchema: z.ZodObject<{
 // @public (undocumented)
 export class PiClient extends BaseEsiClient<typeof piEndpoints> {
     constructor(client: ApiClient);
+    // (undocumented)
+    fetchAllColonies(characterId: number, concurrency?: number): Promise<PlanetaryColony[]>;
+    // (undocumented)
+    fetchAllCorporationCustomsOffices(corporationId: number, concurrency?: number): Promise<CustomsOffice[]>;
     getColonies(characterId: number): Promise<PlanetaryColony[]>;
     getColonyLayout(characterId: number, planetId: number): Promise<ColonyLayout>;
     getCorporationCustomsOffices(corporationId: number): Promise<CustomsOffice[]>;
@@ -6866,6 +7008,14 @@ const RaidableSkyhookSchema: z.ZodObject<{
 }, z.core.$loose>;
 
 // @public (undocumented)
+export interface RateLimitEndpointOverride {
+    // (undocumented)
+    maxTokens: number;
+    // (undocumented)
+    windowSizeMs: number;
+}
+
+// @public (undocumented)
 export class RateLimiter implements IRateLimiter {
     constructor(config?: RateLimiterConfig);
     // (undocumented)
@@ -6894,6 +7044,8 @@ export class RateLimiter implements IRateLimiter {
 export interface RateLimiterConfig {
     // (undocumented)
     decelerationThreshold?: number;
+    // (undocumented)
+    endpointOverrides?: Record<string, RateLimitEndpointOverride>;
     // (undocumented)
     minDelayMs?: number;
     // (undocumented)
@@ -8444,6 +8596,14 @@ export type ValidationDirection = 'request' | 'response';
 // @public (undocumented)
 export class WalletClient extends BaseEsiClient<typeof walletEndpoints> {
     constructor(client: ApiClient);
+    // (undocumented)
+    fetchAllCharacterWalletJournal(characterId: number, concurrency?: number): Promise<WalletJournal[]>;
+    // (undocumented)
+    fetchAllCharacterWalletTransactions(characterId: number, concurrency?: number): Promise<WalletTransaction[]>;
+    // (undocumented)
+    fetchAllCorporationWalletJournal(corporationId: number, division: number, concurrency?: number): Promise<WalletJournal[]>;
+    // (undocumented)
+    fetchAllCorporationWalletTransactions(corporationId: number, division: number, concurrency?: number): Promise<WalletTransaction[]>;
     getCharacterWallet(characterId: number): Promise<number>;
     getCharacterWalletJournal(characterId: number): Promise<WalletJournal[]>;
     getCharacterWalletTransactions(characterId: number): Promise<WalletTransaction[]>;
@@ -8538,6 +8698,10 @@ const WarSchema: z.ZodObject<{
 // @public (undocumented)
 export class WarsClient extends BaseEsiClient<typeof warEndpoints> {
     constructor(client: ApiClient);
+    // (undocumented)
+    fetchAllWarKillmails(warId: number, concurrency?: number): Promise<KillmailSummary[]>;
+    // (undocumented)
+    fetchAllWars(concurrency?: number): Promise<number[]>;
     getWarById(warId: number): Promise<War>;
     getWarKillmails(warId: number): Promise<KillmailSummary[]>;
     getWars(): Promise<number[]>;

--- a/src/clients/AllianceClient.ts
+++ b/src/clients/AllianceClient.ts
@@ -44,9 +44,7 @@ export class AllianceClient extends BaseEsiClient<typeof allianceEndpoints> {
     );
     // Schema mismatch: ContactSchema uses a wider contact_type enum than AllianceContactSchema.
     // Cast through unknown until schemas are unified.
-    return this.contactApi.getAllianceContacts(
-      allianceId,
-    ) as unknown as Promise<AllianceContact[]>;
+    return this.contactApi.getAllianceContacts(allianceId);
   }
 
   /**
@@ -93,6 +91,21 @@ export class AllianceClient extends BaseEsiClient<typeof allianceEndpoints> {
    */
   getAlliances(): Promise<number[]> {
     return this.api.getAlliances();
+  }
+
+  fetchAllAlliances(concurrency?: number): Promise<number[]> {
+    return this.fetchAllEndpoint<number>('getAlliances', [], concurrency);
+  }
+
+  fetchAllCorporations(
+    allianceId: number,
+    concurrency?: number,
+  ): Promise<number[]> {
+    return this.fetchAllEndpoint<number>(
+      'getCorporations',
+      [allianceId],
+      concurrency,
+    );
   }
 
   streamAlliances(): AsyncGenerator<PageResult<number>, void, undefined> {

--- a/src/clients/AssetsClient.ts
+++ b/src/clients/AssetsClient.ts
@@ -21,9 +21,7 @@ export class AssetsClient extends BaseEsiClient<typeof assetEndpoints> {
    * @requires Authentication
    */
   getCharacterAssets(characterId: number): Promise<CharacterAsset[]> {
-    return this.api.getCharacterAssets(characterId) as Promise<
-      CharacterAsset[]
-    >;
+    return this.api.getCharacterAssets(characterId);
   }
 
   /**
@@ -38,10 +36,7 @@ export class AssetsClient extends BaseEsiClient<typeof assetEndpoints> {
     characterId: number,
     itemIds: number[],
   ): Promise<AssetLocation[]> {
-    return this.api.postCharacterAssetLocations(
-      characterId,
-      itemIds,
-    ) as Promise<AssetLocation[]>;
+    return this.api.postCharacterAssetLocations(characterId, itemIds);
   }
 
   /**
@@ -56,9 +51,7 @@ export class AssetsClient extends BaseEsiClient<typeof assetEndpoints> {
     characterId: number,
     itemIds: number[],
   ): Promise<AssetName[]> {
-    return this.api.postCharacterAssetNames(characterId, itemIds) as Promise<
-      AssetName[]
-    >;
+    return this.api.postCharacterAssetNames(characterId, itemIds);
   }
 
   /**
@@ -69,9 +62,7 @@ export class AssetsClient extends BaseEsiClient<typeof assetEndpoints> {
    * @requires Authentication
    */
   getCorporationAssets(corporationId: number): Promise<CharacterAsset[]> {
-    return this.api.getCorporationAssets(corporationId) as Promise<
-      CharacterAsset[]
-    >;
+    return this.api.getCorporationAssets(corporationId);
   }
 
   /**
@@ -108,6 +99,28 @@ export class AssetsClient extends BaseEsiClient<typeof assetEndpoints> {
       corporationId,
       itemIds,
     ) as Promise<AssetName[]>;
+  }
+
+  fetchAllCharacterAssets(
+    characterId: number,
+    concurrency?: number,
+  ): Promise<CharacterAsset[]> {
+    return this.fetchAllEndpoint<CharacterAsset>(
+      'getCharacterAssets',
+      [characterId],
+      concurrency,
+    );
+  }
+
+  fetchAllCorporationAssets(
+    corporationId: number,
+    concurrency?: number,
+  ): Promise<CharacterAsset[]> {
+    return this.fetchAllEndpoint<CharacterAsset>(
+      'getCorporationAssets',
+      [corporationId],
+      concurrency,
+    );
   }
 
   streamCharacterAssets(

--- a/src/clients/BaseEsiClient.ts
+++ b/src/clients/BaseEsiClient.ts
@@ -8,6 +8,7 @@ import {
 import { EndpointMap } from '../core/endpoints/EndpointDefinition';
 import { buildEndpointPath } from '../core/endpoints/buildEndpointPath';
 import {
+  fetchAllPages,
   fetchPages,
   PageResult,
 } from '../core/pagination/AsyncPaginationIterator';
@@ -45,6 +46,29 @@ export abstract class BaseEsiClient<T extends EndpointMap> {
       body,
       def.path,
       def.responseSchema,
+    );
+  }
+
+  public fetchAllEndpoint<R>(
+    endpointName: string & keyof T,
+    args: unknown[],
+    concurrency?: number,
+  ): Promise<R[]> {
+    const def = this._endpoints[endpointName]!;
+    const { path, body } = buildEndpointPath(
+      def,
+      args,
+      this._client.getDatasource(),
+    );
+    return fetchAllPages<R>(
+      this._client,
+      path,
+      def.method,
+      def.requiresAuth,
+      body,
+      def.path,
+      def.responseSchema,
+      concurrency,
     );
   }
 

--- a/src/clients/CalendarClient.ts
+++ b/src/clients/CalendarClient.ts
@@ -74,6 +74,29 @@ export class CalendarClient extends BaseEsiClient<typeof calendarEndpoints> {
     return this.api.getEventAttendees(characterId, eventId);
   }
 
+  fetchAllCalendarEvents(
+    characterId: number,
+    concurrency?: number,
+  ): Promise<CalendarEvent[]> {
+    return this.fetchAllEndpoint<CalendarEvent>(
+      'getCalendarEvents',
+      [characterId],
+      concurrency,
+    );
+  }
+
+  fetchAllEventAttendees(
+    characterId: number,
+    eventId: number,
+    concurrency?: number,
+  ): Promise<CalendarEventAttendee[]> {
+    return this.fetchAllEndpoint<CalendarEventAttendee>(
+      'getEventAttendees',
+      [characterId, eventId],
+      concurrency,
+    );
+  }
+
   streamCalendarEvents(
     characterId: number,
   ): AsyncGenerator<PageResult<CalendarEvent>, void, undefined> {

--- a/src/clients/CharacterClient.ts
+++ b/src/clients/CharacterClient.ts
@@ -191,6 +191,94 @@ export class CharacterClient extends BaseEsiClient<typeof characterEndpoints> {
     >;
   }
 
+  fetchAllCharacterAgentsResearch(
+    characterId: number,
+    concurrency?: number,
+  ): Promise<AgentResearch[]> {
+    return this.fetchAllEndpoint<AgentResearch>(
+      'getAgentsResearch',
+      [characterId],
+      concurrency,
+    );
+  }
+
+  fetchAllCharacterBlueprints(
+    characterId: number,
+    concurrency?: number,
+  ): Promise<Blueprint[]> {
+    return this.fetchAllEndpoint<Blueprint>(
+      'getBlueprints',
+      [characterId],
+      concurrency,
+    );
+  }
+
+  fetchAllCharacterCorporationHistory(
+    characterId: number,
+    concurrency?: number,
+  ): Promise<CorporationHistory[]> {
+    return this.fetchAllEndpoint<CorporationHistory>(
+      'getCorporationHistory',
+      [characterId],
+      concurrency,
+    );
+  }
+
+  fetchAllCharacterMedals(
+    characterId: number,
+    concurrency?: number,
+  ): Promise<Medal[]> {
+    return this.fetchAllEndpoint<Medal>(
+      'getMedals',
+      [characterId],
+      concurrency,
+    );
+  }
+
+  fetchAllCharacterNotifications(
+    characterId: number,
+    concurrency?: number,
+  ): Promise<Notification[]> {
+    return this.fetchAllEndpoint<Notification>(
+      'getNotifications',
+      [characterId],
+      concurrency,
+    );
+  }
+
+  fetchAllCharacterNotificationsContacts(
+    characterId: number,
+    concurrency?: number,
+  ): Promise<Notification[]> {
+    return this.fetchAllEndpoint<Notification>(
+      'getContactNotifications',
+      [characterId],
+      concurrency,
+    );
+  }
+
+  fetchAllCharacterStandings(
+    characterId: number,
+    concurrency?: number,
+  ): Promise<Standing[]> {
+    return this.fetchAllEndpoint<Standing>(
+      'getStandings',
+      [characterId],
+      concurrency,
+    );
+  }
+
+  fetchAllCharacterTitles(
+    characterId: number,
+    concurrency?: number,
+  ): Promise<CharacterTitle[]> {
+    return this.fetchAllEndpoint<CharacterTitle>(
+      'getTitles',
+      [characterId],
+      concurrency,
+    );
+  }
+
   streamCharacterAgentsResearch(
     characterId: number,
   ): AsyncGenerator<PageResult<AgentResearch>, void, undefined> {

--- a/src/clients/ClonesClient.ts
+++ b/src/clients/ClonesClient.ts
@@ -31,6 +31,17 @@ export class ClonesClient extends BaseEsiClient<typeof cloneEndpoints> {
     return this.api.getImplants(characterId);
   }
 
+  fetchAllImplants(
+    characterId: number,
+    concurrency?: number,
+  ): Promise<number[]> {
+    return this.fetchAllEndpoint<number>(
+      'getImplants',
+      [characterId],
+      concurrency,
+    );
+  }
+
   streamImplants(
     characterId: number,
   ): AsyncGenerator<PageResult<number>, void, undefined> {

--- a/src/clients/ContactsClient.ts
+++ b/src/clients/ContactsClient.ts
@@ -131,6 +131,72 @@ export class ContactsClient extends BaseEsiClient<typeof contactEndpoints> {
     return this.api.getCorporationContactLabels(corporationId);
   }
 
+  fetchAllAllianceContacts(
+    allianceId: number,
+    concurrency?: number,
+  ): Promise<Contact[]> {
+    return this.fetchAllEndpoint<Contact>(
+      'getAllianceContacts',
+      [allianceId],
+      concurrency,
+    );
+  }
+
+  fetchAllAllianceContactLabels(
+    allianceId: number,
+    concurrency?: number,
+  ): Promise<ContactLabel[]> {
+    return this.fetchAllEndpoint<ContactLabel>(
+      'getAllianceContactLabels',
+      [allianceId],
+      concurrency,
+    );
+  }
+
+  fetchAllCharacterContacts(
+    characterId: number,
+    concurrency?: number,
+  ): Promise<Contact[]> {
+    return this.fetchAllEndpoint<Contact>(
+      'getCharacterContacts',
+      [characterId],
+      concurrency,
+    );
+  }
+
+  fetchAllCharacterContactLabels(
+    characterId: number,
+    concurrency?: number,
+  ): Promise<ContactLabel[]> {
+    return this.fetchAllEndpoint<ContactLabel>(
+      'getCharacterContactLabels',
+      [characterId],
+      concurrency,
+    );
+  }
+
+  fetchAllCorporationContacts(
+    corporationId: number,
+    concurrency?: number,
+  ): Promise<Contact[]> {
+    return this.fetchAllEndpoint<Contact>(
+      'getCorporationContacts',
+      [corporationId],
+      concurrency,
+    );
+  }
+
+  fetchAllCorporationContactLabels(
+    corporationId: number,
+    concurrency?: number,
+  ): Promise<ContactLabel[]> {
+    return this.fetchAllEndpoint<ContactLabel>(
+      'getCorporationContactLabels',
+      [corporationId],
+      concurrency,
+    );
+  }
+
   streamAllianceContacts(
     allianceId: number,
   ): AsyncGenerator<PageResult<Contact>, void, undefined> {

--- a/src/clients/ContractsClient.ts
+++ b/src/clients/ContractsClient.ts
@@ -17,7 +17,7 @@ export class ContractsClient extends BaseEsiClient<typeof contractEndpoints> {
    * @requires Authentication
    */
   getCharacterContracts(characterId: number): Promise<Contract[]> {
-    return this.api.getCharacterContracts(characterId) as Promise<Contract[]>;
+    return this.api.getCharacterContracts(characterId);
   }
 
   /**
@@ -32,10 +32,7 @@ export class ContractsClient extends BaseEsiClient<typeof contractEndpoints> {
     characterId: number,
     contractId: number,
   ): Promise<ContractBid[]> {
-    return this.api.getCharacterContractBids(
-      characterId,
-      contractId,
-    ) as Promise<ContractBid[]>;
+    return this.api.getCharacterContractBids(characterId, contractId);
   }
 
   /**
@@ -50,10 +47,7 @@ export class ContractsClient extends BaseEsiClient<typeof contractEndpoints> {
     characterId: number,
     contractId: number,
   ): Promise<ContractItem[]> {
-    return this.api.getCharacterContractItems(
-      characterId,
-      contractId,
-    ) as Promise<ContractItem[]>;
+    return this.api.getCharacterContractItems(characterId, contractId);
   }
 
   /**
@@ -63,7 +57,7 @@ export class ContractsClient extends BaseEsiClient<typeof contractEndpoints> {
    * @returns A list of public contracts in the region
    */
   getPublicContracts(regionId: number): Promise<Contract[]> {
-    return this.api.getPublicContracts(regionId) as Promise<Contract[]>;
+    return this.api.getPublicContracts(regionId);
   }
 
   /**
@@ -73,7 +67,7 @@ export class ContractsClient extends BaseEsiClient<typeof contractEndpoints> {
    * @returns A list of bids with bidder, amount, and timestamp
    */
   getPublicContractBids(contractId: number): Promise<ContractBid[]> {
-    return this.api.getPublicContractBids(contractId) as Promise<ContractBid[]>;
+    return this.api.getPublicContractBids(contractId);
   }
 
   /**
@@ -83,9 +77,7 @@ export class ContractsClient extends BaseEsiClient<typeof contractEndpoints> {
    * @returns A list of items in the contract with type, quantity, and included/excluded status
    */
   getPublicContractItems(contractId: number): Promise<ContractItem[]> {
-    return this.api.getPublicContractItems(contractId) as Promise<
-      ContractItem[]
-    >;
+    return this.api.getPublicContractItems(contractId);
   }
 
   /**
@@ -96,9 +88,7 @@ export class ContractsClient extends BaseEsiClient<typeof contractEndpoints> {
    * @requires Authentication
    */
   getCorporationContracts(corporationId: number): Promise<Contract[]> {
-    return this.api.getCorporationContracts(corporationId) as Promise<
-      Contract[]
-    >;
+    return this.api.getCorporationContracts(corporationId);
   }
 
   /**
@@ -113,10 +103,7 @@ export class ContractsClient extends BaseEsiClient<typeof contractEndpoints> {
     corporationId: number,
     contractId: number,
   ): Promise<ContractBid[]> {
-    return this.api.getCorporationContractBids(
-      corporationId,
-      contractId,
-    ) as Promise<ContractBid[]>;
+    return this.api.getCorporationContractBids(corporationId, contractId);
   }
 
   /**
@@ -131,10 +118,40 @@ export class ContractsClient extends BaseEsiClient<typeof contractEndpoints> {
     corporationId: number,
     contractId: number,
   ): Promise<ContractItem[]> {
-    return this.api.getCorporationContractItems(
-      corporationId,
-      contractId,
-    ) as Promise<ContractItem[]>;
+    return this.api.getCorporationContractItems(corporationId, contractId);
+  }
+
+  fetchAllPublicContracts(
+    regionId: number,
+    concurrency?: number,
+  ): Promise<Contract[]> {
+    return this.fetchAllEndpoint<Contract>(
+      'getPublicContracts',
+      [regionId],
+      concurrency,
+    );
+  }
+
+  fetchAllCharacterContracts(
+    characterId: number,
+    concurrency?: number,
+  ): Promise<Contract[]> {
+    return this.fetchAllEndpoint<Contract>(
+      'getCharacterContracts',
+      [characterId],
+      concurrency,
+    );
+  }
+
+  fetchAllCorporationContracts(
+    corporationId: number,
+    concurrency?: number,
+  ): Promise<Contract[]> {
+    return this.fetchAllEndpoint<Contract>(
+      'getCorporationContracts',
+      [corporationId],
+      concurrency,
+    );
   }
 
   streamPublicContracts(

--- a/src/clients/CorporationsClient.ts
+++ b/src/clients/CorporationsClient.ts
@@ -293,6 +293,186 @@ export class CorporationsClient extends BaseEsiClient<
     return this.api.getNpcCorporations();
   }
 
+  fetchAllCorporationAllianceHistory(
+    corporationId: number,
+    concurrency?: number,
+  ): Promise<CorporationAllianceHistory[]> {
+    return this.fetchAllEndpoint<CorporationAllianceHistory>(
+      'getCorporationAllianceHistory',
+      [corporationId],
+      concurrency,
+    );
+  }
+
+  fetchAllCorporationBlueprints(
+    corporationId: number,
+    concurrency?: number,
+  ): Promise<Blueprint[]> {
+    return this.fetchAllEndpoint<Blueprint>(
+      'getCorporationBlueprints',
+      [corporationId],
+      concurrency,
+    );
+  }
+
+  fetchAllCorporationAlscLogs(
+    corporationId: number,
+    concurrency?: number,
+  ): Promise<ContainerLog[]> {
+    return this.fetchAllEndpoint<ContainerLog>(
+      'getCorporationAlscLogs',
+      [corporationId],
+      concurrency,
+    );
+  }
+
+  fetchAllCorporationFacilities(
+    corporationId: number,
+    concurrency?: number,
+  ): Promise<CorporationFacility[]> {
+    return this.fetchAllEndpoint<CorporationFacility>(
+      'getCorporationFacilities',
+      [corporationId],
+      concurrency,
+    );
+  }
+
+  fetchAllCorporationMedals(
+    corporationId: number,
+    concurrency?: number,
+  ): Promise<CorporationMedal[]> {
+    return this.fetchAllEndpoint<CorporationMedal>(
+      'getCorporationMedals',
+      [corporationId],
+      concurrency,
+    );
+  }
+
+  fetchAllCorporationIssuedMedals(
+    corporationId: number,
+    concurrency?: number,
+  ): Promise<CorporationIssuedMedal[]> {
+    return this.fetchAllEndpoint<CorporationIssuedMedal>(
+      'getCorporationIssuedMedals',
+      [corporationId],
+      concurrency,
+    );
+  }
+
+  fetchAllCorporationMembers(
+    corporationId: number,
+    concurrency?: number,
+  ): Promise<number[]> {
+    return this.fetchAllEndpoint<number>(
+      'getCorporationMembers',
+      [corporationId],
+      concurrency,
+    );
+  }
+
+  fetchAllCorporationMemberTitles(
+    corporationId: number,
+    concurrency?: number,
+  ): Promise<CorporationMemberTitle[]> {
+    return this.fetchAllEndpoint<CorporationMemberTitle>(
+      'getCorporationMembersTitles',
+      [corporationId],
+      concurrency,
+    );
+  }
+
+  fetchAllCorporationMemberTracking(
+    corporationId: number,
+    concurrency?: number,
+  ): Promise<CorporationMemberTracking[]> {
+    return this.fetchAllEndpoint<CorporationMemberTracking>(
+      'getCorporationMemberTracking',
+      [corporationId],
+      concurrency,
+    );
+  }
+
+  fetchAllCorporationRoles(
+    corporationId: number,
+    concurrency?: number,
+  ): Promise<CorporationMemberRole[]> {
+    return this.fetchAllEndpoint<CorporationMemberRole>(
+      'getCorporationMemberRoles',
+      [corporationId],
+      concurrency,
+    );
+  }
+
+  fetchAllCorporationRolesHistory(
+    corporationId: number,
+    concurrency?: number,
+  ): Promise<CorporationRoleHistory[]> {
+    return this.fetchAllEndpoint<CorporationRoleHistory>(
+      'getCorporationMemberRolesHistory',
+      [corporationId],
+      concurrency,
+    );
+  }
+
+  fetchAllCorporationShareholders(
+    corporationId: number,
+    concurrency?: number,
+  ): Promise<CorporationShareholder[]> {
+    return this.fetchAllEndpoint<CorporationShareholder>(
+      'getCorporationShareholders',
+      [corporationId],
+      concurrency,
+    );
+  }
+
+  fetchAllCorporationStandings(
+    corporationId: number,
+    concurrency?: number,
+  ): Promise<Standing[]> {
+    return this.fetchAllEndpoint<Standing>(
+      'getCorporationStandings',
+      [corporationId],
+      concurrency,
+    );
+  }
+
+  fetchAllCorporationStarbases(
+    corporationId: number,
+    concurrency?: number,
+  ): Promise<CorporationStarbase[]> {
+    return this.fetchAllEndpoint<CorporationStarbase>(
+      'getCorporationStarbases',
+      [corporationId],
+      concurrency,
+    );
+  }
+
+  fetchAllCorporationStructures(
+    corporationId: number,
+    concurrency?: number,
+  ): Promise<CorporationStructure[]> {
+    return this.fetchAllEndpoint<CorporationStructure>(
+      'getCorporationStructures',
+      [corporationId],
+      concurrency,
+    );
+  }
+
+  fetchAllCorporationTitles(
+    corporationId: number,
+    concurrency?: number,
+  ): Promise<CorporationTitle[]> {
+    return this.fetchAllEndpoint<CorporationTitle>(
+      'getCorporationTitles',
+      [corporationId],
+      concurrency,
+    );
+  }
+
+  fetchAllNpcCorporations(concurrency?: number): Promise<number[]> {
+    return this.fetchAllEndpoint<number>('getNpcCorporations', [], concurrency);
+  }
+
   streamCorporationAllianceHistory(
     corporationId: number,
   ): AsyncGenerator<PageResult<CorporationAllianceHistory>, void, undefined> {

--- a/src/clients/FittingsClient.ts
+++ b/src/clients/FittingsClient.ts
@@ -48,6 +48,17 @@ export class FittingsClient extends BaseEsiClient<typeof fittingEndpoints> {
     return this.api.deleteFitting(characterId, fittingId) as Promise<void>;
   }
 
+  fetchAllFittings(
+    characterId: number,
+    concurrency?: number,
+  ): Promise<Fitting[]> {
+    return this.fetchAllEndpoint<Fitting>(
+      'getFittings',
+      [characterId],
+      concurrency,
+    );
+  }
+
   streamFittings(
     characterId: number,
   ): AsyncGenerator<PageResult<Fitting>, void, undefined> {

--- a/src/clients/FleetClient.ts
+++ b/src/clients/FleetClient.ts
@@ -206,6 +206,28 @@ export class FleetClient extends BaseEsiClient<typeof fleetEndpoints> {
     }>;
   }
 
+  fetchAllFleetMembers(
+    fleetId: number,
+    concurrency?: number,
+  ): Promise<FleetMember[]> {
+    return this.fetchAllEndpoint<FleetMember>(
+      'getFleetMembers',
+      [fleetId],
+      concurrency,
+    );
+  }
+
+  fetchAllFleetWings(
+    fleetId: number,
+    concurrency?: number,
+  ): Promise<FleetWing[]> {
+    return this.fetchAllEndpoint<FleetWing>(
+      'getFleetWings',
+      [fleetId],
+      concurrency,
+    );
+  }
+
   streamFleetMembers(
     fleetId: number,
   ): AsyncGenerator<PageResult<FleetMember>, void, undefined> {

--- a/src/clients/IndustryClient.ts
+++ b/src/clients/IndustryClient.ts
@@ -109,6 +109,91 @@ export class IndustryClient extends BaseEsiClient<typeof industryEndpoints> {
     return this.api.getIndustrySystems();
   }
 
+  fetchAllCharacterIndustryJobs(
+    characterId: number,
+    concurrency?: number,
+  ): Promise<IndustryJob[]> {
+    return this.fetchAllEndpoint<IndustryJob>(
+      'getCharacterIndustryJobs',
+      [characterId],
+      concurrency,
+    );
+  }
+
+  fetchAllCharacterMiningLedger(
+    characterId: number,
+    concurrency?: number,
+  ): Promise<MiningLedgerEntry[]> {
+    return this.fetchAllEndpoint<MiningLedgerEntry>(
+      'getCharacterMiningLedger',
+      [characterId],
+      concurrency,
+    );
+  }
+
+  fetchAllCorporationIndustryJobs(
+    corporationId: number,
+    concurrency?: number,
+  ): Promise<IndustryJob[]> {
+    return this.fetchAllEndpoint<IndustryJob>(
+      'getCorporationIndustryJobs',
+      [corporationId],
+      concurrency,
+    );
+  }
+
+  fetchAllMoonExtractionTimers(
+    corporationId: number,
+    concurrency?: number,
+  ): Promise<MoonExtractionTimer[]> {
+    return this.fetchAllEndpoint<MoonExtractionTimer>(
+      'getMoonExtractionTimers',
+      [corporationId],
+      concurrency,
+    );
+  }
+
+  fetchAllCorporationMiningObservers(
+    corporationId: number,
+    concurrency?: number,
+  ): Promise<MiningObserver[]> {
+    return this.fetchAllEndpoint<MiningObserver>(
+      'getCorporationMiningObservers',
+      [corporationId],
+      concurrency,
+    );
+  }
+
+  fetchAllCorporationMiningObserver(
+    corporationId: number,
+    observerId: number,
+    concurrency?: number,
+  ): Promise<MiningObserverEntry[]> {
+    return this.fetchAllEndpoint<MiningObserverEntry>(
+      'getCorporationMiningObserver',
+      [corporationId, observerId],
+      concurrency,
+    );
+  }
+
+  fetchAllIndustryFacilities(
+    concurrency?: number,
+  ): Promise<IndustryFacility[]> {
+    return this.fetchAllEndpoint<IndustryFacility>(
+      'getIndustryFacilities',
+      [],
+      concurrency,
+    );
+  }
+
+  fetchAllIndustrySystems(concurrency?: number): Promise<IndustrySystem[]> {
+    return this.fetchAllEndpoint<IndustrySystem>(
+      'getIndustrySystems',
+      [],
+      concurrency,
+    );
+  }
+
   streamCharacterIndustryJobs(
     characterId: number,
   ): AsyncGenerator<PageResult<IndustryJob>, void, undefined> {

--- a/src/clients/KillmailsClient.ts
+++ b/src/clients/KillmailsClient.ts
@@ -17,9 +17,7 @@ export class KillmailsClient extends BaseEsiClient<typeof killmailEndpoints> {
    * @requires Authentication
    */
   getCharacterRecentKillmails(characterId: number): Promise<KillmailSummary[]> {
-    return this.api.getCharacterRecentKillmails(characterId) as Promise<
-      KillmailSummary[]
-    >;
+    return this.api.getCharacterRecentKillmails(characterId);
   }
 
   /**
@@ -32,9 +30,7 @@ export class KillmailsClient extends BaseEsiClient<typeof killmailEndpoints> {
   getCorporationRecentKillmails(
     corporationId: number,
   ): Promise<KillmailSummary[]> {
-    return this.api.getCorporationRecentKillmails(corporationId) as Promise<
-      KillmailSummary[]
-    >;
+    return this.api.getCorporationRecentKillmails(corporationId);
   }
 
   /**
@@ -45,7 +41,29 @@ export class KillmailsClient extends BaseEsiClient<typeof killmailEndpoints> {
    * @returns The full killmail details including victim, attackers, and items
    */
   getKillmail(killmailId: number, killmailHash: string): Promise<Killmail> {
-    return this.api.getKillmail(killmailId, killmailHash) as Promise<Killmail>;
+    return this.api.getKillmail(killmailId, killmailHash);
+  }
+
+  fetchAllCharacterRecentKillmails(
+    characterId: number,
+    concurrency?: number,
+  ): Promise<KillmailSummary[]> {
+    return this.fetchAllEndpoint<KillmailSummary>(
+      'getCharacterRecentKillmails',
+      [characterId],
+      concurrency,
+    );
+  }
+
+  fetchAllCorporationRecentKillmails(
+    corporationId: number,
+    concurrency?: number,
+  ): Promise<KillmailSummary[]> {
+    return this.fetchAllEndpoint<KillmailSummary>(
+      'getCorporationRecentKillmails',
+      [corporationId],
+      concurrency,
+    );
   }
 
   streamCharacterRecentKillmails(

--- a/src/clients/LoyaltyClient.ts
+++ b/src/clients/LoyaltyClient.ts
@@ -30,6 +30,28 @@ export class LoyaltyClient extends BaseEsiClient<typeof loyaltyEndpoints> {
     return this.api.getLoyaltyStoreOffers(corporationId);
   }
 
+  fetchAllLoyaltyPoints(
+    characterId: number,
+    concurrency?: number,
+  ): Promise<LoyaltyPoints[]> {
+    return this.fetchAllEndpoint<LoyaltyPoints>(
+      'getLoyaltyPoints',
+      [characterId],
+      concurrency,
+    );
+  }
+
+  fetchAllLoyaltyStoreOffers(
+    corporationId: number,
+    concurrency?: number,
+  ): Promise<LoyaltyStoreOffer[]> {
+    return this.fetchAllEndpoint<LoyaltyStoreOffer>(
+      'getLoyaltyStoreOffers',
+      [corporationId],
+      concurrency,
+    );
+  }
+
   streamLoyaltyPoints(
     characterId: number,
   ): AsyncGenerator<PageResult<LoyaltyPoints>, void, undefined> {

--- a/src/clients/MailClient.ts
+++ b/src/clients/MailClient.ts
@@ -127,6 +127,28 @@ export class MailClient extends BaseEsiClient<typeof mailEndpoints> {
     return this.api.getMailingLists(characterId);
   }
 
+  fetchAllMailHeaders(
+    characterId: number,
+    concurrency?: number,
+  ): Promise<MailMessage[]> {
+    return this.fetchAllEndpoint<MailMessage>(
+      'getCharacterMailHeaders',
+      [characterId],
+      concurrency,
+    );
+  }
+
+  fetchAllMailingLists(
+    characterId: number,
+    concurrency?: number,
+  ): Promise<{ mailing_list_id: number; name: string }[]> {
+    return this.fetchAllEndpoint<{ mailing_list_id: number; name: string }>(
+      'getMailingLists',
+      [characterId],
+      concurrency,
+    );
+  }
+
   streamMailHeaders(
     characterId: number,
   ): AsyncGenerator<PageResult<MailMessage>, void, undefined> {

--- a/src/clients/MarketClient.ts
+++ b/src/clients/MarketClient.ts
@@ -141,6 +141,72 @@ export class MarketClient extends BaseEsiClient<typeof marketEndpoints> {
     return this.api.getMarketOrdersInStructure(structureId);
   }
 
+  fetchAllMarketOrders(
+    regionId: number,
+    concurrency?: number,
+  ): Promise<MarketOrder[]> {
+    return this.fetchAllEndpoint<MarketOrder>(
+      'getMarketOrders',
+      [regionId, 'all'],
+      concurrency,
+    );
+  }
+
+  fetchAllMarketTypes(
+    regionId: number,
+    concurrency?: number,
+  ): Promise<number[]> {
+    return this.fetchAllEndpoint<number>(
+      'getMarketTypes',
+      [regionId],
+      concurrency,
+    );
+  }
+
+  fetchAllCharacterOrderHistory(
+    characterId: number,
+    concurrency?: number,
+  ): Promise<CharacterMarketOrderHistory[]> {
+    return this.fetchAllEndpoint<CharacterMarketOrderHistory>(
+      'getCharacterOrderHistory',
+      [characterId],
+      concurrency,
+    );
+  }
+
+  fetchAllCorporationOrders(
+    corporationId: number,
+    concurrency?: number,
+  ): Promise<CorporationMarketOrder[]> {
+    return this.fetchAllEndpoint<CorporationMarketOrder>(
+      'getCorporationOrders',
+      [corporationId],
+      concurrency,
+    );
+  }
+
+  fetchAllCorporationOrderHistory(
+    corporationId: number,
+    concurrency?: number,
+  ): Promise<CorporationMarketOrderHistory[]> {
+    return this.fetchAllEndpoint<CorporationMarketOrderHistory>(
+      'getCorporationOrderHistory',
+      [corporationId],
+      concurrency,
+    );
+  }
+
+  fetchAllMarketOrdersInStructure(
+    structureId: number,
+    concurrency?: number,
+  ): Promise<StructureMarketOrder[]> {
+    return this.fetchAllEndpoint<StructureMarketOrder>(
+      'getMarketOrdersInStructure',
+      [structureId],
+      concurrency,
+    );
+  }
+
   streamMarketOrders(
     regionId: number,
   ): AsyncGenerator<PageResult<MarketOrder>, void, undefined> {

--- a/src/clients/PiClient.ts
+++ b/src/clients/PiClient.ts
@@ -63,6 +63,28 @@ export class PiClient extends BaseEsiClient<typeof piEndpoints> {
     return this.api.getSchematicInformation(schematicId);
   }
 
+  fetchAllColonies(
+    characterId: number,
+    concurrency?: number,
+  ): Promise<PlanetaryColony[]> {
+    return this.fetchAllEndpoint<PlanetaryColony>(
+      'getColonies',
+      [characterId],
+      concurrency,
+    );
+  }
+
+  fetchAllCorporationCustomsOffices(
+    corporationId: number,
+    concurrency?: number,
+  ): Promise<CustomsOffice[]> {
+    return this.fetchAllEndpoint<CustomsOffice>(
+      'getCorporationCustomsOffices',
+      [corporationId],
+      concurrency,
+    );
+  }
+
   streamColonies(
     characterId: number,
   ): AsyncGenerator<PageResult<PlanetaryColony>, void, undefined> {

--- a/src/clients/SkillsClient.ts
+++ b/src/clients/SkillsClient.ts
@@ -52,6 +52,17 @@ export class CharacterSkillsClient extends BaseEsiClient<
     return this.api.getCharacterSkills(characterId);
   }
 
+  fetchAllCharacterSkillQueue(
+    characterId: number,
+    concurrency?: number,
+  ): Promise<SkillQueue[]> {
+    return this.fetchAllEndpoint<SkillQueue>(
+      'getCharacterSkillQueue',
+      [characterId],
+      concurrency,
+    );
+  }
+
   streamCharacterSkillQueue(
     characterId: number,
   ): AsyncGenerator<PageResult<SkillQueue>, void, undefined> {

--- a/src/clients/WalletClient.ts
+++ b/src/clients/WalletClient.ts
@@ -87,6 +87,52 @@ export class WalletClient extends BaseEsiClient<typeof walletEndpoints> {
     return this.api.getCorporationWalletTransactions(corporationId, division);
   }
 
+  fetchAllCharacterWalletJournal(
+    characterId: number,
+    concurrency?: number,
+  ): Promise<WalletJournal[]> {
+    return this.fetchAllEndpoint<WalletJournal>(
+      'getCharacterWalletJournal',
+      [characterId],
+      concurrency,
+    );
+  }
+
+  fetchAllCorporationWalletJournal(
+    corporationId: number,
+    division: number,
+    concurrency?: number,
+  ): Promise<WalletJournal[]> {
+    return this.fetchAllEndpoint<WalletJournal>(
+      'getCorporationWalletJournal',
+      [corporationId, division],
+      concurrency,
+    );
+  }
+
+  fetchAllCharacterWalletTransactions(
+    characterId: number,
+    concurrency?: number,
+  ): Promise<WalletTransaction[]> {
+    return this.fetchAllEndpoint<WalletTransaction>(
+      'getCharacterWalletTransactions',
+      [characterId],
+      concurrency,
+    );
+  }
+
+  fetchAllCorporationWalletTransactions(
+    corporationId: number,
+    division: number,
+    concurrency?: number,
+  ): Promise<WalletTransaction[]> {
+    return this.fetchAllEndpoint<WalletTransaction>(
+      'getCorporationWalletTransactions',
+      [corporationId, division],
+      concurrency,
+    );
+  }
+
   streamCharacterWalletJournal(
     characterId: number,
   ): AsyncGenerator<PageResult<WalletJournal>, void, undefined> {

--- a/src/clients/WarsClient.ts
+++ b/src/clients/WarsClient.ts
@@ -38,6 +38,21 @@ export class WarsClient extends BaseEsiClient<typeof warEndpoints> {
     return this.api.getWarKillmails(warId);
   }
 
+  fetchAllWars(concurrency?: number): Promise<number[]> {
+    return this.fetchAllEndpoint<number>('getWars', [], concurrency);
+  }
+
+  fetchAllWarKillmails(
+    warId: number,
+    concurrency?: number,
+  ): Promise<KillmailSummary[]> {
+    return this.fetchAllEndpoint<KillmailSummary>(
+      'getWarKillmails',
+      [warId],
+      concurrency,
+    );
+  }
+
   streamWars(): AsyncGenerator<PageResult<number>, void, undefined> {
     return this.streamEndpoint<number>('getWars');
   }

--- a/src/core/pagination/AsyncPaginationIterator.ts
+++ b/src/core/pagination/AsyncPaginationIterator.ts
@@ -32,6 +32,75 @@ function validatePageBody(
   return result.data;
 }
 
+export async function fetchAllPages<T = unknown>(
+  client: ApiClient,
+  endpoint: string,
+  method: string,
+  requiresAuth: boolean = false,
+  body?: unknown,
+  templatePath?: string,
+  responseSchema?: ResponseSchema,
+  concurrency: number = 8,
+): Promise<T[]> {
+  const validate = client.getValidateResponse();
+  const firstResponse = await handleSinglePageRequest(
+    client,
+    endpoint,
+    method,
+    body,
+    requiresAuth,
+    templatePath,
+  );
+
+  const firstBody = validatePageBody(
+    firstResponse.body,
+    responseSchema,
+    `${client.getLink()}/${endpoint}`,
+    validate,
+  );
+
+  const totalPages = parseInt(firstResponse.headers['x-pages'] || '1', 10);
+  const result: T[] = extractArray<T>(firstBody);
+
+  if (totalPages <= 1) return result;
+
+  const remaining = Array.from({ length: totalPages - 1 }, (_, i) => i + 2);
+
+  for (let i = 0; i < remaining.length; i += concurrency) {
+    const batch = remaining.slice(i, i + concurrency);
+    const pages = await Promise.all(
+      batch.map(async (page) => {
+        const sep = endpoint.includes('?') ? '&' : '?';
+        const pagedEndpoint = `${endpoint}${sep}page=${page}`;
+
+        logInfo(`Fetching page ${page}/${totalPages}: ${pagedEndpoint}`);
+
+        const response = await handleSinglePageRequest(
+          client,
+          pagedEndpoint,
+          method,
+          body,
+          requiresAuth,
+          templatePath,
+        );
+
+        return validatePageBody(
+          response.body,
+          responseSchema,
+          `${client.getLink()}/${pagedEndpoint}`,
+          validate,
+        );
+      }),
+    );
+
+    for (const pageBody of pages) {
+      result.push(...extractArray<T>(pageBody));
+    }
+  }
+
+  return result;
+}
+
 export async function* fetchPages<T = unknown>(
   client: ApiClient,
   endpoint: string,

--- a/src/core/rateLimiter/RateLimiter.ts
+++ b/src/core/rateLimiter/RateLimiter.ts
@@ -27,10 +27,16 @@ function getTokenCost(statusCode: number): number {
   return 2;
 }
 
+export interface RateLimitEndpointOverride {
+  maxTokens: number;
+  windowSizeMs: number;
+}
+
 export interface RateLimiterConfig {
   minDelayMs?: number;
   decelerationThreshold?: number;
   userKeyExtractor?: (headers: Record<string, string>) => string;
+  endpointOverrides?: Record<string, RateLimitEndpointOverride>;
 }
 
 interface GroupBucket {
@@ -63,6 +69,7 @@ export class RateLimiter implements IRateLimiter {
   private readonly userKeyExtractor?: (
     headers: Record<string, string>,
   ) => string;
+  private readonly endpointOverrides: Record<string, RateLimitEndpointOverride>;
 
   private lastRequestTime: number = 0;
   private minDelayChain: Promise<void> = Promise.resolve();
@@ -81,6 +88,7 @@ export class RateLimiter implements IRateLimiter {
     this.minDelayMs = config?.minDelayMs ?? 50;
     this.decelerationThreshold = config?.decelerationThreshold ?? 0.2;
     this.userKeyExtractor = config?.userKeyExtractor;
+    this.endpointOverrides = config?.endpointOverrides ?? {};
     if (this.userKeyExtractor) {
       this.userBuckets = new Map();
     }
@@ -132,6 +140,16 @@ export class RateLimiter implements IRateLimiter {
       .replace(/\/$/, '')
       .replace(/\{(\w+)\}/g, (_, name: string) => `{${camelToSnake(name)}}`);
     const key = `${method}:${normalized}`;
+
+    const override = this.endpointOverrides[key];
+    if (override) {
+      return {
+        group: `endpoint:${key}`,
+        maxTokens: override.maxTokens,
+        windowSizeMs: override.windowSizeMs,
+      };
+    }
+
     return esiRateLimitGroups[key];
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,6 +117,7 @@ export type { ICircuitBreaker } from './core/circuitBreaker/ICircuitBreaker';
 // Rate limiter & cache (for direct instantiation)
 export {
   RateLimiter,
+  RateLimitEndpointOverride,
   RateLimitInfo,
   RateLimiterConfig,
 } from './core/rateLimiter/RateLimiter';
@@ -152,6 +153,7 @@ export {
 
 // Async pagination
 export {
+  fetchAllPages,
   fetchPages,
   PageResult,
 } from './core/pagination/AsyncPaginationIterator';

--- a/tests/tdd/core/AsyncPaginationIterator.test.ts
+++ b/tests/tdd/core/AsyncPaginationIterator.test.ts
@@ -1,4 +1,5 @@
 import {
+  fetchAllPages,
   fetchPages,
   PageResult,
 } from '../../../src/core/pagination/AsyncPaginationIterator';
@@ -226,6 +227,102 @@ describe('AsyncPaginationIterator', () => {
         true,
         undefined,
       );
+    });
+  });
+
+  describe('fetchAllPages', () => {
+    it('should return all items from a single page', async () => {
+      mockHandleRequest.mockResolvedValueOnce({
+        headers: { 'x-pages': '1' },
+        body: [{ id: 1 }, { id: 2 }],
+      });
+
+      const result = await fetchAllPages<{ id: number }>(
+        client,
+        'alliances',
+        'GET',
+      );
+
+      expect(result).toEqual([{ id: 1 }, { id: 2 }]);
+      expect(mockHandleRequest).toHaveBeenCalledTimes(1);
+    });
+
+    it('should merge all pages into a single array', async () => {
+      mockHandleRequest
+        .mockResolvedValueOnce({
+          headers: { 'x-pages': '3' },
+          body: [{ id: 1 }],
+        })
+        .mockResolvedValueOnce({
+          headers: { 'x-pages': '3' },
+          body: [{ id: 2 }],
+        })
+        .mockResolvedValueOnce({
+          headers: { 'x-pages': '3' },
+          body: [{ id: 3 }],
+        });
+
+      const result = await fetchAllPages<{ id: number }>(
+        client,
+        'alliances',
+        'GET',
+      );
+
+      expect(result).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }]);
+      expect(mockHandleRequest).toHaveBeenCalledTimes(3);
+    });
+
+    it('should fetch remaining pages concurrently within batch size', async () => {
+      const callOrder: number[] = [];
+      mockHandleRequest.mockImplementation(async (_c, endpoint: string) => {
+        const pageMatch = endpoint.match(/page=(\d+)/);
+        const page = pageMatch ? parseInt(pageMatch[1], 10) : 1;
+        callOrder.push(page);
+        return {
+          headers: { 'x-pages': '5' },
+          body: [{ id: page }],
+        };
+      });
+
+      const result = await fetchAllPages<{ id: number }>(
+        client,
+        'alliances',
+        'GET',
+        false,
+        undefined,
+        undefined,
+        undefined,
+        2,
+      );
+
+      expect(result).toHaveLength(5);
+      expect(mockHandleRequest).toHaveBeenCalledTimes(5);
+    });
+
+    it('should return empty array when body is null', async () => {
+      mockHandleRequest.mockResolvedValueOnce({
+        headers: { 'x-pages': '1' },
+        body: null,
+      });
+
+      const result = await fetchAllPages(client, 'empty', 'GET');
+      expect(result).toEqual([]);
+    });
+
+    it('should handle missing x-pages header as single page', async () => {
+      mockHandleRequest.mockResolvedValueOnce({
+        headers: {},
+        body: [{ id: 1 }],
+      });
+
+      const result = await fetchAllPages<{ id: number }>(
+        client,
+        'alliances',
+        'GET',
+      );
+
+      expect(result).toEqual([{ id: 1 }]);
+      expect(mockHandleRequest).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/tests/tdd/core/RateLimiter.test.ts
+++ b/tests/tdd/core/RateLimiter.test.ts
@@ -895,4 +895,89 @@ describe('RateLimiter', () => {
       expect(specStatus).toBeUndefined();
     });
   });
+
+  describe('endpoint overrides', () => {
+    it('should use endpoint override instead of generated group spec', async () => {
+      const overrideLimiter = new RateLimiter({
+        endpointOverrides: {
+          'GET:markets/{region_id}/history': {
+            maxTokens: 5,
+            windowSizeMs: 1000,
+          },
+        },
+      });
+
+      await overrideLimiter.checkRateLimit(
+        'markets/{region_id}/history',
+        'GET',
+      );
+
+      const status = overrideLimiter.getGroupStatus(
+        'endpoint:GET:markets/{region_id}/history',
+      );
+      expect(status).toBeDefined();
+      expect(status!.limit).toBe(5);
+      expect(status!.windowSizeMs).toBe(1000);
+      overrideLimiter.setTestMode(true);
+    });
+
+    it('should not affect endpoints without overrides', async () => {
+      const overrideLimiter = new RateLimiter({
+        endpointOverrides: {
+          'GET:markets/{region_id}/history': {
+            maxTokens: 5,
+            windowSizeMs: 1000,
+          },
+        },
+      });
+
+      await overrideLimiter.checkRateLimit(
+        'characters/{character_id}/assets',
+        'GET',
+      );
+
+      const overrideStatus = overrideLimiter.getGroupStatus(
+        'endpoint:GET:characters/{character_id}/assets',
+      );
+      expect(overrideStatus).toBeUndefined();
+
+      const groupStatus = overrideLimiter.getGroupStatus('char-asset');
+      expect(groupStatus).toBeDefined();
+      overrideLimiter.setTestMode(true);
+    });
+
+    it('should create separate buckets for overridden endpoints', async () => {
+      const overrideLimiter = new RateLimiter({
+        endpointOverrides: {
+          'GET:markets/{region_id}/history': {
+            maxTokens: 5,
+            windowSizeMs: 1000,
+          },
+          'GET:markets/{region_id}/orders': {
+            maxTokens: 100,
+            windowSizeMs: 900000,
+          },
+        },
+      });
+
+      await overrideLimiter.checkRateLimit(
+        'markets/{region_id}/history',
+        'GET',
+      );
+      await overrideLimiter.checkRateLimit('markets/{region_id}/orders', 'GET');
+
+      const historyStatus = overrideLimiter.getGroupStatus(
+        'endpoint:GET:markets/{region_id}/history',
+      );
+      const ordersStatus = overrideLimiter.getGroupStatus(
+        'endpoint:GET:markets/{region_id}/orders',
+      );
+
+      expect(historyStatus).toBeDefined();
+      expect(ordersStatus).toBeDefined();
+      expect(historyStatus!.limit).toBe(5);
+      expect(ordersStatus!.limit).toBe(100);
+      overrideLimiter.setTestMode(true);
+    });
+  });
 });

--- a/tests/tdd/core/__snapshots__/apiSurfaceSnapshots.test.ts.snap
+++ b/tests/tdd/core/__snapshots__/apiSurfaceSnapshots.test.ts.snap
@@ -110,6 +110,7 @@ exports[`API surface snapshots public API exports should match snapshot 1`] = `
   "createNoopLogger",
   "esiEndpointScopes",
   "fetchAllCursorPages",
+  "fetchAllPages",
   "fetchPages",
   "getDefaultClient",
   "isCircuitOpen",

--- a/tests/tdd/core/streamEndpoint.test.ts
+++ b/tests/tdd/core/streamEndpoint.test.ts
@@ -50,6 +50,28 @@ class TestClient extends BaseEsiClient<typeof testEndpoints> {
   ): AsyncGenerator<PageResult<{ id: number }>, void, undefined> {
     return this.streamEndpoint<{ id: number }>('getSecureItems', characterId);
   }
+
+  fetchAllItems(
+    regionId: number,
+    concurrency?: number,
+  ): Promise<{ id: number }[]> {
+    return this.fetchAllEndpoint<{ id: number }>(
+      'getItems',
+      [regionId],
+      concurrency,
+    );
+  }
+
+  fetchAllSecureItems(
+    characterId: number,
+    concurrency?: number,
+  ): Promise<{ id: number }[]> {
+    return this.fetchAllEndpoint<{ id: number }>(
+      'getSecureItems',
+      [characterId],
+      concurrency,
+    );
+  }
 }
 
 describe('streamEndpoint', () => {
@@ -280,5 +302,77 @@ describe('streamEndpoint', () => {
       false,
       'test/{regionId}/items/',
     );
+  });
+});
+
+describe('fetchAllEndpoint', () => {
+  let apiClient: ApiClient;
+  let testClient: TestClient;
+
+  beforeEach(() => {
+    mockHandleRequest.mockReset();
+    apiClient = new ApiClient('test', 'https://esi.evetech.net');
+    const rateLimiter = new RateLimiter();
+    rateLimiter.setTestMode(true);
+    apiClient.setRateLimiter(rateLimiter);
+    testClient = new TestClient(apiClient);
+  });
+
+  it('should return all items from a single page', async () => {
+    mockHandleRequest.mockResolvedValueOnce({
+      headers: { 'x-pages': '1' },
+      body: [{ id: 1 }, { id: 2 }],
+    });
+
+    const result = await testClient.fetchAllItems(100);
+    expect(result).toEqual([{ id: 1 }, { id: 2 }]);
+    expect(mockHandleRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('should merge all pages into a flat array', async () => {
+    mockHandleRequest
+      .mockResolvedValueOnce({
+        headers: { 'x-pages': '3' },
+        body: [{ id: 1 }],
+      })
+      .mockResolvedValueOnce({
+        headers: { 'x-pages': '3' },
+        body: [{ id: 2 }],
+      })
+      .mockResolvedValueOnce({
+        headers: { 'x-pages': '3' },
+        body: [{ id: 3 }],
+      });
+
+    const result = await testClient.fetchAllItems(100);
+    expect(result).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }]);
+  });
+
+  it('should pass requiresAuth through for auth endpoints', async () => {
+    mockHandleRequest.mockResolvedValueOnce({
+      headers: { 'x-pages': '1' },
+      body: [{ id: 1 }],
+    });
+
+    await testClient.fetchAllSecureItems(999);
+
+    expect(mockHandleRequest).toHaveBeenCalledWith(
+      apiClient,
+      'secure/999/items/',
+      'GET',
+      undefined,
+      true,
+      'secure/{characterId}/items/',
+    );
+  });
+
+  it('should propagate errors', async () => {
+    mockHandleRequest.mockRejectedValueOnce(
+      Object.assign(new Error('Not Found'), { statusCode: 404 }),
+    );
+
+    await expect(testClient.fetchAllItems(100)).rejects.toMatchObject({
+      statusCode: 404,
+    });
   });
 });


### PR DESCRIPTION
## Summary

- **fetchAllPages (#180)**: Add concurrent multi-page fetching with configurable concurrency (default 8). Fetches page 1 to discover total pages, then concurrently fetches remaining pages in batches. 73 `fetchAll*` convenience methods added across all 19 domain clients, mirroring existing `stream*` methods.
- **Per-endpoint rate limit overrides (#181)**: Add `endpointOverrides` config to `RateLimiterConfig` allowing consumers to set endpoint-specific rate limits (e.g., tighter limits on `market/history`). Overrides take precedence over generated group specs.

### Usage

```typescript
// Fetch all market orders concurrently (8 pages at a time)
const allOrders = await client.market.fetchAllMarketOrders(regionId);

// Custom concurrency
const allOrders = await client.market.fetchAllMarketOrders(regionId, 4);

// Per-endpoint rate limiting
const limiter = new RateLimiter({
  endpointOverrides: {
    'GET:markets/{region_id}/history': { maxTokens: 5, windowSizeMs: 1000 },
  },
});
```

## Test plan

- [x] 175 test suites, 4988 tests passing
- [x] 5 new fetchAllPages tests + 4 fetchAllEndpoint tests
- [x] 3 new endpoint override rate limiter tests
- [x] Typecheck clean, lint clean (0 errors)
- [ ] CI passes

Closes #180, closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)