### PR TITLE
fix: unblock PR CI — audit overrides, stale generated types, zod deprecation

### DIFF
--- a/etc/esi.ts.api.md
+++ b/etc/esi.ts.api.md
@@ -104,24 +104,6 @@ const AllianceContactSchema: z.ZodObject<{
 }, z.core.$loose>;
 
 // @public (undocumented)
-interface AllianceDetail {
-    // (undocumented)
-    creator_corporation_id: number;
-    // (undocumented)
-    creator_id: number;
-    // (undocumented)
-    date_founded: string;
-    // (undocumented)
-    executor_corporation_id?: number;
-    // (undocumented)
-    faction_id?: number;
-    // (undocumented)
-    name: string;
-    // (undocumented)
-    ticker: string;
-}
-
-// @public (undocumented)
 export type AllianceIcon = z.infer<typeof AllianceIconSchema>;
 
 // @public (undocumented)
@@ -176,6 +158,24 @@ interface AlliancesAllianceIdIconsGet {
     px128x128?: string;
     // (undocumented)
     px64x64?: string;
+}
+
+// @public (undocumented)
+interface AlliancesDetail {
+    // (undocumented)
+    creator_corporation_id: number;
+    // (undocumented)
+    creator_id: number;
+    // (undocumented)
+    date_founded: string;
+    // (undocumented)
+    executor_corporation_id?: number;
+    // (undocumented)
+    faction_id?: number;
+    // (undocumented)
+    name: string;
+    // (undocumented)
+    ticker: string;
 }
 
 // @public (undocumented)
