### PR TITLE
feat: add typed response header fields to EsiResponseMeta

### DIFF
--- a/etc/esi.ts.api.md
+++ b/etc/esi.ts.api.md
@@ -4590,6 +4590,11 @@ function esiResponse<T extends z.ZodTypeAny>(dataSchema: T): z.ZodObject<{
             group: z.ZodNullable<z.ZodString>;
         }, z.core.$strip>>;
         responseTimeMs: z.ZodOptional<z.ZodNumber>;
+        etag: z.ZodOptional<z.ZodString>;
+        pages: z.ZodOptional<z.ZodNumber>;
+        expires: z.ZodOptional<z.ZodString>;
+        errorLimitRemain: z.ZodOptional<z.ZodNumber>;
+        errorLimitReset: z.ZodOptional<z.ZodNumber>;
     }, z.core.$loose>;
 }, z.core.$strip>;
 
@@ -4620,6 +4625,11 @@ const EsiResponseMetaSchema: z.ZodObject<{
         group: z.ZodNullable<z.ZodString>;
     }, z.core.$strip>>;
     responseTimeMs: z.ZodOptional<z.ZodNumber>;
+    etag: z.ZodOptional<z.ZodString>;
+    pages: z.ZodOptional<z.ZodNumber>;
+    expires: z.ZodOptional<z.ZodString>;
+    errorLimitRemain: z.ZodOptional<z.ZodNumber>;
+    errorLimitReset: z.ZodOptional<z.ZodNumber>;
 }, z.core.$loose>;
 
 // @public (undocumented)

--- a/src/core/endpoints/createClient.ts
+++ b/src/core/endpoints/createClient.ts
@@ -88,6 +88,20 @@ function buildMeta(response: EsiHandlerResponse): EsiResponseMeta {
       group: response.headers['x-ratelimit-group'] ?? null,
     };
   }
+  if (response.headers['etag']) meta.etag = response.headers['etag'];
+  if (response.headers['x-pages'])
+    meta.pages = parseInt(response.headers['x-pages'], 10);
+  if (response.headers['expires']) meta.expires = response.headers['expires'];
+  if (response.headers['x-esi-error-limit-remain'])
+    meta.errorLimitRemain = parseInt(
+      response.headers['x-esi-error-limit-remain'],
+      10,
+    );
+  if (response.headers['x-esi-error-limit-reset'])
+    meta.errorLimitReset = parseInt(
+      response.headers['x-esi-error-limit-reset'],
+      10,
+    );
   return meta;
 }
 

--- a/src/schemas/common.ts
+++ b/src/schemas/common.ts
@@ -30,6 +30,11 @@ export const EsiResponseMetaSchema = z.looseObject({
   contentLanguage: z.string().optional(),
   rateLimit: RateLimitMetaSchema.optional(),
   responseTimeMs: z.number().optional(),
+  etag: z.string().optional(),
+  pages: z.number().optional(),
+  expires: z.string().optional(),
+  errorLimitRemain: z.number().optional(),
+  errorLimitReset: z.number().optional(),
 });
 
 export function esiResponse<T extends z.ZodTypeAny>(dataSchema: T) {

--- a/tests/tdd/core/WithMetadata.test.ts
+++ b/tests/tdd/core/WithMetadata.test.ts
@@ -126,6 +126,91 @@ describe('withMetadata()', () => {
     });
   });
 
+  describe('typed response headers', () => {
+    it('populates etag from response headers', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify([99000001]), {
+        headers: standardHeaders({ etag: '"abc123"' }),
+      });
+
+      const metaClient = allianceClient.withMetadata();
+      const result = await metaClient.getAlliances();
+
+      expect(result.meta.etag).toBe('"abc123"');
+    });
+
+    it('populates pages from x-pages header', async () => {
+      const mockAlliance = {
+        alliance_id: 99000001,
+        name: 'Test Alliance',
+        ticker: 'TEST',
+        creator_id: 123,
+        creator_corporation_id: 456,
+        date_founded: '2020-01-01T00:00:00Z',
+      };
+
+      fetchMock.mockResponseOnce(JSON.stringify(mockAlliance), {
+        headers: standardHeaders(),
+      });
+
+      const metaClient = allianceClient.withMetadata();
+      const result = await metaClient.getAllianceById(99000001);
+
+      expect(result.meta.pages).toBe(1);
+    });
+
+    it('populates expires from response headers', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify([99000001]), {
+        headers: standardHeaders({
+          expires: 'Thu, 01 Jan 2099 00:00:00 GMT',
+        }),
+      });
+
+      const metaClient = allianceClient.withMetadata();
+      const result = await metaClient.getAlliances();
+
+      expect(result.meta.expires).toBe('Thu, 01 Jan 2099 00:00:00 GMT');
+    });
+
+    it('populates errorLimitRemain and errorLimitReset from response headers', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify([99000001]), {
+        headers: standardHeaders({
+          'x-esi-error-limit-remain': '87',
+          'x-esi-error-limit-reset': '42',
+        }),
+      });
+
+      const metaClient = allianceClient.withMetadata();
+      const result = await metaClient.getAlliances();
+
+      expect(result.meta.errorLimitRemain).toBe(87);
+      expect(result.meta.errorLimitReset).toBe(42);
+    });
+
+    it('typed header fields are undefined when headers are absent', async () => {
+      const mockAlliance = {
+        alliance_id: 99000001,
+        name: 'Test Alliance',
+        ticker: 'TEST',
+        creator_id: 123,
+        creator_corporation_id: 456,
+        date_founded: '2020-01-01T00:00:00Z',
+      };
+
+      fetchMock.mockResponseOnce(JSON.stringify(mockAlliance), {
+        headers: { 'content-type': 'application/json' },
+      });
+
+      const metaClient = allianceClient.withMetadata();
+      const result = await metaClient.getAllianceById(99000001);
+
+      expect(result.meta.etag).toBeUndefined();
+      expect(result.meta.pages).toBeUndefined();
+      expect(result.meta.expires).toBeUndefined();
+      expect(result.meta.errorLimitRemain).toBeUndefined();
+      expect(result.meta.errorLimitReset).toBeUndefined();
+    });
+  });
+
   describe('cache hit type', () => {
     it('cacheHitType is undefined for normal 200 response', async () => {
       fetchMock.mockResponseOnce(JSON.stringify([99000001]), {


### PR DESCRIPTION
## Summary

- Adds `etag`, `pages`, `expires`, `errorLimitRemain`, and `errorLimitReset` as typed optional fields on `EsiResponseMeta`
- Consumers using `.withMetadata()` now get autocomplete and type safety for common ESI response headers instead of raw string lookups
- Added 5 new tests covering each typed field and the absent-headers case

## Test plan

- [x] All 4,592 unit tests pass (123 suites)
- [x] API surface snapshot unchanged (fields added to existing schema, no new exports)
- [x] API report regenerated
- [x] Typecheck clean
- [x] Lint clean (no new errors)

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)