### PR TITLE
ci: run Schemathesis nightly, off the PR path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,41 +328,6 @@ jobs:
             exit 1
           fi
 
-  schemathesis:
-    name: Schemathesis API Fuzz
-    runs-on: ubuntu-latest
-    needs: lint-and-build
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          persist-credentials: false
-
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
-        with:
-          node-version: '20'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Pull Schemathesis Docker image
-        run: docker pull schemathesis/schemathesis
-
-      - name: Run Schemathesis
-        run: bash scripts/run-schemathesis.sh ./reports/schemathesis
-        timeout-minutes: 20
-
-      - name: Upload Schemathesis report
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        if: always()
-        with:
-          name: schemathesis-report
-          path: reports/schemathesis/
-          retention-days: 30
-
   documentation:
     name: Generate Documentation
     runs-on: ubuntu-latest
@@ -430,7 +395,6 @@ jobs:
         contract-tests,
         fuzz-tests,
         api-surface,
-        schemathesis,
         lockfile,
       ]
     if: always()
@@ -438,12 +402,36 @@ jobs:
     steps:
       - name: Check all jobs
         env:
-          RESULTS: "${{ join(needs.*.result, ' ') }}"
+          UNIT_TESTS: ${{ needs.unit-tests.result }}
+          BDD_TESTS: ${{ needs.bdd-tests.result }}
+          FULL_TEST_SUITE: ${{ needs.full-test-suite.result }}
+          COVERAGE: ${{ needs.coverage.result }}
+          STATIC_ANALYSIS: ${{ needs.static-analysis.result }}
+          CONTRACT_TESTS: ${{ needs.contract-tests.result }}
+          FUZZ_TESTS: ${{ needs.fuzz-tests.result }}
+          API_SURFACE: ${{ needs.api-surface.result }}
+          LOCKFILE: ${{ needs.lockfile.result }}
         run: |
-          for r in $RESULTS; do
-            if [[ "$r" != "success" ]]; then
-              echo "::error::One or more required jobs failed, were cancelled, or were skipped"
-              exit 1
+          FAILED=""
+          for entry in \
+            "Unit Tests=$UNIT_TESTS" \
+            "BDD Scenarios=$BDD_TESTS" \
+            "Complete Test Suite=$FULL_TEST_SUITE" \
+            "Test Coverage=$COVERAGE" \
+            "Static Analysis=$STATIC_ANALYSIS" \
+            "Contract Tests=$CONTRACT_TESTS" \
+            "Fuzz Tests=$FUZZ_TESTS" \
+            "API Surface Check=$API_SURFACE" \
+            "Lockfile Consistency=$LOCKFILE"
+          do
+            NAME="${entry%%=*}"
+            RESULT="${entry#*=}"
+            if [[ "$RESULT" != "success" ]]; then
+              FAILED="$FAILED $NAME ($RESULT)"
             fi
           done
+          if [[ -n "$FAILED" ]]; then
+            echo "::error::Quality gate failed. Jobs not green:$FAILED"
+            exit 1
+          fi
           echo "All quality checks passed!"

--- a/.github/workflows/nightly-schemathesis.yml
+++ b/.github/workflows/nightly-schemathesis.yml
@@ -1,0 +1,56 @@
+name: Nightly Schemathesis API Fuzz
+
+on:
+  schedule:
+    - cron: '0 1 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  schemathesis:
+    name: Schemathesis API Fuzz
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Pull Schemathesis Docker image
+        run: docker pull schemathesis/schemathesis
+
+      - name: Run Schemathesis
+        run: bash scripts/run-schemathesis.sh ./reports/schemathesis
+
+      - name: Upload Schemathesis report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: always()
+        with:
+          name: schemathesis-report
+          path: reports/schemathesis/
+          retention-days: 30
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "## Nightly Schemathesis API Fuzz" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Date:** $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_STEP_SUMMARY
+          if [ -f reports/schemathesis/junit.xml ]; then
+            echo "- **JUnit report:** uploaded as artifact" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- **JUnit report:** not produced (job did not reach the fuzz step)" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/TESTING.md
+++ b/TESTING.md
@@ -385,7 +385,7 @@ Traditional unit tests check known inputs. Property-based tests check invariants
 | Live smoke tests         | Daily/weekly                | `ESI_LIVE_TESTS=true npm run test:integration`                                         |
 | Spec contract validation | Weekly                      | `ESI_LIVE_TESTS=true npm run test:integration -- --testPathPatterns=esi-spec-contract` |
 | Spec drift detection     | Weekly                      | `npm run contract:snapshot && npm run contract:diff`                                   |
-| API fuzz (Schemathesis)  | Weekly                      | `npm run fuzz:api` (Docker)                                                            |
+| API fuzz (Schemathesis)  | Nightly (01:00 UTC)         | `npm run fuzz:api` (Docker)                                                            |
 | Gated auth tests         | Weekly (with token refresh) | `ESI_GATED_TESTS=true npm run test:integration:gated`                                  |
 
 ## File Reference


### PR DESCRIPTION
- Remove the 20-min Schemathesis API Fuzz job from ci.yml so it no longer blocks PRs (and consumes ~20 CI-minutes per PR).
- Add nightly-schemathesis.yml: same job, runs at 01:00 UTC plus workflow_dispatch for on-demand runs, with a roomier 40-min cap.
- Quality Gate now names which downstream job was not green (previously it failed with a single opaque message).
- TESTING.md: update API-fuzz schedule from Weekly to Nightly.

Follow-up (tracked in beads): master branch protection still requires a check named 'Quality Gate' — that must be repointed to the 'CI/CD Pipeline' aggregate status check, otherwise master will dangle.