@@ -4233,7 +4233,7 @@ export class EsiError extends Error {
 // @public (undocumented)
 interface EsiOperationTypes {
     // (undocumented)
-    'GetAlliancesAllianceId': AllianceDetail;
+    'GetAlliancesAllianceId': AlliancesDetail;
     // (undocumented)
     'GetAlliancesAllianceIdContacts': AlliancesAllianceIdContactsGet[];
     // (undocumented)
@@ -4565,7 +4565,7 @@ export interface EsiResponse<T> {
 }
 
 // @public (undocumented)
-function esiResponse<T extends z.ZodTypeAny>(dataSchema: T): z.ZodObject<{
+function esiResponse<T extends z.ZodType>(dataSchema: T): z.ZodObject<{
     data: T;
     meta: z.ZodObject<{
         headers: z.ZodRecord<z.ZodString, z.ZodString>;
@@ -4648,8 +4648,8 @@ export type EsiScope = 'esi-access.read_lists.v1' | 'esi-activities.read_charact
 
 declare namespace EsiSpec {
     export {
-        AllianceDetail,
         AlliancesAllianceIdIconsGet,
+        AlliancesDetail,
         CharactersCharacterIdAssetsGet,
         CharactersCharacterIdAssetsLocationsPost,
         CharactersCharacterIdAssetsNamesPost,
@@ -5832,9 +5832,9 @@ interface IndustrySystemsGet {
 export type InferEndpointResult<D> = D extends {
     cursorPagination: true;
 } ? D extends {
-    responseSchema: infer S extends z.ZodTypeAny;
+    responseSchema: infer S extends z.ZodType;
 } ? CursorResult<UnwrapArray<z.infer<S>>> : CursorResult : D extends {
-    responseSchema: infer S extends z.ZodTypeAny;
+    responseSchema: infer S extends z.ZodType;
 } ? z.infer<S> : unknown;
 
 // Warning: (ae-forgotten-export) The symbol "insuranceEndpoints" needs to be exported by the entry point index.d.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -1922,9 +1922,9 @@
       }
     },
     "node_modules/@faker-js/faker": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-10.5.0.tgz",
-      "integrity": "sha512-bsxD8WLS5lIj7aaoCx1YJkktqYj5vlBUE6HWzu2Q51ksrGJ0H737ECCKlFU7Yf8Br45z9t99frBp/J7kzbMPAg==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-10.6.0.tgz",
+      "integrity": "sha512-3RQHgEtvL1Frl/d1cSreo7qhJ3Gk1OdNUai/CtZ8G+wYeRQnJih3s9xJ9/kgYekPQRdwgh0HXRPqMlzWGwivIQ==",
       "dev": true,
       "funding": [
         {
@@ -2412,9 +2412,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
-      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7637,9 +7637,9 @@
       "license": "Python-2.0"
     },
     "node_modules/cosmiconfig/node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {
@@ -8618,9 +8618,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true,
       "funding": [
         {
@@ -10923,9 +10923,9 @@
       }
     },
     "node_modules/json-schema-ref-parser/node_modules/js-yaml": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
-      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12719,14 +12719,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/postman-collection/node_modules/@faker-js/faker": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-5.5.3.tgz",
-      "integrity": "sha512-R11tGE6yIFwqpaIqcfkcg7AICXzFg14+5h5v0TfF/9+RMDL6jhzCy/pxHVOfbALGdtVYdt6JdR21tuxEgl34dw==",
-      "deprecated": "Please update to a newer version.",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/postman-collection/node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -12982,9 +12974,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -281,9 +281,20 @@
   "overrides": {
     "lodash": "4.18.1",
     "fast-xml-parser": ">=5.7.0",
-    "qs": ">=6.15.2",
+    "qs": ">=6.16.0",
     "brace-expansion": ">=5.0.8",
     "esbuild": ">=0.28.1",
-    "uuid": "~11.1.1"
+    "uuid": "~11.1.1",
+    "@faker-js/faker": ">=10.5.0",
+    "fast-uri": "^3.1.6",
+    "cosmiconfig": {
+      "js-yaml": "^4.3.2"
+    },
+    "json-schema-ref-parser": {
+      "js-yaml": "^3.15.2"
+    },
+    "@istanbuljs/load-nyc-config": {
+      "js-yaml": "^3.15.2"
+    }
   }
 }

--- a/src/core/endpoints/EndpointDefinition.ts
+++ b/src/core/endpoints/EndpointDefinition.ts
@@ -29,9 +29,9 @@ export interface EndpointDefinition {
   /** Mark an endpoint as deprecated with optional migration guidance */
   deprecated?: DeprecationInfo;
   /** Zod schema for runtime response validation */
-  responseSchema?: z.ZodTypeAny;
+  responseSchema?: z.ZodType;
   /** Zod schema for runtime request body validation (opt-in via validateRequest) */
-  requestSchema?: z.ZodTypeAny;
+  requestSchema?: z.ZodType;
 }
 
 export type EndpointMap = Record<string, EndpointDefinition>;

--- a/src/core/endpoints/createClient.ts
+++ b/src/core/endpoints/createClient.ts
@@ -39,10 +39,10 @@ export type UnwrapArray<T> = T extends readonly (infer E)[] ? E : T;
  * - Falls back to `unknown` when no `responseSchema` is defined.
  */
 export type InferEndpointResult<D> = D extends { cursorPagination: true }
-  ? D extends { responseSchema: infer S extends z.ZodTypeAny }
+  ? D extends { responseSchema: infer S extends z.ZodType }
     ? CursorResult<UnwrapArray<z.infer<S>>>
     : CursorResult
-  : D extends { responseSchema: infer S extends z.ZodTypeAny }
+  : D extends { responseSchema: infer S extends z.ZodType }
     ? z.infer<S>
     : unknown;
 

--- a/src/schemas/common.ts
+++ b/src/schemas/common.ts
@@ -37,7 +37,7 @@ export const EsiResponseMetaSchema = z.looseObject({
   errorLimitReset: z.number().optional(),
 });
 
-export function esiResponse<T extends z.ZodTypeAny>(dataSchema: T) {
+export function esiResponse<T extends z.ZodType>(dataSchema: T) {
   return z.object({
     data: dataSchema,
     meta: EsiResponseMetaSchema,

--- a/src/types/generated/esi-spec.generated.ts
+++ b/src/types/generated/esi-spec.generated.ts
@@ -1,11 +1,16 @@
 /* eslint-disable */
 // Auto-generated from ESI OpenAPI spec — do not edit manually
-// Spec hash: 2aa65109f19c
+// Spec hash: f50f760055e8
 // Total interfaces: 161
 
 // --- Alliance ---
 
-export interface AllianceDetail {
+export interface AlliancesAllianceIdIconsGet {
+  px128x128?: string;
+  px64x64?: string;
+}
+
+export interface AlliancesDetail {
   creator_corporation_id: number;
   creator_id: number;
   date_founded: string;
@@ -13,11 +18,6 @@ export interface AllianceDetail {
   faction_id?: number;
   name: string;
   ticker: string;
-}
-
-export interface AlliancesAllianceIdIconsGet {
-  px128x128?: string;
-  px64x64?: string;
 }
 
 // --- Assets ---
@@ -2054,7 +2054,7 @@ export interface WarsWarIdKillmailsGet {
 
 // Operation ID → Response type mapping
 export interface EsiOperationTypes {
-  'GetAlliancesAllianceId': AllianceDetail;
+  'GetAlliancesAllianceId': AlliancesDetail;
   'GetAlliancesAllianceIdContacts': AlliancesAllianceIdContactsGet[];
   'GetAlliancesAllianceIdContactsLabels': AlliancesAllianceIdContactsLabelsGet[];
   'GetAlliancesAllianceIdIcons': AlliancesAllianceIdIconsGet;

--- a/src/types/generated/spec-alignment.check.ts
+++ b/src/types/generated/spec-alignment.check.ts
@@ -187,7 +187,7 @@ type AssertTrue<T extends true> = T;
 
 // Alliance
 type _AllianceInfo = AssertTrue<
-  HasAllSpecKeys<EsiSpec.AllianceDetail, AllianceInfo>
+  HasAllSpecKeys<EsiSpec.AlliancesDetail, AllianceInfo>
 >;
 type _AllianceIcon = AssertTrue<
   HasAllSpecKeys<EsiSpec.AlliancesAllianceIdIconsGet, AllianceIcon>


### PR DESCRIPTION
Three unrelated failures were breaking **every** open PR (#232, #233, #236). None of them were caused by the PRs themselves.

## 1. `npm audit --audit-level=high` fails (Static Analysis)

Master is latently broken here — Static Analysis only runs on PRs, not pushes, so master looks green while any PR fails.

| Package | Advisory | Reached via |
|---|---|---|
| `@faker-js/faker` | arbitrary code execution in `helpers.fake` | `@stoplight/prism-cli` |
| `fast-uri` | SSRF / host confusion (4 advisories) | `ajv` |
| `js-yaml` | CPU exhaustion via `maxTotalMergeKeys` | `cosmiconfig`, `json-schema-ref-parser`, `@istanbuljs/load-nyc-config` |

All are dev-only transitive deps, so they're pinned via `overrides`. `js-yaml` needs **per-parent** overrides because the 3.x and 4.x branches have separate fixed versions (3.15.2 and 4.3.2) — a single range would force 3.x consumers onto an incompatible major. The `qs` override is raised to `>=6.16.0` to clear the new array-limit advisory.

Remaining after this: one *moderate* `adm-zip` finding, below the `high` gate. Its only "fix" is a downgrade to 0.5.8, which is a breaking change for the SDE downloader — left alone deliberately.

## 2. Generated types are stale

Upstream ESI renamed `AllianceDetail` → `AlliancesDetail` (spec hash `2aa65109f19c` → `f50f760055e8`). Regenerated, and updated the two hand-maintained places that referenced the old name: the `spec-alignment.check.ts` assertion and the API surface report.

## 3. `z.ZodTypeAny` is deprecated

`sonarjs/deprecation` reports this as an **error**, which is what produced #236's 5 lint errors under its zod bump. Migrated the five usages to `z.ZodType`. Landing it here so the dependency bump rebases clean.

## Validation

Every Static Analysis and Quality Gate step run locally:

- audit, lockfile consistency, typecheck, lint (**0 errors**), format, build
- schema drift, auth/scope alignment, API surface, generated-types freshness
- contract tests (15 passed, live spec), unit + BDD (**4993 passed**)
- coverage 96.37% statements / 95.16% branches / 90.93% functions — above thresholds

🤖 Generated with [Claude Code](https://claude.com/claude-code)